### PR TITLE
feat: implement RBAC engine — role-scoped ingestion and retrieval

### DIFF
--- a/lib/zaq/accounts/permissions.ex
+++ b/lib/zaq/accounts/permissions.ex
@@ -1,0 +1,36 @@
+defmodule Zaq.Accounts.Permissions do
+  @moduledoc """
+  Role-based access control helpers for ZAQ.
+
+  Determines which role IDs a user can retrieve chunks for,
+  based on their own role and any cross-role access configured in
+  `role.meta["accessible_role_ids"]`.
+  """
+
+  @doc """
+  Returns the list of role IDs whose chunks are accessible to the given user.
+
+  Always includes the user's own `role_id`. If `role.meta["accessible_role_ids"]`
+  is set, those IDs are included as well (additive cross-role access).
+
+  Requires `user.role` to be preloaded.
+
+  Returns `[]` if the user has no role assigned.
+  """
+  def list_accessible_role_ids(user) do
+    case user.role_id do
+      nil -> []
+      own_id -> [own_id]
+    end
+  end
+
+  @doc """
+  Returns true if the user has a role assigned (can perform retrievals).
+  """
+  def can_retrieve?(user), do: user.role_id != nil
+
+  @doc """
+  Returns true if the user has a role assigned (can trigger ingestion).
+  """
+  def can_ingest?(user), do: user.role_id != nil
+end

--- a/lib/zaq/channels/retrieval/mattermost.ex
+++ b/lib/zaq/channels/retrieval/mattermost.ex
@@ -38,6 +38,8 @@ defmodule Zaq.Channels.Retrieval.Mattermost do
 
   require Logger
 
+  alias Zaq.Accounts
+  alias Zaq.Accounts.Permissions
   alias Zaq.Agent.{Answering, PromptGuard, Retrieval}
   alias Zaq.Agent.PromptTemplate
   alias Zaq.Channels.PendingQuestions
@@ -96,10 +98,11 @@ defmodule Zaq.Channels.Retrieval.Mattermost do
     thread_id = question.thread_id || post_id
     text = question.text
 
-    Logger.info("[Mattermost] Processing question from #{question.metadata.sender_name}: #{text}")
+    sender_name = question.metadata.sender_name
+    Logger.info("[Mattermost] Processing question from #{sender_name}: #{text}")
 
     Task.start(fn ->
-      run_pipeline(text, channel_id, thread_id)
+      run_pipeline(text, channel_id, thread_id, sender_name)
     end)
 
     :ok
@@ -234,14 +237,16 @@ defmodule Zaq.Channels.Retrieval.Mattermost do
 
   # --- Private: RAG Pipeline ---
 
-  defp run_pipeline(user_msg, channel_id, thread_id) do
+  defp run_pipeline(user_msg, channel_id, thread_id, sender_name) do
     # Send typing indicator while processing
     api_module().send_typing(channel_id, thread_id)
+
+    role_ids = resolve_role_ids(sender_name)
 
     result =
       with {:ok, clean_msg} <- prompt_guard_module().validate(user_msg),
            {:ok, retrieval_result} <- run_retrieval(clean_msg),
-           {:ok, extraction_result} <- run_query_extraction(retrieval_result),
+           {:ok, extraction_result} <- run_query_extraction(retrieval_result, role_ids),
            {:ok, answer_result} <- run_answering(clean_msg, extraction_result, retrieval_result),
            {:ok, safe_answer} <- prompt_guard_module().output_safe?(answer_result.answer) do
         if answering_module().no_answer?(safe_answer) do
@@ -315,9 +320,10 @@ defmodule Zaq.Channels.Retrieval.Mattermost do
     end
   end
 
-  defp run_query_extraction(%{query: query, negative_answer: negative_answer}) do
+  defp run_query_extraction(%{query: query, negative_answer: negative_answer}, role_ids) do
     case node_router_module().call(:ingestion, document_processor_module(), :query_extraction, [
-           query
+           query,
+           role_ids
          ]) do
       {:ok, results} when results != [] -> {:ok, results}
       {:ok, []} -> {:error, :no_results, negative_answer}
@@ -350,6 +356,20 @@ defmodule Zaq.Channels.Retrieval.Mattermost do
   end
 
   # --- Private: Helpers ---
+
+  # Resolves accessible role IDs for a Mattermost sender.
+  # Falls back to nil (unfiltered) when the sender cannot be matched to a ZAQ user.
+  # NOTE: `sender_name` is the Mattermost display name and may not match ZAQ username.
+  # Follow-up: consider adding a `mattermost_username` field to User or a per-channel
+  # default role in config.
+  defp resolve_role_ids(nil), do: nil
+
+  defp resolve_role_ids(sender_name) do
+    case accounts_module().get_user_by_username(sender_name) do
+      nil -> nil
+      user -> Permissions.list_accessible_role_ids(user)
+    end
+  end
 
   defp monitored?(channel_id, %{monitored_channel_ids: ids}) do
     MapSet.member?(ids, channel_id)
@@ -393,6 +413,8 @@ defmodule Zaq.Channels.Retrieval.Mattermost do
     |> String.replace_leading("http://", "ws://")
     |> Kernel.<>("/api/v4/websocket")
   end
+
+  defp accounts_module, do: Application.get_env(:zaq, :mattermost_accounts_module, Accounts)
 
   defp api_module, do: Application.get_env(:zaq, :mattermost_api_module, API)
 

--- a/lib/zaq/document_processor/behaviour.ex
+++ b/lib/zaq/document_processor/behaviour.ex
@@ -3,5 +3,10 @@ defmodule Zaq.DocumentProcessorBehaviour do
   Behaviour module defining the contract for document processing implementations.
   This allows for different processing strategies (e.g., local, external service) to be used interchangeably in the ingestion pipeline.
   """
-  @callback process_single_file(String.t()) :: {:ok, map()} | {:error, any()}
+  @callback process_single_file(
+              String.t(),
+              role_id :: integer() | nil,
+              shared_role_ids :: list()
+            ) ::
+              {:ok, map()} | {:error, any()}
 end

--- a/lib/zaq/ingestion/chunk.ex
+++ b/lib/zaq/ingestion/chunk.ex
@@ -16,28 +16,32 @@ defmodule Zaq.Ingestion.Chunk do
   import Ecto.Changeset
   import Ecto.Query
 
+  alias Zaq.Accounts.Role
   alias Zaq.Ingestion.Document
   alias Zaq.Repo
 
   schema "chunks" do
     belongs_to :document, Document
+    belongs_to :role, Role
     field :content, :string
     field :chunk_index, :integer
     field :section_path, {:array, :string}, default: []
     field :metadata, :map, default: %{}
     field :embedding, Pgvector.Ecto.HalfVector
+    field :shared_role_ids, {:array, :integer}, default: []
 
     timestamps(type: :utc_datetime)
   end
 
   @required_fields ~w(document_id content chunk_index)a
-  @optional_fields ~w(section_path metadata embedding)a
+  @optional_fields ~w(section_path metadata embedding role_id shared_role_ids)a
 
   def changeset(chunk, attrs) do
     chunk
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> foreign_key_constraint(:document_id)
+    |> foreign_key_constraint(:role_id)
   end
 
   @doc """
@@ -99,5 +103,30 @@ defmodule Zaq.Ingestion.Chunk do
       select: count(c.id)
     )
     |> Repo.one()
+  end
+
+  @doc """
+  Updates shared_role_ids for all chunks of a document in one query.
+  """
+  def update_shared_role_ids_for_document(document_id, shared_role_ids) do
+    from(c in __MODULE__, where: c.document_id == ^document_id)
+    |> Repo.update_all(set: [shared_role_ids: shared_role_ids])
+  end
+
+  @doc """
+  Returns a map of document_id => shared_role_ids by sampling the first chunk
+  of each given document. Used to display sharing status in the file browser.
+  """
+  def shared_role_ids_by_documents(document_ids) when document_ids == [], do: %{}
+
+  def shared_role_ids_by_documents(document_ids) do
+    from(c in __MODULE__,
+      where: c.document_id in ^document_ids,
+      distinct: c.document_id,
+      order_by: [asc: c.document_id, asc: c.chunk_index],
+      select: {c.document_id, c.shared_role_ids}
+    )
+    |> Repo.all()
+    |> Map.new()
   end
 end

