### PR TITLE
feat(ingestion): add PDF → markdown pipeline via Python scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ zaq-*.tar
 npm-debug.log
 /assets/node_modules/
 
+/priv/python/
+/.venv/
 /priv/keys
 /priv/licenses
 /priv/documents

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ ZAQ is a single Elixir/OTP application composed of five internal services. Each 
 - Erlang/OTP 28
 - PostgreSQL 16+ with [pgvector](https://github.com/pgvector/pgvector) extension
 - Node.js 20+ (for asset compilation)
+- Python 3.10+ (for PDF ingestion pipeline)
 
 ## Setup
 
@@ -72,7 +73,31 @@ cd zaq
 mix setup
 ```
 
-This runs `mix deps.get`, creates the database, runs migrations, and installs assets.
+This runs `mix deps.get`, creates the database, runs migrations, installs assets, and fetches the Python pipeline scripts.
+
+### Python Pipeline (PDF Ingestion)
+
+`mix setup` fetches the Python scripts automatically. To set up the virtual environment:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r priv/python/crawler-ingest/requirements.txt
+```
+
+PDF files uploaded for ingestion are automatically converted to clean markdown before chunking and embedding. Image descriptions are generated via Scaleway Pixtral when `SCALEWAY_API_KEY` is set — otherwise that step is skipped.
+
+```bash
+# Optional — enables image-to-text descriptions in PDFs
+export SCALEWAY_API_KEY=your-key-here
+```
+
+To re-fetch or pin the Python scripts to a specific commit:
+
+```bash
+mix zaq.python.fetch                      # latest main
+mix zaq.python.fetch --commit <sha>       # pin to commit
+```
 
 ### Database
 

--- a/config/dev.secret.example.exs
+++ b/config/dev.secret.example.exs
@@ -30,6 +30,12 @@ config :zaq, Zaq.Ingestion,
   chunk_max_tokens: String.to_integer("900"),
   base_path: "priv/documents"
 
+# -- Image to Text (Scaleway Pixtral) --
+config :zaq, Zaq.Ingestion.Python.ImageToText,
+  api_url: System.get_env("SCALEWAY_API_URL", "https://api.scaleway.ai/v1/chat/completions"),
+  model: System.get_env("SCALEWAY_MODEL", "pixtral-12b-2409"),
+  api_key: System.get_env("SCALEWAY_API_KEY", "")
+
 config :zaq,
   sme_channel_id: System.get_env("SME_CHANNEL_ID", ""),
   knowledge_gap_immediate_threshold:

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -108,6 +108,12 @@ if config_env() == :prod do
     base_path: System.get_env("INGESTION_BASE_PATH", "priv/documents"),
     volumes: ingestion_volumes
 
+  # -- Image to Text (Scaleway Pixtral) --
+  config :zaq, Zaq.Ingestion.Python.ImageToText,
+    api_url: System.get_env("SCALEWAY_API_URL", "https://api.scaleway.ai/v1/chat/completions"),
+    model: System.get_env("SCALEWAY_MODEL", "pixtral-12b-2409"),
+    api_key: System.get_env("SCALEWAY_API_KEY", "")
+
   # -- Oban --
   config :zaq, Oban,
     repo: Zaq.Repo,

--- a/lib/mix/tasks/zaq.fetch_python.ex
+++ b/lib/mix/tasks/zaq.fetch_python.ex
@@ -1,0 +1,155 @@
+defmodule Mix.Tasks.Zaq.Python.Fetch do
+  @moduledoc """
+  Fetches the python crawler scripts from the upstream repository.
+
+  ## Usage
+
+      mix zaq.python.fetch [options]
+
+  ## Options
+
+      * `--branch <name>` - The branch name to fetch from (default: "main")
+      * `--commit <sha>` - The specific commit SHA to fetch (overrides --branch)
+      * `--dest <path>` - The destination directory (default: "priv/python/crawler-ingest")
+      * `--repo <url>` - The GitHub repository (default: "www-zaq-ai/crawler-ingest")
+  """
+  use Mix.Task
+
+  require Logger
+
+  @default_repo "www-zaq-ai/crawler-ingest"
+  @default_branch "main"
+  @default_dest "priv/python/crawler-ingest"
+  @required_files ~w(
+    web_crawler.py
+    pipeline.py
+    pdf_to_md.py
+    image_dedup.py
+    image_to_text.py
+    clean_md.py
+    inject_descriptions.py
+    requirements.txt
+  )
+
+  @doc false
+  def required_files, do: @required_files
+
+  @impl Mix.Task
+  def run(args) do
+    ensure_http_client_started()
+
+    {opts, _} =
+      OptionParser.parse!(args,
+        strict: [branch: :string, commit: :string, dest: :string, repo: :string]
+      )
+
+    repo = opts[:repo] || @default_repo
+    dest = opts[:dest] || @default_dest
+
+    # Determine commit SHA
+    commit_sha =
+      if opts[:commit] do
+        opts[:commit]
+      else
+        branch = opts[:branch] || @default_branch
+        resolve_branch_sha(repo, branch)
+      end
+
+    if is_nil(commit_sha) do
+      Mix.raise("Could not resolve commit SHA for the given reference.")
+    end
+
+    Mix.shell().info([:green, "Fetching scripts from #{repo} @ #{commit_sha}..."])
+
+    # Ensure destination exists
+    File.mkdir_p!(dest)
+
+    # Fetch files
+    Enum.each(@required_files, fn filename ->
+      fetch_file(repo, commit_sha, filename, dest)
+    end)
+
+    # Write manifest
+    manifest = %{
+      repo: repo,
+      commit: commit_sha,
+      files: @required_files,
+      fetched_at: DateTime.utc_now()
+    }
+
+    File.write!(Path.join(dest, "manifest.json"), Jason.encode!(manifest, pretty: true))
+
+    Mix.shell().info([:green, "✓ Successfully fetched python scripts to #{dest}"])
+
+    Mix.shell().info([
+      :yellow,
+      "Don't forget to install the requirements inside a virtual environment:"
+    ])
+
+    Mix.shell().info([:yellow, "  python3 -m venv .venv"])
+    Mix.shell().info([:yellow, "  source .venv/bin/activate"])
+    Mix.shell().info([:yellow, "  pip install -r #{dest}/requirements.txt"])
+  end
+
+  defp ensure_http_client_started do
+    if http_client() == Req do
+      case Application.ensure_all_started(:req) do
+        {:ok, _started_apps} ->
+          :ok
+
+        {:error, {app, reason}} ->
+          Mix.raise("Failed to start #{inspect(app)} required for Req: #{inspect(reason)}")
+
+        {:error, reason} ->
+          Mix.raise("Failed to start Req dependencies: #{inspect(reason)}")
+      end
+    end
+  end
+
+  defp resolve_branch_sha(repo, branch) do
+    url = "https://api.github.com/repos/#{repo}/commits/#{branch}"
+
+    case http_client().get(url, headers: [{"User-Agent", "Mix Task"}]) do
+      {:ok, %{status: 200, body: %{"sha" => sha}}} ->
+        sha
+
+      {:ok, %{status: 404}} ->
+        Mix.raise("Branch '#{branch}' not found in repository '#{repo}'")
+
+      {:error, reason} ->
+        Mix.raise("Failed to resolve branch SHA: #{inspect(reason)}")
+
+      _ ->
+        Mix.raise("Unexpected response from GitHub API when resolving branch")
+    end
+  end
+
+  defp fetch_file(repo, sha, filename, dest) do
+    url = "https://raw.githubusercontent.com/#{repo}/#{sha}/#{filename}"
+    dest_path = Path.join(dest, filename)
+
+    Mix.shell().info("  Downloading #{filename}...")
+
+    case http_client().get(url) do
+      {:ok, %{status: 200, body: body}} ->
+        File.write!(dest_path, body)
+
+        if String.ends_with?(filename, ".py") do
+          File.chmod(dest_path, 0o755)
+        end
+
+      {:ok, %{status: 404}} ->
+        Mix.raise("File '#{filename}' not found at commit #{sha}")
+
+      {:error, reason} ->
+        Mix.raise("Failed to download #{filename}: #{inspect(reason)}")
+
+      _ ->
+        Mix.raise("Unexpected response when downloading #{filename}")
+    end
+  end
+
+  defp http_client do
+    Application.get_env(:zaq, :http_client, Req)
+  end
+end

--- a/lib/zaq/ingestion/document_processor.ex
+++ b/lib/zaq/ingestion/document_processor.ex
@@ -22,6 +22,7 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   alias Zaq.Agent.TokenEstimator
   alias Zaq.Embedding.Client, as: EmbeddingClient
   alias Zaq.Ingestion.{Chunk, Document, DocumentChunker, FileExplorer}
+  alias Zaq.Ingestion.Python.Pipeline
   alias Zaq.Repo
 
   require Logger
@@ -79,12 +80,15 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   end
 
   @doc """
-  Processes a single markdown file: read -> upsert document -> chunk -> embed -> store.
+  Processes a single file: converts PDF to markdown if needed, then reads ->
+  upserts document -> chunks -> embeds -> stores.
   """
   def process_single_file(file_path, role_id \\ nil, shared_role_ids \\ []) do
     Logger.info("Processing file: #{file_path}")
 
-    with {:ok, content} <- File.read(file_path),
+    with {:ok, file_path} <- maybe_convert_pdf(file_path),
+         {:ok, raw} <- File.read(file_path),
+         content = sanitize_utf8(raw),
          {:ok, source} <- extract_source(content, file_path),
          {:ok, document} <- store_document(content, source, role_id),
          {:ok, _chunks} <-
@@ -95,6 +99,31 @@ defmodule Zaq.Ingestion.DocumentProcessor do
       {:error, reason} = error ->
         Logger.error("Failed to process #{file_path}: #{inspect(reason)}")
         error
+    end
+  end
+
+  # Strips bytes that are not part of a valid UTF-8 sequence.
+  # Needed when ingesting files produced by external tools (e.g. the Python
+  # PDF pipeline) that may emit Latin-1 or other non-UTF-8 encodings.
+  defp sanitize_utf8(binary), do: sanitize_utf8(binary, [])
+
+  defp sanitize_utf8(<<>>, acc), do: IO.iodata_to_binary(:lists.reverse(acc))
+  defp sanitize_utf8(<<c::utf8, rest::binary>>, acc), do: sanitize_utf8(rest, [<<c::utf8>> | acc])
+  defp sanitize_utf8(<<_::8, rest::binary>>, acc), do: sanitize_utf8(rest, acc)
+
+  defp maybe_convert_pdf(file_path) do
+    if Path.extname(file_path) |> String.downcase() == ".pdf" do
+      case Pipeline.run(file_path) do
+        {:ok, md_path} ->
+          Logger.info("[DocumentProcessor] PDF converted to markdown: #{md_path}")
+          {:ok, md_path}
+
+        {:error, reason} ->
+          Logger.error("[DocumentProcessor] PDF conversion failed: #{inspect(reason)}")
+          {:error, reason}
+      end
+    else
+      {:ok, file_path}
     end
   end
 

--- a/lib/zaq/ingestion/python/pipeline.ex
+++ b/lib/zaq/ingestion/python/pipeline.ex
@@ -1,0 +1,111 @@
+defmodule Zaq.Ingestion.Python.Pipeline do
+  @moduledoc """
+  Elixir orchestrator for the PDF → clean markdown pipeline.
+
+  Calls each Python step script individually so steps can be
+  conditionally skipped. Steps 4 and 5 (image descriptions) are
+  skipped when no Scaleway API key is configured.
+
+  ## Usage
+
+      Pipeline.run("/path/to/report.pdf")
+      # => {:ok, "/path/to/report.md"} | {:error, reason}
+
+  """
+
+  require Logger
+
+  alias Zaq.Ingestion.FileExplorer
+
+  alias Zaq.Ingestion.Python.Steps.{
+    CleanMd,
+    ImageDedup,
+    ImageToText,
+    InjectDescriptions,
+    PdfToMd
+  }
+
+  @doc """
+  Run the full pipeline for a single PDF.
+  Returns `{:ok, md_path}` on success.
+  """
+  @spec run(String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def run(pdf_path, opts \\ []) do
+    api_key = resolve_api_key(opts)
+    md_path = opts[:output] || Path.rootname(pdf_path) <> ".md"
+    base = FileExplorer.base_path()
+    images_dir = opts[:images_dir] || Path.join(base, "images")
+
+    pdf_name = Path.basename(pdf_path, ".pdf")
+    images_folder = Path.join(images_dir, pdf_name)
+    descriptions_json = Path.join(images_folder, "descriptions.json")
+
+    result =
+      with {:ok, _} <- PdfToMd.run(pdf_path, md_path, images_dir),
+           {:ok, _} <- ImageDedup.run(images_folder),
+           {:ok, _} <- CleanMd.run(md_path, images_folder),
+           {:ok, _} <- maybe_image_to_text(api_key, images_folder, descriptions_json),
+           {:ok, _} <- maybe_inject_descriptions(api_key, md_path, descriptions_json) do
+        {:ok, md_path}
+      end
+
+    case result do
+      {:ok, md_path} ->
+        cleanup_images(images_dir, images_folder)
+        {:ok, md_path}
+
+      {:error, reason} ->
+        move_to_debug(base, images_folder, pdf_name)
+        {:error, reason}
+    end
+  end
+
+  # --- Private ---
+
+  defp resolve_api_key(opts) do
+    key =
+      opts[:api_key] ||
+        Application.get_env(:zaq, Zaq.Ingestion.Python.ImageToText, [])[:api_key]
+
+    if key && key != "", do: key, else: nil
+  end
+
+  defp maybe_image_to_text(nil, _folder, _output) do
+    Logger.warning("[Pipeline] No Scaleway API key — skipping image descriptions")
+    {:ok, :skipped}
+  end
+
+  defp maybe_image_to_text(api_key, images_folder, descriptions_json) do
+    ImageToText.run(images_folder, descriptions_json, api_key)
+  end
+
+  defp maybe_inject_descriptions(nil, _md_path, _descriptions_json) do
+    {:ok, :skipped}
+  end
+
+  defp maybe_inject_descriptions(_api_key, md_path, descriptions_json) do
+    InjectDescriptions.run(md_path, descriptions_json)
+  end
+
+  defp cleanup_images(images_dir, images_folder) do
+    if File.dir?(images_folder) do
+      File.rm_rf!(images_folder)
+      Logger.info("[Pipeline] Cleaned up images folder: #{images_folder}")
+    end
+
+    # Remove the parent images/ dir if now empty
+    if File.dir?(images_dir) and File.ls!(images_dir) == [] do
+      File.rmdir(images_dir)
+    end
+  end
+
+  defp move_to_debug(base, images_folder, pdf_name) do
+    if File.dir?(images_folder) do
+      debug_dir = Path.join(base, "debugging")
+      debug_dest = Path.join(debug_dir, pdf_name)
+      File.mkdir_p!(debug_dir)
+      File.rename(images_folder, debug_dest)
+      Logger.warning("[Pipeline] Debug images saved to: #{debug_dest}")
+    end
+  end
+end

--- a/lib/zaq/ingestion/python/runner.ex
+++ b/lib/zaq/ingestion/python/runner.ex
@@ -1,0 +1,51 @@
+defmodule Zaq.Ingestion.Python.Runner do
+  @moduledoc """
+  Base runner for Python scripts in priv/python/crawler-ingest/.
+  Resolves paths, finds the Python executable, and executes scripts
+  via System.cmd/3.
+  """
+
+  require Logger
+
+  @scripts_dir "priv/python/crawler-ingest"
+
+  @doc """
+  Run a Python script by filename with the given args.
+
+  ## Examples
+
+      Runner.run("pipeline.py", ["report.pdf", "--quiet"])
+      # => {:ok, "..."} | {:error, %{exit_code: code, output: output}}
+
+  """
+  @spec run(String.t(), [String.t()]) :: {:ok, String.t()} | {:error, term()}
+  def run(script_name, args \\ []) do
+    script_path = scripts_dir() |> Path.join(script_name)
+    python = python_executable()
+
+    Logger.debug("[Python.Runner] #{python} #{script_path} #{Enum.join(args, " ")}")
+
+    case System.cmd(python, [script_path | args], stderr_to_stdout: true) do
+      {output, 0} ->
+        {:ok, String.trim(output)}
+
+      {output, code} ->
+        Logger.error("[Python.Runner] Script failed (exit #{code}): #{output}")
+        {:error, %{exit_code: code, output: output}}
+    end
+  end
+
+  @doc "Absolute path to the scripts directory"
+  def scripts_dir do
+    case :code.priv_dir(:zaq) do
+      {:error, _} -> Path.join(File.cwd!(), @scripts_dir)
+      priv -> Path.join(to_string(priv), "python/crawler-ingest")
+    end
+  end
+
+  @doc "Resolve the Python executable (venv > system)"
+  def python_executable do
+    venv = Path.join(File.cwd!(), ".venv/bin/python3")
+    if File.exists?(venv), do: venv, else: "python3"
+  end
+end

--- a/lib/zaq/ingestion/python/steps/clean_md.ex
+++ b/lib/zaq/ingestion/python/steps/clean_md.ex
@@ -1,0 +1,15 @@
+defmodule Zaq.Ingestion.Python.Steps.CleanMd do
+  @moduledoc false
+
+  alias Zaq.Ingestion.Python.Runner
+
+  def run(md_path, images_folder) do
+    mapping = Path.join(images_folder, "duplicate_mapping.txt")
+
+    if File.exists?(mapping) do
+      Runner.run("clean_md.py", [md_path, "--mapping", mapping])
+    else
+      {:ok, :skipped}
+    end
+  end
+end

--- a/lib/zaq/ingestion/python/steps/image_dedup.ex
+++ b/lib/zaq/ingestion/python/steps/image_dedup.ex
@@ -1,0 +1,11 @@
+defmodule Zaq.Ingestion.Python.Steps.ImageDedup do
+  @moduledoc false
+
+  alias Zaq.Ingestion.Python.Runner
+
+  def run(images_folder, opts \\ []) do
+    args = [images_folder, "--delete"]
+    args = if v = opts[:threshold], do: args ++ ["--threshold", "#{v}"], else: args
+    Runner.run("image_dedup.py", args)
+  end
+end

--- a/lib/zaq/ingestion/python/steps/image_to_text.ex
+++ b/lib/zaq/ingestion/python/steps/image_to_text.ex
@@ -1,0 +1,16 @@
+defmodule Zaq.Ingestion.Python.Steps.ImageToText do
+  @moduledoc false
+
+  alias Zaq.Ingestion.Python.Runner
+
+  def run(images_folder, output_json, api_key) do
+    Runner.run("image_to_text.py", [
+      "--folder",
+      images_folder,
+      "--output",
+      output_json,
+      "--api-key",
+      api_key
+    ])
+  end
+end

--- a/lib/zaq/ingestion/python/steps/inject_descriptions.ex
+++ b/lib/zaq/ingestion/python/steps/inject_descriptions.ex
@@ -1,0 +1,11 @@
+defmodule Zaq.Ingestion.Python.Steps.InjectDescriptions do
+  @moduledoc false
+
+  alias Zaq.Ingestion.Python.Runner
+
+  def run(md_path, descriptions_json, opts \\ []) do
+    args = [md_path, "--descriptions", descriptions_json]
+    args = if v = opts[:format], do: args ++ ["--format", "#{v}"], else: args
+    Runner.run("inject_descriptions.py", args)
+  end
+end

--- a/lib/zaq/ingestion/python/steps/pdf_to_md.ex
+++ b/lib/zaq/ingestion/python/steps/pdf_to_md.ex
@@ -1,0 +1,15 @@
+defmodule Zaq.Ingestion.Python.Steps.PdfToMd do
+  @moduledoc false
+
+  alias Zaq.Ingestion.Python.Runner
+
+  def run(pdf_path, output_md, images_dir) do
+    Runner.run("pdf_to_md.py", [
+      pdf_path,
+      output_md,
+      "--with-images",
+      "--images-dir",
+      images_dir
+    ])
+  end
+end

--- a/lib/zaq_web/components/bo_layout.ex
+++ b/lib/zaq_web/components/bo_layout.ex
@@ -776,4 +776,41 @@ defmodule ZaqWeb.Components.BOLayout do
     </div>
     """
   end
+
+  attr :label, :string, required: true
+  attr :status, :any, default: nil
+  attr :event, :string, default: nil
+  attr :button_label, :string, default: "Test Connection"
+  slot :inner_block, required: true
+  slot :footer_extra
+
+  def diagnostic_card(assigns) do
+    ~H"""
+    <div class="bg-white rounded-xl border border-black/10 p-5 flex flex-col">
+      <div class="flex items-center justify-between mb-4">
+        <p class="font-mono text-[0.7rem] text-black/40 uppercase tracking-wider">{@label}</p>
+        <.status_badge :if={@status != nil} status={@status} />
+      </div>
+      <div class="space-y-2 mb-4">
+        {render_slot(@inner_block)}
+      </div>
+      <div :if={@event} class="mt-auto border-t border-black/5 pt-3">
+        <button
+          phx-click={@event}
+          disabled={@status == :loading}
+          class="w-full font-mono text-[0.75rem] font-bold px-4 py-2 rounded-lg bg-[#3c4b64] text-white hover:bg-[#3c4b64]/80 disabled:opacity-40 transition-colors"
+        >
+          {if @status == :loading, do: "Testing…", else: @button_label}
+        </button>
+        <p
+          :if={is_tuple(@status) and elem(@status, 0) == :error}
+          class="font-mono text-[0.7rem] text-red-500 mt-2 break-all"
+        >
+          {elem(@status, 1)}
+        </p>
+        {render_slot(@footer_extra)}
+      </div>
+    </div>
+    """
+  end
 end

--- a/lib/zaq_web/live/bo/ai/ai_diagnostics_live.ex
+++ b/lib/zaq_web/live/bo/ai/ai_diagnostics_live.ex
@@ -4,6 +4,7 @@ defmodule ZaqWeb.Live.BO.AI.AIDiagnosticsLive do
   alias Zaq.Agent.{LLM, PromptTemplate, TokenEstimator}
   alias Zaq.Embedding.Client, as: EmbeddingClient
   alias Zaq.Ingestion.{Chunk, Document}
+  alias Zaq.Ingestion.Python.Runner
 
   @modules [
     # Phase 1
@@ -84,8 +85,10 @@ defmodule ZaqWeb.Live.BO.AI.AIDiagnosticsLive do
        llm_config: load_llm_config(),
        embedding_config: load_embedding_config(),
        ingestion_config: load_ingestion_config(),
+       image_to_text_config: load_image_to_text_config(),
        llm_status: :idle,
        embedding_status: :idle,
+       pdf_pipeline_status: :idle,
        token_test_result: nil,
        prompt_templates: load_prompt_templates(),
        document_count: document_count(),
@@ -144,6 +147,30 @@ defmodule ZaqWeb.Live.BO.AI.AIDiagnosticsLive do
     {:noreply, assign(socket, token_test_result: result)}
   end
 
+  def handle_event("test_pdf_pipeline", _params, socket) do
+    socket = assign(socket, pdf_pipeline_status: :loading)
+
+    status =
+      try do
+        scripts_dir = Runner.scripts_dir()
+
+        if File.dir?(scripts_dir) do
+          python = Runner.python_executable()
+
+          case System.cmd(python, ["--version"], stderr_to_stdout: true) do
+            {_output, 0} -> :ok
+            {output, _} -> {:error, "Python unavailable: #{String.trim(output)}"}
+          end
+        else
+          {:error, "Scripts not found. Run: mix zaq.python.fetch"}
+        end
+      rescue
+        e -> {:error, Exception.message(e)}
+      end
+
+    {:noreply, assign(socket, pdf_pipeline_status: status)}
+  end
+
   # --- Private helpers ---
 
   defp load_llm_config do
@@ -176,6 +203,16 @@ defmodule ZaqWeb.Live.BO.AI.AIDiagnosticsLive do
       hybrid_search_limit: cfg[:hybrid_search_limit] || 20,
       chunk_min_tokens: cfg[:chunk_min_tokens] || 400,
       chunk_max_tokens: cfg[:chunk_max_tokens] || 900
+    }
+  end
+
+  defp load_image_to_text_config do
+    cfg = Application.get_env(:zaq, Zaq.Ingestion.Python.ImageToText, [])
+
+    %{
+      api_url: cfg[:api_url] || "not set",
+      model: cfg[:model] || "not set",
+      api_key_set: cfg[:api_key] not in [nil, ""]
     }
   end
 

--- a/lib/zaq_web/live/bo/ai/ai_diagnostics_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/ai_diagnostics_live.html.heex
@@ -19,161 +19,155 @@
     </div>
     <div class="bg-white rounded-xl border border-black/10 p-5">
       <p class="font-mono text-[0.65rem] text-black/40 uppercase tracking-wider mb-1">
-        Documents
+        PDF Pipeline Model
+      </p>
+      <p class="font-mono text-sm font-bold text-black truncate">{@image_to_text_config.model}</p>
+    </div>
+    <div class="bg-white rounded-xl border border-black/10 p-5">
+      <p class="font-mono text-[0.65rem] text-black/40 uppercase tracking-wider mb-1">
+        Knowledge Base
       </p>
       <p class="font-mono text-2xl font-bold text-black">
         {if @document_count, do: @document_count, else: "—"}
+        <span class="font-mono text-[0.65rem] text-black/40 font-normal">docs</span>
       </p>
-    </div>
-    <div class="bg-white rounded-xl border border-black/10 p-5">
-      <p class="font-mono text-[0.65rem] text-black/40 uppercase tracking-wider mb-1">Chunks</p>
-      <p class="font-mono text-2xl font-bold text-black">
+      <p class="font-mono text-sm font-bold text-black/60 mt-1">
         {if @chunk_count, do: @chunk_count, else: "—"}
+        <span class="font-mono text-[0.65rem] text-black/40 font-normal">chunks</span>
       </p>
     </div>
   </div>
 
-  <div class="grid grid-cols-3 gap-6">
-    <!-- LLM Config -->
-    <div class="bg-white rounded-xl border border-black/10 p-5 flex flex-col">
-      <div class="flex items-center justify-between mb-4">
-        <p class="font-mono text-[0.7rem] text-black/40 uppercase tracking-wider">LLM</p>
-        <ZaqWeb.Components.BOLayout.status_badge status={@llm_status} />
-      </div>
-      <div class="space-y-2 mb-4">
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Endpoint"
-          value={@llm_config.endpoint}
-          truncate
-          hint="LLM_ENDPOINT"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Model"
-          value={@llm_config.model}
-          hint="LLM_MODEL"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Temperature"
-          value={to_string(@llm_config.temperature)}
-          hint="config/runtime.exs"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Top-p"
-          value={to_string(@llm_config.top_p)}
-          hint="config/runtime.exs"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Logprobs"
-          value={if @llm_config.supports_logprobs, do: "yes", else: "no"}
-          hint="config/runtime.exs"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="JSON Mode"
-          value={if @llm_config.supports_json_mode, do: "yes", else: "no"}
-          hint="config/runtime.exs"
-        />
-      </div>
-      <div class="mt-auto">
-        <button
-          phx-click="test_llm"
-          disabled={@llm_status == :loading}
-          class="w-full font-mono text-[0.75rem] font-bold px-4 py-2 rounded-lg bg-[#3c4b64] text-white hover:bg-[#3c4b64]/80 disabled:opacity-40 transition-colors"
-        >
-          {if @llm_status == :loading, do: "Testing…", else: "Test Connection"}
-        </button>
-        <%= if is_tuple(@llm_status) and elem(@llm_status, 0) == :error do %>
-          <p class="font-mono text-[0.7rem] text-red-500 mt-2 break-all">
-            {elem(@llm_status, 1)}
-          </p>
-        <% end %>
-      </div>
-    </div>
+  <div class="grid grid-cols-4 gap-6">
+    <!-- LLM -->
+    <ZaqWeb.Components.BOLayout.diagnostic_card
+      label="LLM"
+      status={@llm_status}
+      event="test_llm"
+    >
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Endpoint"
+        value={@llm_config.endpoint}
+        truncate
+        hint="LLM_ENDPOINT"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Model"
+        value={@llm_config.model}
+        hint="LLM_MODEL"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Temperature"
+        value={to_string(@llm_config.temperature)}
+        hint="config/runtime.exs"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Top-p"
+        value={to_string(@llm_config.top_p)}
+        hint="config/runtime.exs"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Logprobs"
+        value={if @llm_config.supports_logprobs, do: "yes", else: "no"}
+        hint="config/runtime.exs"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="JSON Mode"
+        value={if @llm_config.supports_json_mode, do: "yes", else: "no"}
+        hint="config/runtime.exs"
+      />
+    </ZaqWeb.Components.BOLayout.diagnostic_card>
     
-<!-- Embedding Config -->
-    <div class="bg-white rounded-xl border border-black/10 p-5 flex flex-col">
-      <div class="flex items-center justify-between mb-4">
-        <p class="font-mono text-[0.7rem] text-black/40 uppercase tracking-wider">Embedding</p>
-        <ZaqWeb.Components.BOLayout.status_badge status={@embedding_status} />
-      </div>
-      <div class="space-y-2 mb-4">
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Endpoint"
-          value={@embedding_config.endpoint}
-          truncate
-          hint="EMBEDDING_ENDPOINT"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Model"
-          value={@embedding_config.model}
-          hint="EMBEDDING_MODEL"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Dimension"
-          value={to_string(@embedding_config.dimension)}
-          hint="EMBEDDING_DIMENSION"
-        />
-      </div>
-      <div class="mt-auto">
-        <button
-          phx-click="test_embedding"
-          disabled={@embedding_status == :loading}
-          class="w-full font-mono text-[0.75rem] font-bold px-4 py-2 rounded-lg bg-[#3c4b64] text-white hover:bg-[#3c4b64]/80 disabled:opacity-40 transition-colors"
-        >
-          {if @embedding_status == :loading, do: "Testing…", else: "Test Connection"}
-        </button>
-        <%= if is_tuple(@embedding_status) and elem(@embedding_status, 0) == :error do %>
-          <p class="font-mono text-[0.7rem] text-red-500 mt-2 break-all">
-            {elem(@embedding_status, 1)}
-          </p>
-        <% end %>
-      </div>
-    </div>
+<!-- Embedding -->
+    <ZaqWeb.Components.BOLayout.diagnostic_card
+      label="Embedding"
+      status={@embedding_status}
+      event="test_embedding"
+    >
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Endpoint"
+        value={@embedding_config.endpoint}
+        truncate
+        hint="EMBEDDING_ENDPOINT"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Model"
+        value={@embedding_config.model}
+        hint="EMBEDDING_MODEL"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Dimension"
+        value={to_string(@embedding_config.dimension)}
+        hint="EMBEDDING_DIMENSION"
+      />
+    </ZaqWeb.Components.BOLayout.diagnostic_card>
     
-<!-- Ingestion Config -->
-    <div class="bg-white rounded-xl border border-black/10 p-5 flex flex-col">
-      <p class="font-mono text-[0.7rem] text-black/40 uppercase tracking-wider mb-4">Ingestion</p>
-      <div class="space-y-2 mb-4">
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Max Context"
-          value={"#{@ingestion_config.max_context_window} tokens"}
-          hint="config/runtime.exs"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Distance Threshold"
-          value={to_string(@ingestion_config.distance_threshold)}
-          hint="config/runtime.exs"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Hybrid Search Limit"
-          value={to_string(@ingestion_config.hybrid_search_limit)}
-          hint="config/runtime.exs"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Chunk Min Tokens"
-          value={to_string(@ingestion_config.chunk_min_tokens)}
-          hint="config/runtime.exs"
-        />
-        <ZaqWeb.Components.BOLayout.config_row
-          label="Chunk Max Tokens"
-          value={to_string(@ingestion_config.chunk_max_tokens)}
-          hint="config/runtime.exs"
-        />
-      </div>
-      <div class="mt-auto border-t border-black/5 pt-3">
-        <button
-          phx-click="test_token_estimator"
-          class="w-full font-mono text-[0.75rem] font-bold px-4 py-2 rounded-lg bg-[#3c4b64] text-white hover:bg-[#3c4b64]/80 transition-colors"
-        >
-          Test TokenEstimator
-        </button>
-        <%= if @token_test_result do %>
-          <p class="font-mono text-[0.7rem] text-black/50 mt-2 text-center">
-            "The quick brown fox…" →
-            <span class="text-black font-bold">{@token_test_result} tokens</span>
-          </p>
-        <% end %>
-      </div>
-    </div>
+<!-- Ingestion -->
+    <ZaqWeb.Components.BOLayout.diagnostic_card
+      label="Ingestion"
+      event="test_token_estimator"
+      button_label="Test TokenEstimator"
+    >
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Max Context"
+        value={"#{@ingestion_config.max_context_window} tokens"}
+        hint="config/runtime.exs"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Distance Threshold"
+        value={to_string(@ingestion_config.distance_threshold)}
+        hint="config/runtime.exs"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Hybrid Search Limit"
+        value={to_string(@ingestion_config.hybrid_search_limit)}
+        hint="config/runtime.exs"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Chunk Min Tokens"
+        value={to_string(@ingestion_config.chunk_min_tokens)}
+        hint="config/runtime.exs"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Chunk Max Tokens"
+        value={to_string(@ingestion_config.chunk_max_tokens)}
+        hint="config/runtime.exs"
+      />
+      <:footer_extra>
+        <p :if={@token_test_result} class="font-mono text-[0.7rem] text-black/50 mt-2 text-center">
+          "The quick brown fox…" →
+          <span class="text-black font-bold">{@token_test_result} tokens</span>
+        </p>
+      </:footer_extra>
+    </ZaqWeb.Components.BOLayout.diagnostic_card>
+    
+<!-- PDF Pipeline -->
+    <ZaqWeb.Components.BOLayout.diagnostic_card
+      label="PDF Pipeline"
+      status={@pdf_pipeline_status}
+      event="test_pdf_pipeline"
+    >
+      <ZaqWeb.Components.BOLayout.config_row
+        label="API URL"
+        value={@image_to_text_config.api_url}
+        truncate
+        hint="SCALEWAY_API_URL"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="Model"
+        value={@image_to_text_config.model}
+        hint="SCALEWAY_MODEL"
+      />
+      <ZaqWeb.Components.BOLayout.config_row
+        label="API Key"
+        value={
+          if @image_to_text_config.api_key_set,
+            do: "configured",
+            else: "not set — image steps skipped"
+        }
+        hint="SCALEWAY_API_KEY"
+      />
+    </ZaqWeb.Components.BOLayout.diagnostic_card>
   </div>
   
 <!-- Prompt Templates Summary -->

--- a/mix.exs
+++ b/mix.exs
@@ -107,7 +107,7 @@ defmodule Zaq.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
+      setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build", "zaq.python.fetch"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],

--- a/test/zaq/ingestion/python/pipeline_test.exs
+++ b/test/zaq/ingestion/python/pipeline_test.exs
@@ -1,0 +1,118 @@
+defmodule Zaq.Ingestion.Python.PipelineTest do
+  use ExUnit.Case, async: false
+
+  alias Zaq.Ingestion.Python.Pipeline
+
+  # ---------------------------------------------------------------------------
+  # Shared setup: capture original config and restore on exit
+  # ---------------------------------------------------------------------------
+
+  setup do
+    original_image_to_text = Application.get_env(:zaq, Zaq.Ingestion.Python.ImageToText)
+
+    on_exit(fn ->
+      if is_nil(original_image_to_text) do
+        Application.delete_env(:zaq, Zaq.Ingestion.Python.ImageToText)
+      else
+        Application.put_env(:zaq, Zaq.Ingestion.Python.ImageToText, original_image_to_text)
+      end
+    end)
+
+    # Build a temporary directory acting as the PDF's parent dir.
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "zaq_pipeline_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  # ---------------------------------------------------------------------------
+  # resolve_api_key — tested indirectly through run/1
+  # ---------------------------------------------------------------------------
+
+  describe "resolve_api_key via run/1" do
+    test "opts :api_key takes precedence over Application env" do
+      # We cannot easily assert on the internal key; instead we assert that
+      # Pipeline.run/1 passes the key through by checking it invokes
+      # ImageToText.run when an api_key is supplied.  Because the actual
+      # Python scripts are absent in CI we just verify the function returns
+      # an error tuple (not a crash / bad match) when scripts are missing.
+      Application.delete_env(:zaq, Zaq.Ingestion.Python.ImageToText)
+
+      result = Pipeline.run("/nonexistent/report.pdf", api_key: "inline-key")
+      assert match?({:error, _}, result)
+    end
+
+    test "falls back to Application env api_key when not in opts" do
+      Application.put_env(:zaq, Zaq.Ingestion.Python.ImageToText, api_key: "env-key")
+
+      result = Pipeline.run("/nonexistent/report.pdf")
+      assert match?({:error, _}, result)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # step skipping — no api_key
+  # ---------------------------------------------------------------------------
+
+  describe "run/1 without api_key" do
+    test "returns error from first failing step (no api_key, scripts absent)" do
+      Application.delete_env(:zaq, Zaq.Ingestion.Python.ImageToText)
+
+      # Step 1 (PdfToMd) will fail because the PDF and script don't exist.
+      # Steps 4 & 5 are unreachable, so no api_key error is the relevant path.
+      result = Pipeline.run("/tmp/nonexistent_#{System.unique_integer()}.pdf")
+      assert match?({:error, _}, result)
+    end
+
+    test "nil and empty-string api_key both skip image steps" do
+      # Both must produce the same code path (step 1 fails, not an api_key error)
+      Application.put_env(:zaq, Zaq.Ingestion.Python.ImageToText, api_key: nil)
+      result_nil = Pipeline.run("/tmp/no_key_nil_#{System.unique_integer()}.pdf")
+
+      Application.put_env(:zaq, Zaq.Ingestion.Python.ImageToText, api_key: "")
+      result_empty = Pipeline.run("/tmp/no_key_empty_#{System.unique_integer()}.pdf")
+
+      # Both paths should fail at step 1 (PdfToMd), not at image_to_text
+      assert match?({:error, _}, result_nil)
+      assert match?({:error, _}, result_empty)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # output path derivation
+  # ---------------------------------------------------------------------------
+
+  describe "output md_path" do
+    test "defaults to pdf basename with .md extension" do
+      # We cannot inspect the private md_path directly, so we test indirectly:
+      # PdfToMd.run receives the derived md_path as its second arg and will
+      # fail with an :error map containing the script invocation info.
+      # The simplest assertion is that run/1 returns an error and does not crash.
+      Application.delete_env(:zaq, Zaq.Ingestion.Python.ImageToText)
+      assert match?({:error, _}, Pipeline.run("/tmp/report.pdf"))
+    end
+
+    test "honours opts :output for custom md_path" do
+      Application.delete_env(:zaq, Zaq.Ingestion.Python.ImageToText)
+      custom_out = "/tmp/custom_out_#{System.unique_integer()}.md"
+      assert match?({:error, _}, Pipeline.run("/tmp/report.pdf", output: custom_out))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Integration smoke-test using a real (trivial) markdown file
+  # When Python scripts are present the full pipeline would run. Here we only
+  # assert the public contract when scripts are absent.
+  # ---------------------------------------------------------------------------
+
+  describe "run/1 return shape" do
+    test "always returns a two-element tagged tuple" do
+      Application.delete_env(:zaq, Zaq.Ingestion.Python.ImageToText)
+      result = Pipeline.run("/tmp/missing_#{System.unique_integer()}.pdf")
+      assert match?({:ok, _}, result) or match?({:error, _}, result)
+    end
+  end
+end

--- a/test/zaq/ingestion/python/runner_test.exs
+++ b/test/zaq/ingestion/python/runner_test.exs
@@ -1,0 +1,121 @@
+defmodule Zaq.Ingestion.Python.RunnerTest do
+  use ExUnit.Case, async: true
+
+  alias Zaq.Ingestion.Python.Runner
+
+  # ---------------------------------------------------------------------------
+  # scripts_dir/0
+  # ---------------------------------------------------------------------------
+
+  describe "scripts_dir/0" do
+    test "returns a string" do
+      assert is_binary(Runner.scripts_dir())
+    end
+
+    test "path ends with python/crawler-ingest" do
+      assert String.ends_with?(Runner.scripts_dir(), "python/crawler-ingest")
+    end
+
+    test "returns an absolute path" do
+      assert Path.type(Runner.scripts_dir()) == :absolute
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # python_executable/0
+  # ---------------------------------------------------------------------------
+
+  describe "python_executable/0" do
+    test "returns a string" do
+      assert is_binary(Runner.python_executable())
+    end
+
+    test "returns venv python when venv exists" do
+      venv_python = Path.join(File.cwd!(), ".venv/bin/python3")
+
+      if File.exists?(venv_python) do
+        assert Runner.python_executable() == venv_python
+      else
+        assert Runner.python_executable() == "python3"
+      end
+    end
+
+    test "falls back to system python3 when no venv present" do
+      venv_python = Path.join(File.cwd!(), ".venv/bin/python3")
+
+      unless File.exists?(venv_python) do
+        assert Runner.python_executable() == "python3"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # run/2 — tested by exercising real system commands via a temp wrapper script
+  # ---------------------------------------------------------------------------
+
+  describe "run/2" do
+    setup do
+      # Create a temporary scripts dir with a trivial echo script so we can
+      # exercise Runner.run/2 without needing the real Python pipeline.
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "zaq_runner_test_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      {:ok, tmp_dir: tmp_dir}
+    end
+
+    test "returns {:ok, stdout} when the command exits 0", %{tmp_dir: tmp_dir} do
+      # Write a tiny shell script that exits 0 with known output.
+      script = Path.join(tmp_dir, "success.sh")
+      File.write!(script, "#!/bin/sh\necho hello")
+      File.chmod!(script, 0o755)
+
+      # Run shell directly (bypassing Runner.scripts_dir) to verify the
+      # {:ok, stdout} shape.
+      assert {:ok, "hello"} = run_shell_script(script, [])
+    end
+
+    test "returns {:error, map} when the command exits non-zero", %{tmp_dir: tmp_dir} do
+      script = Path.join(tmp_dir, "failure.sh")
+      File.write!(script, "#!/bin/sh\necho oops\nexit 42")
+      File.chmod!(script, 0o755)
+
+      assert {:error, %{exit_code: 42, output: output}} = run_shell_script(script, [])
+      assert String.contains?(output, "oops")
+    end
+
+    test "passes args to the script", %{tmp_dir: tmp_dir} do
+      script = Path.join(tmp_dir, "echo_args.sh")
+      File.write!(script, "#!/bin/sh\necho \"$1 $2\"")
+      File.chmod!(script, 0o755)
+
+      assert {:ok, "foo bar"} = run_shell_script(script, ["foo", "bar"])
+    end
+
+    test "trims trailing whitespace from stdout on success", %{tmp_dir: tmp_dir} do
+      script = Path.join(tmp_dir, "trailing.sh")
+      File.write!(script, "#!/bin/sh\nprintf 'result   \\n\\n'")
+      File.chmod!(script, 0o755)
+
+      assert {:ok, stdout} = run_shell_script(script, [])
+      refute String.ends_with?(stdout, " ")
+      refute String.ends_with?(stdout, "\n")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Exercises the same System.cmd logic as Runner.run/2 but with an arbitrary
+  # executable so tests are hermetic (no real Python scripts required).
+  defp run_shell_script(script_path, args) do
+    case System.cmd("sh", [script_path | args], stderr_to_stdout: false) do
+      {stdout, 0} -> {:ok, String.trim(stdout)}
+      {stdout, code} -> {:error, %{exit_code: code, output: stdout}}
+    end
+  end
+end

--- a/test/zaq/ingestion/python/steps/image_to_text_test.exs
+++ b/test/zaq/ingestion/python/steps/image_to_text_test.exs
@@ -1,0 +1,32 @@
+defmodule Zaq.Ingestion.Python.Steps.ImageToTextTest do
+  use ExUnit.Case, async: true
+
+  alias Zaq.Ingestion.Python.Steps.ImageToText
+
+  # ---------------------------------------------------------------------------
+  # run/3 — delegates to Runner.run/2 with flag-style args
+  # ---------------------------------------------------------------------------
+
+  describe "run/3" do
+    test "returns {:error, _} when script is absent (no real Python env)" do
+      result = ImageToText.run("/tmp/images", "/tmp/descriptions.json", "test-api-key")
+      assert match?({:error, _}, result)
+    end
+
+    test "returns a two-element tagged tuple" do
+      result =
+        ImageToText.run(
+          "/tmp/nonexistent_images",
+          "/tmp/nonexistent_descriptions.json",
+          "some-key"
+        )
+
+      assert match?({:ok, _}, result) or match?({:error, _}, result)
+    end
+
+    test "does not raise for any string arguments" do
+      result = ImageToText.run("", "", "")
+      assert elem(result, 0) in [:ok, :error]
+    end
+  end
+end

--- a/test/zaq/ingestion/python/steps/pdf_to_md_test.exs
+++ b/test/zaq/ingestion/python/steps/pdf_to_md_test.exs
@@ -1,0 +1,28 @@
+defmodule Zaq.Ingestion.Python.Steps.PdfToMdTest do
+  use ExUnit.Case, async: true
+
+  alias Zaq.Ingestion.Python.Steps.PdfToMd
+
+  # ---------------------------------------------------------------------------
+  # run/3 — delegates to Runner.run/2 with the correct script name + args
+  # ---------------------------------------------------------------------------
+
+  describe "run/3" do
+    test "returns {:error, _} when script is absent (no real Python env)" do
+      # In CI there are no Python scripts so any call must return an error.
+      result = PdfToMd.run("/tmp/report.pdf", "/tmp/report.md", "./images")
+      assert match?({:error, _}, result)
+    end
+
+    test "returns a two-element tagged tuple" do
+      result = PdfToMd.run("/tmp/nonexistent.pdf", "/tmp/nonexistent.md", "/tmp/images")
+      assert match?({:ok, _}, result) or match?({:error, _}, result)
+    end
+
+    test "does not raise on missing file paths" do
+      # run/3 must return a tagged tuple, never raise, even for absent paths.
+      result = PdfToMd.run("/does/not/exist.pdf", "/does/not/exist.md", "/images")
+      assert elem(result, 0) in [:ok, :error]
+    end
+  end
+end


### PR DESCRIPTION
When a PDF is ingested, DocumentProcessor now transparently converts it to clean markdown (with optional image descriptions) before chunking and embedding. The Python pipeline is orchestrated from Elixir — each step script (pdf_to_md, image_dedup, clean_md, image_to_text, inject_descriptions) is called individually so steps 4-5 are skipped when no Scaleway API key is configured.

- Add Zaq.Ingestion.Python.Runner — System.cmd wrapper, venv-aware
- Add Zaq.Ingestion.Python.Pipeline — Elixir orchestrator
- Add step modules: PdfToMd, ImageDedup, CleanMd, ImageToText, InjectDescriptions
- Hook maybe_convert_pdf/1 into DocumentProcessor.process_single_file/3
- Add Zaq.Ingestion.Python.ImageToText config (SCALEWAY_API_URL/MODEL/KEY)
- Add unit tests for Runner, Pipeline, and step modules

Closes #18 #28 