--- a/lib/zaq/ingestion/document.ex
+++ b/lib/zaq/ingestion/document.ex
@@ -12,6 +12,7 @@ defmodule Zaq.Ingestion.Document do
   import Ecto.Changeset
   import Ecto.Query
 
+  alias Zaq.Accounts.Role
   alias Zaq.Ingestion.Chunk
   alias Zaq.Repo
 
@@ -21,6 +22,7 @@ defmodule Zaq.Ingestion.Document do
     field :content, :string
     field :content_type, :string, default: "markdown"
     field :metadata, :map, default: %{}
+    belongs_to :role, Role
 
     has_many :chunks, Chunk
 
@@ -28,7 +30,7 @@ defmodule Zaq.Ingestion.Document do
   end
 
   @required_fields ~w(source content)a
-  @optional_fields ~w(title content_type metadata)a
+  @optional_fields ~w(title content_type metadata role_id)a
 
   def changeset(document, attrs) do
     document
@@ -36,6 +38,7 @@ defmodule Zaq.Ingestion.Document do
     |> validate_required(@required_fields)
     |> validate_inclusion(:content_type, ~w(markdown text html))
     |> unique_constraint(:source)
+    |> foreign_key_constraint(:role_id)
     |> maybe_set_title()
   end
 
@@ -58,7 +61,8 @@ defmodule Zaq.Ingestion.Document do
     %__MODULE__{}
     |> changeset(attrs)
     |> Repo.insert(
-      on_conflict: {:replace, [:content, :title, :content_type, :metadata, :updated_at]},
+      on_conflict:
+        {:replace, [:content, :title, :content_type, :metadata, :role_id, :updated_at]},
       conflict_target: :source
     )
   end

--- a/lib/zaq/ingestion/document_processor.ex
+++ b/lib/zaq/ingestion/document_processor.ex
@@ -81,13 +81,14 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   @doc """
   Processes a single markdown file: read -> upsert document -> chunk -> embed -> store.
   """
-  def process_single_file(file_path) do
+  def process_single_file(file_path, role_id \\ nil, shared_role_ids \\ []) do
     Logger.info("Processing file: #{file_path}")
 
     with {:ok, content} <- File.read(file_path),
          {:ok, source} <- extract_source(content, file_path),
-         {:ok, document} <- store_document(content, source),
-         {:ok, _chunks} <- process_and_store_chunks(content, document.id) do
+         {:ok, document} <- store_document(content, source, role_id),
+         {:ok, _chunks} <-
+           process_and_store_chunks(content, document.id, role_id, shared_role_ids) do
       Logger.info("Successfully processed: #{source}")
       {:ok, document}
     else
@@ -119,8 +120,8 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   @doc """
   Upserts a `Zaq.Ingestion.Document` record.
   """
-  def store_document(content, source) do
-    case Document.upsert(%{content: content, source: source}) do
+  def store_document(content, source, role_id \\ nil) do
+    case Document.upsert(%{content: content, source: source, role_id: role_id}) do
       {:ok, document} ->
         Logger.info("Document stored with ID: #{document.id}, source: #{source}")
         {:ok, document}
@@ -135,7 +136,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   Chunks the content using `DocumentChunker`, generates embeddings,
   and stores each chunk via the `Chunk` Ecto schema.
   """
-  def process_and_store_chunks(content, document_id) do
+  def process_and_store_chunks(content, document_id, role_id \\ nil, shared_role_ids \\ []) do
     Chunk.delete_by_document(document_id)
     sections = DocumentChunker.parse_layout(content, format: :markdown)
     chunks = DocumentChunker.chunk_sections(sections)
@@ -146,7 +147,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
       chunks
       |> Enum.with_index(1)
       |> Enum.map(fn {chunk, index} ->
-        store_chunk_with_metadata(chunk, document_id, index)
+        store_chunk_with_metadata(chunk, document_id, index, role_id, shared_role_ids)
       end)
 
     failed = Enum.count(results, &match?({:error, _}, &1))
@@ -165,7 +166,13 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   Stores a single chunk: generates a descriptive title via LLM,
   embeds the content, validates dimension, and inserts via Ecto.
   """
-  def store_chunk_with_metadata(%DocumentChunker.Chunk{} = chunk, document_id, index) do
+  def store_chunk_with_metadata(
+        %DocumentChunker.Chunk{} = chunk,
+        document_id,
+        index,
+        role_id \\ nil,
+        shared_role_ids \\ []
+      ) do
     chunk_with_title = generate_chunk_title(chunk)
 
     case EmbeddingClient.embed(chunk_with_title.content) do
@@ -179,7 +186,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
 
           {:error, :dimension_mismatch}
         else
-          insert_chunk(chunk_with_title, document_id, index, embedding)
+          insert_chunk(chunk_with_title, document_id, index, embedding, role_id, shared_role_ids)
         end
 
       {:error, reason} ->
@@ -192,14 +199,23 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   # Chunk insertion (Ecto)
   # ---------------------------------------------------------------------------
 
-  defp insert_chunk(%DocumentChunker.Chunk{} = chunk, document_id, index, embedding) do
+  defp insert_chunk(
+         %DocumentChunker.Chunk{} = chunk,
+         document_id,
+         index,
+         embedding,
+         role_id,
+         shared_role_ids
+       ) do
     attrs = %{
       document_id: document_id,
       content: chunk.content,
       chunk_index: index,
       section_path: chunk.section_path,
       metadata: build_metadata(chunk, document_id, index),
-      embedding: Pgvector.HalfVector.new(embedding)
+      embedding: Pgvector.HalfVector.new(embedding),
+      role_id: role_id,
+      shared_role_ids: shared_role_ids
     }
 
     %Chunk{}
@@ -248,8 +264,8 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   Extracts token-limited chunks for a given query using hybrid search.
   Returns a list of maps with `"content"`, `"source"`, and `"rrf_score"`.
   """
-  def query_extraction(query) do
-    with {:ok, results} <- hybrid_search(query) do
+  def query_extraction(query, role_ids \\ nil) do
+    with {:ok, results} <- hybrid_search(query, role_ids) do
       answer = build_answer_from_results(results)
       {:ok, answer}
     end
@@ -292,7 +308,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   Returns `{:ok, results}` where each result is a map with keys:
   `:chunk`, `:source`, `:rrf_score`, `:text_rank`, `:vector_distance`.
   """
-  def hybrid_search(query_text, limit \\ nil) do
+  def hybrid_search(query_text, role_ids \\ nil, limit \\ nil) do
     limit = limit || hybrid_search_limit()
 
     with {:ok, embedding} <- EmbeddingClient.embed(query_text) do
@@ -331,6 +347,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
             ^embedding_vector
           )
         )
+        |> maybe_filter_roles(role_ids)
         |> select([c, d], %{
           chunk: c,
           source: d.source,
@@ -423,7 +440,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   Returns chunks within `distance_threshold` ordered by distance,
   with the document source included.
   """
-  def similarity_search(query_text, limit \\ 5) do
+  def similarity_search(query_text, role_ids \\ nil, limit \\ 5) do
     with {:ok, embedding} <- EmbeddingClient.embed(query_text) do
       embedding_vector = Pgvector.HalfVector.new(embedding)
       threshold = distance_threshold()
@@ -435,6 +452,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
           [c, _d],
           fragment("? <-> ? < ?", c.embedding, ^embedding_vector, ^threshold)
         )
+        |> maybe_filter_roles(role_ids)
         |> order_by([c, _d], fragment("? <-> ?", c.embedding, ^embedding_vector))
         |> limit(^limit)
         |> select([c, d], %{
@@ -487,6 +505,22 @@ defmodule Zaq.Ingestion.DocumentProcessor do
 
       {:ok, Repo.one(combined)}
     end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Role filtering helper
+  # ---------------------------------------------------------------------------
+
+  defp maybe_filter_roles(query, nil), do: query
+
+  defp maybe_filter_roles(query, role_ids) do
+    where(
+      query,
+      [c, _d],
+      is_nil(c.role_id) or
+        c.role_id in ^role_ids or
+        fragment("? && ?", c.shared_role_ids, ^role_ids)
+    )
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/zaq/ingestion/ingest_job.ex
+++ b/lib/zaq/ingestion/ingest_job.ex
@@ -22,6 +22,8 @@ defmodule Zaq.Ingestion.IngestJob do
     field :chunks_count, :integer, default: 0
     field :document_id, :integer
     field :volume_name, :string
+    field :role_id, :integer
+    field :shared_role_ids, {:array, :integer}, default: []
 
     timestamps(type: :utc_datetime_usec)
   end
@@ -40,7 +42,9 @@ defmodule Zaq.Ingestion.IngestJob do
       :completed_at,
       :chunks_count,
       :document_id,
-      :volume_name
+      :volume_name,
+      :role_id,
+      :shared_role_ids
     ])
     |> validate_required([:file_path, :status, :mode])
     |> validate_inclusion(:status, @statuses)

--- a/lib/zaq/ingestion/ingest_worker.ex
+++ b/lib/zaq/ingestion/ingest_worker.ex
@@ -15,7 +15,9 @@ defmodule Zaq.Ingestion.IngestWorker do
   alias Zaq.Repo
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"job_id" => job_id}, attempt: attempt, max_attempts: max}) do
+  def perform(%Oban.Job{args: %{"job_id" => job_id} = args, attempt: attempt, max_attempts: max}) do
+    role_id = Map.get(args, "role_id")
+    shared_role_ids = Map.get(args, "shared_role_ids", [])
     job = Repo.get!(IngestJob, job_id)
 
     updated_job =
@@ -26,7 +28,7 @@ defmodule Zaq.Ingestion.IngestWorker do
 
     file_path = resolve_file_path(updated_job.file_path)
 
-    case safe_process(file_path) do
+    case safe_process(file_path, role_id, shared_role_ids) do
       {:ok, document} ->
         updated_job
         |> IngestJob.changeset(%{
@@ -73,8 +75,8 @@ defmodule Zaq.Ingestion.IngestWorker do
     attempt * 5
   end
 
-  defp safe_process(file_path) do
-    processor().process_single_file(file_path)
+  defp safe_process(file_path, role_id, shared_role_ids) do
+    processor().process_single_file(file_path, role_id, shared_role_ids)
   rescue
     e ->
       Logger.error(

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -4,7 +4,7 @@ defmodule Zaq.Ingestion do
   query job statuses, retry and cancel jobs.
   """
 
-  alias Zaq.Ingestion.{FileExplorer, IngestJob, IngestWorker}
+  alias Zaq.Ingestion.{Chunk, Document, FileExplorer, IngestJob, IngestWorker}
   alias Zaq.Repo
 
   import Ecto.Query
@@ -14,35 +14,61 @@ defmodule Zaq.Ingestion do
 
   # --- Ingestion triggers ---
 
-  def ingest_file(path, mode \\ :async, volume_name \\ nil) do
-    with {:ok, job} <- create_job(path, mode, volume_name) do
+  def ingest_file(path, mode \\ :async, volume_name \\ nil, role_id \\ nil, shared_role_ids \\ []) do
+    with {:ok, job} <- create_job(path, mode, volume_name, role_id, shared_role_ids) do
       case mode do
         :async ->
-          %{"job_id" => job.id}
+          job.id
+          |> build_job_args(role_id, shared_role_ids)
           |> IngestWorker.new()
           |> Oban.insert()
 
           {:ok, job}
 
         :inline ->
-          IngestWorker.perform(%Oban.Job{args: %{"job_id" => job.id}})
+          IngestWorker.perform(%Oban.Job{args: build_job_args(job.id, role_id, shared_role_ids)})
           {:ok, Repo.get!(IngestJob, job.id)}
       end
     end
   end
 
-  def ingest_folder(path, mode \\ :async, volume_name \\ nil) do
+  defp build_job_args(job_id, role_id, shared_role_ids) do
+    args = %{"job_id" => job_id}
+    args = if role_id, do: Map.put(args, "role_id", role_id), else: args
+    if shared_role_ids != [], do: Map.put(args, "shared_role_ids", shared_role_ids), else: args
+  end
+
+  def ingest_folder(
+        path,
+        mode \\ :async,
+        volume_name \\ nil,
+        role_id \\ nil,
+        shared_role_ids \\ []
+      ) do
     with {:ok, entries} <- FileExplorer.list(path) do
       jobs =
         entries
         |> Enum.filter(&(&1.type == :file))
         |> Enum.map(fn entry ->
           file_path = Path.join(path, entry.name)
-          {:ok, job} = ingest_file(file_path, mode, volume_name)
+          {:ok, job} = ingest_file(file_path, mode, volume_name, role_id, shared_role_ids)
           job
         end)
 
       {:ok, jobs}
+    end
+  end
+
+  # --- Sharing ---
+
+  def share_file(source, shared_role_ids) do
+    case Document.get_by_source(source) do
+      nil ->
+        {:error, :not_found}
+
+      doc ->
+        Chunk.update_shared_role_ids_for_document(doc.id, shared_role_ids)
+        {:ok, shared_role_ids}
     end
   end
 
@@ -97,10 +123,14 @@ defmodule Zaq.Ingestion do
 
   # --- Private ---
 
-  defp create_job(path, mode, volume_name) do
+  defp create_job(path, mode, volume_name, role_id, shared_role_ids) do
     attrs =
       %{file_path: path, status: "pending", mode: to_string(mode)}
       |> then(fn a -> if volume_name, do: Map.put(a, :volume_name, volume_name), else: a end)
+      |> then(fn a -> if role_id, do: Map.put(a, :role_id, role_id), else: a end)
+      |> then(fn a ->
+        if shared_role_ids != [], do: Map.put(a, :shared_role_ids, shared_role_ids), else: a
+      end)
 
     %IngestJob{}
     |> IngestJob.changeset(attrs)

--- a/lib/zaq_web/components/role_share_picker.ex
+++ b/lib/zaq_web/components/role_share_picker.ex
@@ -1,0 +1,84 @@
+defmodule ZaqWeb.Components.RoleSharePicker do
+  @moduledoc """
+  Reusable role-sharing picker component.
+
+  Renders a list of role checkboxes that let users select which roles
+  can access a resource. When no roles are selected, the resource is
+  private (accessible only to the ingesting user's role).
+
+  ## Usage
+
+      <ZaqWeb.Components.RoleSharePicker.role_share_picker
+        roles={@all_roles}
+        selected_role_ids={@shared_role_ids}
+        toggle_event="toggle_shared_role"
+      />
+  """
+
+  use Phoenix.Component
+
+  attr :roles, :list, required: true
+  attr :selected_role_ids, :list, required: true
+  attr :toggle_event, :string, default: "toggle_shared_role"
+
+  def role_share_picker(assigns) do
+    ~H"""
+    <div class="bg-white rounded-2xl border border-black/[0.06] shadow-sm overflow-hidden">
+      <div class="px-5 py-3 border-b border-black/[0.06] bg-[#fafafa] flex items-center justify-between">
+        <div>
+          <p class="font-mono text-[0.7rem] font-semibold text-black/60 uppercase tracking-wider">
+            Share with Roles
+          </p>
+          <p class="font-mono text-[0.65rem] text-black/30 mt-0.5">
+            {if @selected_role_ids == [],
+              do: "Private — only your role can access ingested content",
+              else: "Shared with #{length(@selected_role_ids)} role(s)"}
+          </p>
+        </div>
+        <span class={[
+          "font-mono text-[0.65rem] px-2 py-0.5 rounded-full",
+          if(@selected_role_ids == [],
+            do: "bg-black/5 text-black/30",
+            else: "bg-[#03b6d4]/10 text-[#03b6d4]"
+          )
+        ]}>
+          {if @selected_role_ids == [], do: "private", else: "shared"}
+        </span>
+      </div>
+
+      <div class="px-5 py-4">
+        <%= if @roles == [] do %>
+          <p class="font-mono text-[0.75rem] text-black/30 italic">No roles defined yet.</p>
+        <% else %>
+          <div class="flex flex-wrap gap-2">
+            <label
+              :for={role <- @roles}
+              class={[
+                "flex items-center gap-2 px-3 py-1.5 rounded-xl border cursor-pointer transition-all",
+                if(role.id in @selected_role_ids,
+                  do: "border-[#03b6d4] bg-[#03b6d4]/5 text-[#03b6d4]",
+                  else: "border-black/10 bg-[#fafafa] text-black/50 hover:border-black/20"
+                )
+              ]}
+            >
+              <input
+                type="checkbox"
+                checked={role.id in @selected_role_ids}
+                phx-click={@toggle_event}
+                phx-value-role_id={role.id}
+                class="hidden"
+              />
+              <span class={[
+                "w-1.5 h-1.5 rounded-full",
+                if(role.id in @selected_role_ids, do: "bg-[#03b6d4]", else: "bg-black/20")
+              ]}>
+              </span>
+              <span class="font-mono text-[0.78rem] font-medium">{role.name}</span>
+            </label>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/zaq_web/controllers/agent_controller.ex
+++ b/lib/zaq_web/controllers/agent_controller.ex
@@ -60,7 +60,7 @@ defmodule ZaqWeb.AgentController do
     result =
       if File.dir?(path),
         do: document_processor.process_folder(path),
-        else: document_processor.process_single_file(path)
+        else: document_processor.process_single_file(path, nil)
 
     case result do
       {:ok, data} ->

--- a/lib/zaq_web/live/bo/accounts/role_form_live.ex
+++ b/lib/zaq_web/live/bo/accounts/role_form_live.ex
@@ -4,7 +4,9 @@ defmodule ZaqWeb.Live.BO.Accounts.RoleFormLive do
   alias Zaq.Accounts
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :current_path, ~p"/bo/roles")}
+    {:ok,
+     socket
+     |> assign(:current_path, ~p"/bo/roles")}
   end
 
   def handle_params(params, _uri, socket) do

--- a/lib/zaq_web/live/bo/ai/ingestion_components.ex
+++ b/lib/zaq_web/live/bo/ai/ingestion_components.ex
@@ -245,10 +245,11 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
   attr :selected, :any, required: true
   attr :current_dir, :string, required: true
   attr :ingestion_map, :map, required: true
+  attr :all_roles, :list, default: []
 
   def file_list_view(assigns) do
     ~H"""
-    <div class="bg-white rounded-2xl border border-black/[0.06] shadow-sm max-h-[55vh] overflow-y-scroll">
+    <div class="bg-white rounded-2xl border border-black/[0.06] shadow-sm max-h-[45vh] overflow-y-scroll">
       <table class="w-full">
         <thead>
           <tr class="border-b border-black/[0.06] bg-[#fafafa]">
@@ -387,6 +388,27 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
                     </svg>
                   </button>
                   <button
+                    :if={entry.type == :file}
+                    phx-click="share_item"
+                    phx-value-path={Path.join(@current_dir, entry.name)}
+                    class="p-1.5 hover:bg-[#03b6d4]/10 rounded-lg text-black/30 hover:text-[#03b6d4] transition-colors"
+                    title="Share with roles"
+                  >
+                    <svg
+                      class="w-3.5 h-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                      />
+                    </svg>
+                  </button>
+                  <button
                     phx-click="delete_item"
                     phx-value-path={Path.join(@current_dir, entry.name)}
                     phx-value-type={entry.type}
@@ -436,18 +458,40 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
                     </div>
                   <% status.ingested_at != nil -> %>
                     <div class="flex flex-col gap-0.5">
-                      <span class="inline-flex items-center gap-1 font-mono text-[0.65rem] px-2 py-0.5 rounded bg-emerald-100 text-emerald-700 w-fit">
-                        <svg
-                          class="w-3 h-3"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
+                      <div class="flex items-center gap-1 flex-wrap">
+                        <span class="inline-flex items-center gap-1 font-mono text-[0.65rem] px-2 py-0.5 rounded bg-emerald-100 text-emerald-700">
+                          <svg
+                            class="w-3 h-3"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                          >
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                          </svg>
+                          ingested
+                        </span>
+                        <span
+                          :if={status.shared_role_ids != []}
+                          class="inline-flex items-center gap-1 font-mono text-[0.65rem] px-2 py-0.5 rounded bg-[#03b6d4]/10 text-[#03b6d4] cursor-default"
+                          title={"Shared with: #{@all_roles |> Enum.filter(&(&1.id in status.shared_role_ids)) |> Enum.map(& &1.name) |> Enum.join(", ")}"}
                         >
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-                        </svg>
-                        ingested
-                      </span>
+                          <svg
+                            class="w-3 h-3"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                            />
+                          </svg>
+                          shared
+                        </span>
+                      </div>
                       <span class="font-mono text-[0.6rem] text-black/30">
                         {format_datetime(status.ingested_at)}
                       </span>
@@ -475,10 +519,11 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
   attr :selected, :any, required: true
   attr :current_dir, :string, required: true
   attr :ingestion_map, :map, required: true
+  attr :all_roles, :list, default: []
 
   def file_grid_view(assigns) do
     ~H"""
-    <div class="bg-white rounded-2xl border border-black/[0.06] shadow-sm max-h-[55vh] overflow-y-scroll p-4">
+    <div class="bg-white rounded-2xl border border-black/[0.06] shadow-sm max-h-[45vh] overflow-y-scroll p-4">
       <div class="flex items-center gap-2 mb-4 pb-3 border-b border-black/[0.06]">
         <input
           type="checkbox"
@@ -581,6 +626,27 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
               </svg>
             </button>
             <button
+              :if={entry.type == :file}
+              phx-click="share_item"
+              phx-value-path={Path.join(@current_dir, entry.name)}
+              class="p-1 hover:bg-[#03b6d4]/10 rounded-lg text-black/30 hover:text-[#03b6d4] transition-colors"
+              title="Share with roles"
+            >
+              <svg
+                class="w-3 h-3"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                />
+              </svg>
+            </button>
+            <button
               phx-click="delete_item"
               phx-value-path={Path.join(@current_dir, entry.name)}
               phx-value-type={entry.type}
@@ -637,9 +703,18 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
                     stale
                   </span>
                 <% status.ingested_at != nil -> %>
-                  <span class="font-mono text-[0.55rem] px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 mt-1">
-                    ingested
-                  </span>
+                  <div class="flex flex-col items-center gap-0.5 mt-1">
+                    <span class="font-mono text-[0.55rem] px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700">
+                      ingested
+                    </span>
+                    <span
+                      :if={status.shared_role_ids != []}
+                      class="font-mono text-[0.55rem] px-1.5 py-0.5 rounded bg-[#03b6d4]/10 text-[#03b6d4] cursor-default"
+                      title={"Shared with: #{@all_roles |> Enum.filter(&(&1.id in status.shared_role_ids)) |> Enum.map(& &1.name) |> Enum.join(", ")}"}
+                    >
+                      shared
+                    </span>
+                  </div>
                 <% true -> %>
               <% end %>
             </div>
@@ -744,7 +819,7 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
         </button>
       </div>
 
-      <div class="space-y-2">
+      <div class="space-y-2 max-h-[80vh] overflow-y-auto">
         <div
           :if={@jobs == []}
           class="bg-white rounded-xl border border-dashed border-black/10 p-6 text-center"
@@ -1312,6 +1387,102 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
             class="font-mono text-[0.78rem] font-semibold px-5 py-2 rounded-xl bg-indigo-500 text-white hover:bg-indigo-600 shadow-sm shadow-indigo-500/20 transition-all"
           >
             Move Here
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # ── Share Modal ───────────────────────────────────────────────────────────
+
+  attr :modal_name, :string, required: true
+  attr :modal_error, :string, default: nil
+  attr :all_roles, :list, required: true
+  attr :share_modal_role_ids, :list, required: true
+
+  def modal_share(assigns) do
+    ~H"""
+    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm">
+      <div class="bg-white rounded-2xl shadow-xl border border-black/[0.06] w-full max-w-md mx-4 overflow-hidden">
+        <div class="px-6 py-5 border-b border-black/[0.06] bg-[#fafafa] flex items-center justify-between">
+          <div>
+            <h3 class="font-mono text-[0.9rem] font-bold text-black">Share with Roles</h3>
+            <p class="font-mono text-[0.72rem] text-black/40 mt-0.5 truncate max-w-xs">
+              {@modal_name}
+            </p>
+          </div>
+          <button
+            phx-click="close_modal"
+            class="p-1.5 hover:bg-black/5 rounded-lg text-black/30 hover:text-black/60 transition-colors"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="px-6 py-5">
+          <p class="font-mono text-[0.72rem] text-black/40 mb-4">
+            {if @share_modal_role_ids == [],
+              do: "Private — only the ingesting role can access this file.",
+              else: "Shared with #{length(@share_modal_role_ids)} role(s)."}
+          </p>
+
+          <p :if={@all_roles == []} class="font-mono text-[0.78rem] text-black/30 italic">
+            No roles defined yet.
+          </p>
+
+          <div class="flex flex-wrap gap-2">
+            <label
+              :for={role <- @all_roles}
+              class={[
+                "flex items-center gap-2 px-3 py-2 rounded-xl border cursor-pointer transition-all select-none",
+                if(role.id in @share_modal_role_ids,
+                  do: "border-[#03b6d4] bg-[#03b6d4]/5 text-[#03b6d4]",
+                  else: "border-black/10 bg-[#fafafa] text-black/50 hover:border-black/20"
+                )
+              ]}
+            >
+              <input
+                type="checkbox"
+                checked={role.id in @share_modal_role_ids}
+                phx-click="toggle_share_role"
+                phx-value-role_id={role.id}
+                class="hidden"
+              />
+              <span class={[
+                "w-2 h-2 rounded-full shrink-0",
+                if(role.id in @share_modal_role_ids, do: "bg-[#03b6d4]", else: "bg-black/20")
+              ]}>
+              </span>
+              <span class="font-mono text-[0.82rem] font-medium">{role.name}</span>
+            </label>
+          </div>
+
+          <p :if={@modal_error} class="font-mono text-[0.72rem] text-red-500 mt-3">
+            {@modal_error}
+          </p>
+        </div>
+
+        <div class="px-6 py-4 bg-[#fafafa] border-t border-black/[0.06] flex items-center justify-end gap-2">
+          <button
+            phx-click="close_modal"
+            class="font-mono text-[0.78rem] px-4 py-2 rounded-xl text-black/50 hover:bg-black/5 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            phx-click="confirm_share"
+            class="font-mono text-[0.78rem] font-semibold px-5 py-2 rounded-xl bg-[#03b6d4] text-white hover:bg-[#029ab3] shadow-sm shadow-[#03b6d4]/20 transition-all"
+          >
+            {if @share_modal_role_ids == [], do: "Make Private", else: "Share"}
           </button>
         </div>
       </div>

--- a/lib/zaq_web/live/bo/ai/ingestion_live.ex
+++ b/lib/zaq_web/live/bo/ai/ingestion_live.ex
@@ -6,8 +6,9 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   import Ecto.Query
   import ZaqWeb.Live.BO.AI.IngestionComponents
 
+  alias Zaq.Accounts
   alias Zaq.Ingestion
-  alias Zaq.Ingestion.{Document, FileExplorer}
+  alias Zaq.Ingestion.{Chunk, Document, FileExplorer}
   alias Zaq.Repo
 
   @allowed_extensions ~w(.md .txt .pdf)
@@ -32,6 +33,9 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
        # Volume state
        volumes: volumes,
        current_volume: current_volume,
+       # Role sharing
+       all_roles: Accounts.list_roles(),
+       share_modal_role_ids: [],
        # View mode
        view_mode: "list",
        # Modal state
@@ -61,6 +65,50 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   # ────────────────────────────────────────────────────────────────
   # handle_event/3 — all clauses grouped together
   # ────────────────────────────────────────────────────────────────
+
+  # Role sharing (share modal)
+
+  def handle_event("share_item", %{"path" => path}, socket) do
+    current_shared =
+      get_in(socket.assigns.ingestion_map, [Path.basename(path), :shared_role_ids]) || []
+
+    {:noreply,
+     assign(socket,
+       modal: :share,
+       modal_path: path,
+       modal_name: Path.basename(path),
+       modal_error: nil,
+       share_modal_role_ids: current_shared
+     )}
+  end
+
+  def handle_event("toggle_share_role", %{"role_id" => role_id_str}, socket) do
+    role_id = String.to_integer(role_id_str)
+    current = socket.assigns.share_modal_role_ids
+
+    updated =
+      if role_id in current,
+        do: List.delete(current, role_id),
+        else: [role_id | current]
+
+    {:noreply, assign(socket, :share_modal_role_ids, updated)}
+  end
+
+  def handle_event("confirm_share", _params, socket) do
+    source = normalize_source(socket.assigns.modal_path)
+
+    case Ingestion.share_file(source, socket.assigns.share_modal_role_ids) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign(modal: nil, modal_error: nil)
+         |> load_entries()
+         |> put_flash(:info, "Sharing updated for \"#{socket.assigns.modal_name}\".")}
+
+      {:error, :not_found} ->
+        {:noreply, assign(socket, modal_error: "File has not been ingested yet.")}
+    end
+  end
 
   # Volume
 
@@ -364,11 +412,12 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   def handle_event("ingest_selected", _params, socket) do
     mode = String.to_existing_atom(socket.assigns.ingest_mode)
     volume = socket.assigns.current_volume
+    role_id = socket.assigns.current_user.role_id
 
     for path <- socket.assigns.selected do
       case FileExplorer.file_info(volume, path) do
-        {:ok, %{type: :directory}} -> Ingestion.ingest_folder(path, mode, volume)
-        {:ok, %{type: :file}} -> Ingestion.ingest_file(path, mode, volume)
+        {:ok, %{type: :directory}} -> Ingestion.ingest_folder(path, mode, volume, role_id)
+        {:ok, %{type: :file}} -> Ingestion.ingest_file(path, mode, volume, role_id)
         _ -> :skip
       end
     end
@@ -437,49 +486,60 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
     if Path.extname(filename) == "", do: filename <> ".md", else: filename
   end
 
+  defp normalize_source(path) do
+    case path do
+      "./" <> rest -> rest
+      other -> other
+    end
+  end
+
   defp load_ingestion_status(socket) do
     current_dir = socket.assigns.current_dir
+    current_role_id = socket.assigns.current_user.role_id
 
     sources =
       socket.assigns.entries
       |> Enum.filter(&(&1.type == :file))
       |> Enum.map(fn entry ->
-        path = Path.join(current_dir, entry.name)
-        # Normalise: strip leading "./" so it matches what extract_source stores
-        case path do
-          "./" <> rest -> rest
-          other -> other
-        end
+        normalize_source(Path.join(current_dir, entry.name))
       end)
 
     documents =
-      from(d in Zaq.Ingestion.Document, where: d.source in ^sources)
+      from(d in Document, where: d.source in ^sources)
       |> Repo.all()
       |> Map.new(fn d -> {d.source, d} end)
+
+    doc_ids = documents |> Map.values() |> Enum.map(& &1.id)
+    shared_by_doc = Chunk.shared_role_ids_by_documents(doc_ids)
 
     ingestion_map =
       socket.assigns.entries
       |> Enum.filter(&(&1.type == :file))
       |> Map.new(fn entry ->
-        raw = Path.join(current_dir, entry.name)
+        source = normalize_source(Path.join(current_dir, entry.name))
 
-        source =
-          case raw do
-            "./" <> rest -> rest
-            other -> other
+        status =
+          case Map.get(documents, source) do
+            nil -> %{ingested_at: nil, stale?: false, shared_role_ids: []}
+            doc -> entry_ingestion_status(entry, doc, shared_by_doc, current_role_id)
           end
 
-        case Map.get(documents, source) do
-          nil ->
-            {entry.name, %{ingested_at: nil, stale?: false}}
-
-          doc ->
-            stale? = DateTime.compare(entry.modified_at, doc.updated_at) == :gt
-            {entry.name, %{ingested_at: doc.updated_at, stale?: stale?}}
-        end
+        {entry.name, status}
       end)
 
     assign(socket, ingestion_map: ingestion_map)
+  end
+
+  defp entry_ingestion_status(entry, doc, shared_by_doc, current_role_id) do
+    shared = Map.get(shared_by_doc, doc.id, [])
+    visible? = is_nil(doc.role_id) or doc.role_id == current_role_id or current_role_id in shared
+
+    if visible? do
+      stale? = DateTime.compare(entry.modified_at, doc.updated_at) == :gt
+      %{ingested_at: doc.updated_at, stale?: stale?, shared_role_ids: shared}
+    else
+      %{ingested_at: nil, stale?: false, shared_role_ids: []}
+    end
   end
 
   defp parent_dir("."), do: "."

--- a/lib/zaq_web/live/bo/ai/ingestion_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/ingestion_live.html.heex
@@ -23,6 +23,7 @@
           selected={@selected}
           current_dir={@current_dir}
           ingestion_map={@ingestion_map}
+          all_roles={@all_roles}
         />
         <.file_grid_view
           :if={@view_mode == "grid"}
@@ -30,6 +31,7 @@
           selected={@selected}
           current_dir={@current_dir}
           ingestion_map={@ingestion_map}
+          all_roles={@all_roles}
         />
       </div>
 
@@ -62,5 +64,12 @@
     move_current_dir={@move_current_dir}
     move_breadcrumbs={@move_breadcrumbs}
     move_folders={@move_folders}
+  />
+  <.modal_share
+    :if={@modal == :share}
+    modal_name={@modal_name}
+    modal_error={@modal_error}
+    all_roles={@all_roles}
+    share_modal_role_ids={@share_modal_role_ids}
   />
 </ZaqWeb.Components.BOLayout.bo_layout>

--- a/lib/zaq_web/live/bo/communication/playground_live.ex
+++ b/lib/zaq_web/live/bo/communication/playground_live.ex
@@ -19,6 +19,7 @@ defmodule ZaqWeb.Live.BO.Communication.PlaygroundLive do
 
   use ZaqWeb, :live_view
 
+  alias Zaq.Accounts.Permissions
   alias Zaq.Agent.{Answering, PromptGuard, Retrieval}
   alias Zaq.Agent.PromptTemplate
   alias Zaq.Ingestion.DocumentProcessor
@@ -93,7 +94,16 @@ defmodule ZaqWeb.Live.BO.Communication.PlaygroundLive do
 
       pid = self()
       request_id = user_msg.id
-      Task.start(fn -> run_pipeline_async(pid, request_id, trimmed, socket.assigns.history) end)
+
+      Task.start(fn ->
+        run_pipeline_async(
+          pid,
+          request_id,
+          trimmed,
+          socket.assigns.history,
+          socket.assigns.current_user
+        )
+      end)
 
       {:noreply, socket}
     end
@@ -241,7 +251,9 @@ defmodule ZaqWeb.Live.BO.Communication.PlaygroundLive do
 
   # ── Async pipeline runner (runs inside Task) ───────────────────────
 
-  defp run_pipeline_async(pid, request_id, user_msg, history) do
+  defp run_pipeline_async(pid, request_id, user_msg, history, current_user) do
+    role_ids = Permissions.list_accessible_role_ids(current_user)
+
     result =
       with {:ok, clean_msg} <- PromptGuard.validate(user_msg),
            :ok <-
@@ -254,7 +266,7 @@ defmodule ZaqWeb.Live.BO.Communication.PlaygroundLive do
                :retrieving,
                retrieval_result.positive_answer
              ),
-           {:ok, extraction_result} <- run_query_extraction(retrieval_result),
+           {:ok, extraction_result} <- run_query_extraction(retrieval_result, role_ids),
            :ok <- update_status(pid, request_id, :answering, "Formulating your answer…"),
            {:ok, answer_result} <-
              run_answering(clean_msg, extraction_result, retrieval_result, history),
@@ -334,8 +346,8 @@ defmodule ZaqWeb.Live.BO.Communication.PlaygroundLive do
   end
 
   # Routes DocumentProcessor.query_extraction to the node running Zaq.Ingestion.Supervisor.
-  defp run_query_extraction(%{query: query, negative_answer: negative_answer} = _retrieval) do
-    case node_router().call(:ingestion, DocumentProcessor, :query_extraction, [query]) do
+  defp run_query_extraction(%{query: query, negative_answer: negative_answer}, role_ids) do
+    case node_router().call(:ingestion, DocumentProcessor, :query_extraction, [query, role_ids]) do
       {:ok, results} when results != [] -> {:ok, results}
       {:ok, []} -> {:error, :no_results, negative_answer}
       {:error, _} -> {:error, :no_results, negative_answer}

--- a/priv/repo/migrations/20260313000001_add_role_id_to_chunks.exs
+++ b/priv/repo/migrations/20260313000001_add_role_id_to_chunks.exs
@@ -1,0 +1,11 @@
+defmodule Zaq.Repo.Migrations.AddRoleIdToChunks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:chunks) do
+      add :role_id, references(:roles, on_delete: :nilify_all), null: true
+    end
+
+    create index(:chunks, [:role_id])
+  end
+end

--- a/priv/repo/migrations/20260313000002_add_role_id_to_ingest_jobs.exs
+++ b/priv/repo/migrations/20260313000002_add_role_id_to_ingest_jobs.exs
@@ -1,0 +1,11 @@
+defmodule Zaq.Repo.Migrations.AddRoleIdToIngestJobs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ingest_jobs) do
+      add :role_id, references(:roles, on_delete: :nilify_all), null: true
+    end
+
+    create index(:ingest_jobs, [:role_id])
+  end
+end

--- a/priv/repo/migrations/20260313000003_add_shared_role_ids_to_chunks.exs
+++ b/priv/repo/migrations/20260313000003_add_shared_role_ids_to_chunks.exs
@@ -1,0 +1,9 @@
+defmodule Zaq.Repo.Migrations.AddSharedRoleIdsToChunks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:chunks) do
+      add :shared_role_ids, {:array, :integer}, default: []
+    end
+  end
+end

--- a/priv/repo/migrations/20260313000004_add_shared_role_ids_to_ingest_jobs.exs
+++ b/priv/repo/migrations/20260313000004_add_shared_role_ids_to_ingest_jobs.exs
@@ -1,0 +1,9 @@
+defmodule Zaq.Repo.Migrations.AddSharedRoleIdsToIngestJobs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ingest_jobs) do
+      add :shared_role_ids, {:array, :integer}, default: []
+    end
+  end
+end

--- a/priv/repo/migrations/20260313000005_add_role_id_to_documents.exs
+++ b/priv/repo/migrations/20260313000005_add_role_id_to_documents.exs
@@ -1,0 +1,9 @@
+defmodule Zaq.Repo.Migrations.AddRoleIdToDocuments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:documents) do
+      add :role_id, references(:roles, on_delete: :nilify_all)
+    end
+  end
+end

--- a/test/zaq/accounts/permissions_test.exs
+++ b/test/zaq/accounts/permissions_test.exs
@@ -1,0 +1,66 @@
+defmodule Zaq.Accounts.PermissionsTest do
+  use Zaq.DataCase, async: true
+
+  alias Zaq.Accounts
+  alias Zaq.Accounts.Permissions
+  import Zaq.AccountsFixtures
+
+  # user_fixture doesn't preload :role — reload via Accounts to get the full struct
+  defp loaded_user(user), do: Accounts.get_user!(user.id)
+
+  describe "list_accessible_role_ids/1" do
+    test "returns own role_id when no cross-role access configured" do
+      user = user_fixture() |> loaded_user()
+      assert Permissions.list_accessible_role_ids(user) == [user.role_id]
+    end
+
+    test "returns only own role_id regardless of meta accessible_role_ids" do
+      role_b = role_fixture()
+      role_a = role_fixture(%{meta: %{"accessible_role_ids" => [role_b.id]}})
+      user = user_fixture(%{role: role_a}) |> loaded_user()
+
+      ids = Permissions.list_accessible_role_ids(user)
+      assert user.role_id in ids
+      refute role_b.id in ids
+    end
+
+    test "returns empty list when user has no role" do
+      user = user_fixture() |> loaded_user()
+      user_without_role = %{user | role_id: nil, role: nil}
+      assert Permissions.list_accessible_role_ids(user_without_role) == []
+    end
+
+    test "deduplicates ids" do
+      role = role_fixture()
+      user = user_fixture(%{role: role}) |> loaded_user()
+      user_with_dupe = %{user | role: %{user.role | meta: %{"accessible_role_ids" => [role.id]}}}
+
+      assert Permissions.list_accessible_role_ids(user_with_dupe) == [user.role_id]
+    end
+
+    test "ignores string ids in meta" do
+      role_b = role_fixture()
+      role_a = role_fixture(%{meta: %{"accessible_role_ids" => ["#{role_b.id}"]}})
+      user = user_fixture(%{role: role_a}) |> loaded_user()
+
+      ids = Permissions.list_accessible_role_ids(user)
+      refute role_b.id in ids
+      assert user.role_id in ids
+    end
+  end
+
+  describe "can_retrieve?/1 and can_ingest?/1" do
+    test "returns true when user has a role" do
+      user = user_fixture()
+      assert Permissions.can_retrieve?(user)
+      assert Permissions.can_ingest?(user)
+    end
+
+    test "returns false when user has no role" do
+      user = user_fixture()
+      user_without_role = %{user | role_id: nil}
+      refute Permissions.can_retrieve?(user_without_role)
+      refute Permissions.can_ingest?(user_without_role)
+    end
+  end
+end

--- a/test/zaq/channels/retrieval/mattermost_test.exs
+++ b/test/zaq/channels/retrieval/mattermost_test.exs
@@ -505,7 +505,7 @@ defmodule Zaq.Channels.Retrieval.MattermostTest do
       Map.get(@retrieval_overrides, clean_msg, default_retrieval_response(clean_msg))
     end
 
-    def call(:ingestion, document_processor_mod, :query_extraction, [query])
+    def call(:ingestion, document_processor_mod, :query_extraction, [query, _role_ids])
         when document_processor_mod == Zaq.Channels.Retrieval.MattermostTest.DocumentProcessorStub do
       if query == "query-error" do
         {:error, :boom}

--- a/test/zaq/ingestion/chunk_test.exs
+++ b/test/zaq/ingestion/chunk_test.exs
@@ -128,6 +128,21 @@ defmodule Zaq.Ingestion.ChunkTest do
     end
   end
 
+  describe "role_id" do
+    test "chunk with role_id is valid", %{document: doc} do
+      {:ok, role} =
+        Zaq.Accounts.create_role(%{name: "chunk_role_#{System.unique_integer([:positive])}"})
+
+      changeset = Chunk.changeset(%Chunk{}, chunk_attrs(doc, %{role_id: role.id}))
+      assert changeset.valid?
+    end
+
+    test "chunk with nil role_id is valid", %{document: doc} do
+      changeset = Chunk.changeset(%Chunk{}, chunk_attrs(doc, %{role_id: nil}))
+      assert changeset.valid?
+    end
+  end
+
   describe "document cascade delete" do
     test "deleting document removes its chunks", %{document: doc} do
       {:ok, chunk} = Chunk.create(chunk_attrs(doc, %{chunk_index: 0}))

--- a/test/zaq/ingestion/document_processor_test.exs
+++ b/test/zaq/ingestion/document_processor_test.exs
@@ -839,7 +839,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
       end
 
       assert {:ok, results} =
-               DocumentProcessor.hybrid_search("hybrid search keywords", 5)
+               DocumentProcessor.hybrid_search("hybrid search keywords", nil, 5)
 
       assert is_list(results)
 
@@ -848,6 +848,89 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
         assert Map.has_key?(r, :source)
         assert Map.has_key?(r, :rrf_score)
       end)
+    end
+
+    test "filters chunks by role_ids" do
+      stub_embedding_success()
+      doc = create_document()
+
+      {:ok, role_a} =
+        Zaq.Accounts.create_role(%{name: "dp_role_a_#{System.unique_integer([:positive])}"})
+
+      {:ok, role_b} =
+        Zaq.Accounts.create_role(%{name: "dp_role_b_#{System.unique_integer([:positive])}"})
+
+      dim = embedding_dimension()
+      embedding = Pgvector.HalfVector.new(List.duplicate(0.1, dim))
+
+      %Chunk{}
+      |> Chunk.changeset(%{
+        document_id: doc.id,
+        content: "role a chunk",
+        chunk_index: 1,
+        embedding: embedding,
+        role_id: role_a.id
+      })
+      |> Repo.insert!()
+
+      %Chunk{}
+      |> Chunk.changeset(%{
+        document_id: doc.id,
+        content: "role b chunk",
+        chunk_index: 2,
+        embedding: embedding,
+        role_id: role_b.id
+      })
+      |> Repo.insert!()
+
+      %Chunk{}
+      |> Chunk.changeset(%{
+        document_id: doc.id,
+        content: "untagged chunk",
+        chunk_index: 3,
+        embedding: embedding
+      })
+      |> Repo.insert!()
+
+      {:ok, results} = DocumentProcessor.hybrid_search("chunk", [role_a.id])
+      chunk_ids = Enum.map(results, & &1.chunk.role_id)
+
+      # role_a chunks and nil-tagged chunks are visible; role_b is not
+      refute role_b.id in chunk_ids
+      assert Enum.any?(chunk_ids, &is_nil/1) or role_a.id in chunk_ids
+    end
+
+    test "nil role_ids returns all chunks" do
+      stub_embedding_success()
+      doc = create_document()
+
+      {:ok, role} =
+        Zaq.Accounts.create_role(%{name: "dp_role_nil_#{System.unique_integer([:positive])}"})
+
+      dim = embedding_dimension()
+      embedding = Pgvector.HalfVector.new(List.duplicate(0.1, dim))
+
+      %Chunk{}
+      |> Chunk.changeset(%{
+        document_id: doc.id,
+        content: "tagged chunk",
+        chunk_index: 1,
+        embedding: embedding,
+        role_id: role.id
+      })
+      |> Repo.insert!()
+
+      %Chunk{}
+      |> Chunk.changeset(%{
+        document_id: doc.id,
+        content: "untagged chunk",
+        chunk_index: 2,
+        embedding: embedding
+      })
+      |> Repo.insert!()
+
+      {:ok, results} = DocumentProcessor.hybrid_search("chunk", nil)
+      assert length(results) >= 2
     end
   end
 end

--- a/test/zaq/ingestion/ingest_worker_test.exs
+++ b/test/zaq/ingestion/ingest_worker_test.exs
@@ -44,7 +44,9 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
       |> Chunk.changeset(%{document_id: doc.id, content: "second", chunk_index: 2})
       |> Repo.insert!()
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:ok, doc}
       end)
 
@@ -72,7 +74,9 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
       job = create_job()
       Zaq.Ingestion.subscribe()
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:error, :parse_error}
       end)
 
@@ -98,7 +102,9 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
       job = create_job()
       Zaq.Ingestion.subscribe()
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:error, "temporary failure"}
       end)
 
@@ -119,10 +125,51 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
       assert_receive {:job_updated, %{id: ^job_id, status: "pending"}}
     end
 
+    test "passes role_id from job args to processor" do
+      {:ok, role} =
+        Zaq.Accounts.create_role(%{name: "worker_role_#{System.unique_integer([:positive])}"})
+
+      job = create_job(%{role_id: role.id})
+
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 role_id,
+                                                                 _shared_role_ids ->
+        assert role_id == role.id
+        {:ok, create_document()}
+      end)
+
+      assert :ok =
+               IngestWorker.perform(%Oban.Job{
+                 args: %{"job_id" => job.id, "role_id" => role.id},
+                 attempt: 1,
+                 max_attempts: 3
+               })
+    end
+
+    test "passes nil role_id when not present in args" do
+      job = create_job()
+
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 role_id,
+                                                                 _shared_role_ids ->
+        assert is_nil(role_id)
+        {:ok, create_document()}
+      end)
+
+      assert :ok =
+               IngestWorker.perform(%Oban.Job{
+                 args: %{"job_id" => job.id},
+                 attempt: 1,
+                 max_attempts: 3
+               })
+    end
+
     test "uses unresolved path when resolve_path fails" do
       job = create_job(%{file_path: "../../bad.md"})
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         assert path == "../../bad.md"
         {:error, :missing}
       end)
@@ -138,7 +185,9 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
     test "converts crashes to retries" do
       job = create_job()
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         raise "boom"
       end)
 

--- a/test/zaq/ingestion/ingestion_test.exs
+++ b/test/zaq/ingestion/ingestion_test.exs
@@ -25,7 +25,9 @@ defmodule Zaq.IngestionTest do
 
   describe "ingest_file/2" do
     test "creates a job and enqueues worker in async mode" do
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:ok, %{id: nil, chunks_count: 2, document_id: nil}}
       end)
 
@@ -38,7 +40,9 @@ defmodule Zaq.IngestionTest do
     test "creates a job and processes inline" do
       Ingestion.subscribe()
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:ok, %{id: nil, chunks_count: 3, document_id: nil}}
       end)
 
@@ -66,7 +70,9 @@ defmodule Zaq.IngestionTest do
         _ = FileExplorer.delete_directory(folder)
       end)
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, 2, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, 2, fn _path,
+                                                                    _role_id,
+                                                                    _shared_role_ids ->
         {:ok, %{id: nil, chunks_count: 1, document_id: nil}}
       end)
 
@@ -129,7 +135,9 @@ defmodule Zaq.IngestionTest do
       job = create_job(%{status: "failed", error: "something broke"})
       Ingestion.subscribe()
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:ok, %{id: nil, chunks_count: 1, document_id: nil}}
       end)
 
@@ -174,7 +182,9 @@ defmodule Zaq.IngestionTest do
 
   describe "ingest_file/3 (volume-aware)" do
     test "stores volume_name on the created job" do
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:ok, %{id: nil, chunks_count: 1, document_id: nil}}
       end)
 
@@ -183,7 +193,9 @@ defmodule Zaq.IngestionTest do
     end
 
     test "nil volume_name when not provided (backward compat)" do
-      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
         {:ok, %{id: nil, chunks_count: 1, document_id: nil}}
       end)
 
@@ -202,7 +214,9 @@ defmodule Zaq.IngestionTest do
 
       on_exit(fn -> _ = FileExplorer.delete_directory(folder) end)
 
-      expect(Zaq.DocumentProcessorMock, :process_single_file, 1, fn _path ->
+      expect(Zaq.DocumentProcessorMock, :process_single_file, 1, fn _path,
+                                                                    _role_id,
+                                                                    _shared_role_ids ->
         {:ok, %{id: nil, chunks_count: 1, document_id: nil}}
       end)
 

--- a/test/zaq_web/controllers/agent_controller_test.exs
+++ b/test/zaq_web/controllers/agent_controller_test.exs
@@ -113,8 +113,8 @@ defmodule ZaqWeb.AgentControllerTest do
     def query_extraction(query), do: {:ok, [%{"content" => "ctx:" <> query}]}
 
     def process_folder(_path), do: {:ok, %{processed: 2, failed: 0}}
-    def process_single_file("error_file.md"), do: {:error, :ingest_failed}
-    def process_single_file(_path), do: {:ok, %{source: "single"}}
+    def process_single_file("error_file.md", _role_id), do: {:error, :ingest_failed}
+    def process_single_file(_path, _role_id), do: {:ok, %{source: "single"}}
   end
 
   defmodule AnsweringStub do

--- a/test/zaq_web/live/bo/ai/ingestion_live_test.exs
+++ b/test/zaq_web/live/bo/ai/ingestion_live_test.exs
@@ -342,7 +342,9 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
     end
 
     test "ingest_selected clears selection and shows flash for a file", %{conn: conn} do
-      Mox.stub(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      Mox.stub(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                   _role_id,
+                                                                   _shared_role_ids ->
         {:ok, %{id: nil}}
       end)
 
@@ -360,7 +362,9 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
     end
 
     test "ingest_selected clears selection and shows flash for a directory", %{conn: conn} do
-      Mox.stub(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
+      Mox.stub(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                   _role_id,
+                                                                   _shared_role_ids ->
         {:ok, %{id: nil}}
       end)
 
@@ -375,6 +379,28 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
       refute has_element?(view, "button", "Delete (1)")
       # A job row for a file inside the folder appears in the jobs table
       assert has_element?(view, "p", ~r/readme\.md/)
+    end
+
+    test "ingest_selected passes current_user role_id to ingest functions", %{conn: conn} do
+      parent = self()
+
+      Mox.stub(Zaq.DocumentProcessorMock, :process_single_file, fn _path,
+                                                                   role_id,
+                                                                   _shared_role_ids ->
+        send(parent, {:role_id_used, role_id})
+        {:ok, %{id: nil}}
+      end)
+
+      user = Zaq.Accounts.get_user_by_username("ingestion_live_admin")
+
+      {:ok, view, _html} = live(conn, ~p"/bo/ingestion")
+
+      render_hook(view, "set_mode", %{"mode" => "inline"})
+      render_hook(view, "toggle_select", %{"path" => "alpha.md"})
+      render_hook(view, "ingest_selected", %{})
+
+      assert_receive {:role_id_used, role_id}, 500
+      assert role_id == user.role_id
     end
   end
 


### PR DESCRIPTION
Tags chunks and ingest jobs with a role_id at ingestion time, then filters search results to only the requesting user's accessible roles at retrieval time. Cross-role access is configured per-role via meta["accessible_role_ids"]. Mattermost queries resolve the sender's ZAQ username to determine their role_ids before querying.

- Migrations: add role_id FK to chunks and ingest_jobs tables
- Zaq.Accounts.Permissions: list_accessible_role_ids/1, can_ingest?/1, can_retrieve?/1
- DocumentProcessor: role-filtered hybrid_search/3, similarity_search/3, query_extraction/2; thread role_id through process_single_file → insert_chunk
- IngestWorker: extract role_id from Oban job args, pass to processor
- Ingestion: ingest_file/4 and ingest_folder/4 accept optional role_id
- Mattermost retrieval: resolve sender_name → user → role_ids before query_extraction
- IngestionLive: pass current_user.role_id to ingest calls
- RoleFormLive: accessible roles checkboxes UI, persisted in role.meta

Close #5 