### PR TITLE
feat(ingestion): role-based file access control with public sharing

### DIFF
--- a/lib/zaq/ingestion/document.ex
+++ b/lib/zaq/ingestion/document.ex
@@ -22,6 +22,7 @@ defmodule Zaq.Ingestion.Document do
     field :content, :string
     field :content_type, :string, default: "markdown"
     field :metadata, :map, default: %{}
+    field :shared_role_ids, {:array, :integer}, default: []
     belongs_to :role, Role
 
     has_many :chunks, Chunk
@@ -29,8 +30,8 @@ defmodule Zaq.Ingestion.Document do
     timestamps(type: :utc_datetime)
   end
 
-  @required_fields ~w(source content)a
-  @optional_fields ~w(title content_type metadata role_id)a
+  @required_fields ~w(source)a
+  @optional_fields ~w(title content content_type metadata role_id shared_role_ids)a
 
   def changeset(document, attrs) do
     document
@@ -62,7 +63,8 @@ defmodule Zaq.Ingestion.Document do
     |> changeset(attrs)
     |> Repo.insert(
       on_conflict:
-        {:replace, [:content, :title, :content_type, :metadata, :role_id, :updated_at]},
+        {:replace,
+         [:content, :title, :content_type, :metadata, :role_id, :shared_role_ids, :updated_at]},
       conflict_target: :source
     )
   end
@@ -97,6 +99,15 @@ defmodule Zaq.Ingestion.Document do
   """
   def delete(%__MODULE__{} = document) do
     Repo.delete(document)
+  end
+
+  @doc """
+  Updates only the shared_role_ids on an existing document without touching any other field.
+  """
+  def set_shared_role_ids(%__MODULE__{} = document, shared_role_ids) do
+    document
+    |> changeset(%{shared_role_ids: shared_role_ids})
+    |> Repo.update()
   end
 
   # -- Private --

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -59,17 +59,68 @@ defmodule Zaq.Ingestion do
     end
   end
 
+  # --- Access control ---
+
+  @doc """
+  Returns true if the given user can access a file at `relative_path`.
+  - Super admins bypass all checks.
+  - Files with no Document record are accessible to all (backward compat).
+  - Files shared with the "public" role are accessible to all.
+  - Otherwise: only the owning role (doc.role_id) or explicitly shared roles.
+  """
+  def can_access_file?(relative_path, current_user) do
+    source = normalize_source(relative_path)
+
+    case Document.get_by_source(source) do
+      nil ->
+        true
+
+      doc ->
+        super_admin? = current_user.role.name == "super_admin"
+        shared = doc.shared_role_ids
+        public? = public_role_id() in shared
+
+        super_admin? or
+          public? or
+          is_nil(doc.role_id) or
+          doc.role_id == current_user.role_id or
+          current_user.role_id in shared
+    end
+  end
+
+  defp public_role_id do
+    case Zaq.Accounts.get_role_by_name("public") do
+      nil -> nil
+      role -> role.id
+    end
+  end
+
+  # --- Upload tracking ---
+
+  @doc """
+  Records a newly uploaded file in the documents table with the uploader's role_id.
+  This is called immediately at upload time — before any ingestion happens — so that
+  the file browser can enforce role-based visibility right away.
+  """
+  def track_upload(path, role_id) do
+    source = normalize_source(path)
+    Document.upsert(%{source: source, role_id: role_id})
+  end
+
+  defp normalize_source("./" <> rest), do: rest
+  defp normalize_source(path), do: path
+
   # --- Sharing ---
 
   def share_file(source, shared_role_ids) do
-    case Document.get_by_source(source) do
-      nil ->
-        {:error, :not_found}
+    doc =
+      case Document.get_by_source(source) do
+        nil -> elem(Document.create(%{source: source, shared_role_ids: shared_role_ids}), 1)
+        doc -> elem(Document.set_shared_role_ids(doc, shared_role_ids), 1)
+      end
 
-      doc ->
-        Chunk.update_shared_role_ids_for_document(doc.id, shared_role_ids)
-        {:ok, shared_role_ids}
-    end
+    Chunk.update_shared_role_ids_for_document(doc.id, shared_role_ids)
+    {:ok, shared_role_ids}
   end
 
   # --- Job queries ---

--- a/lib/zaq_web/controllers/file_controller.ex
+++ b/lib/zaq_web/controllers/file_controller.ex
@@ -3,6 +3,7 @@
 defmodule ZaqWeb.FileController do
   use ZaqWeb, :controller
 
+  alias Zaq.Ingestion
   alias Zaq.Ingestion.FileExplorer
 
   @mime_types %{
@@ -24,33 +25,36 @@ defmodule ZaqWeb.FileController do
   def show(conn, %{"path" => path_segments}) do
     relative_path = Path.join(path_segments)
 
-    with {:ok, full_path} <- FileExplorer.resolve_path(relative_path),
-         {:ok, stat} <- File.stat(full_path),
-         false <- stat.type == :directory,
-         {:ok, content} <- File.read(full_path) do
-      ext = full_path |> Path.extname() |> String.downcase()
-      content_type = Map.get(@mime_types, ext, "application/octet-stream")
+    if Ingestion.can_access_file?(relative_path, conn.assigns.current_user) do
+      with {:ok, full_path} <- FileExplorer.resolve_path(relative_path),
+           {:ok, stat} <- File.stat(full_path),
+           false <- stat.type == :directory,
+           {:ok, content} <- File.read(full_path) do
+        ext = full_path |> Path.extname() |> String.downcase()
+        content_type = Map.get(@mime_types, ext, "application/octet-stream")
 
-      conn
-      |> put_resp_content_type(content_type)
-      |> put_resp_header(
-        "content-disposition",
-        ~s(inline; filename="#{Path.basename(full_path)}")
-      )
-      |> send_resp(200, content)
+        conn
+        |> put_resp_content_type(content_type)
+        |> put_resp_header(
+          "content-disposition",
+          ~s(inline; filename="#{Path.basename(full_path)}")
+        )
+        |> send_resp(200, content)
+      else
+        {:error, :path_traversal} ->
+          conn |> put_status(:forbidden) |> text("Forbidden")
+
+        {:error, :enoent} ->
+          conn |> put_status(:not_found) |> text("File not found")
+
+        true ->
+          conn |> put_status(:bad_request) |> text("Not a file")
+
+        _ ->
+          conn |> put_status(:internal_server_error) |> text("Could not read file")
+      end
     else
-      {:error, :path_traversal} ->
-        conn |> put_status(:forbidden) |> text("Forbidden")
-
-      {:error, :enoent} ->
-        conn |> put_status(:not_found) |> text("File not found")
-
-      true ->
-        # path is a directory
-        conn |> put_status(:bad_request) |> text("Not a file")
-
-      _ ->
-        conn |> put_status(:internal_server_error) |> text("Could not read file")
+      conn |> put_status(:forbidden) |> text("Access denied")
     end
   end
 end

--- a/lib/zaq_web/live/bo/ai/file_preview_live.ex
+++ b/lib/zaq_web/live/bo/ai/file_preview_live.ex
@@ -3,6 +3,7 @@
 defmodule ZaqWeb.Live.BO.AI.FilePreviewLive do
   use ZaqWeb, :live_view
 
+  alias Zaq.Ingestion
   alias Zaq.Ingestion.FileExplorer
   alias Zaq.Ingestion.Python.Steps.{DocxToMd, XlsxToMd}
 
@@ -16,52 +17,60 @@ defmodule ZaqWeb.Live.BO.AI.FilePreviewLive do
   @impl true
   def mount(%{"path" => path_segments}, _session, socket) do
     relative_path = Path.join(path_segments)
-    filename = Path.basename(relative_path)
-    ext = relative_path |> Path.extname() |> String.downcase()
 
-    result =
-      with {:ok, full_path} <- FileExplorer.resolve_path(relative_path),
-           false <- File.dir?(full_path),
-           {:ok, stat} <- File.stat(full_path, time: :posix) do
-        {:ok, full_path, stat}
-      else
-        true -> {:error, :is_directory}
-        {:error, reason} -> {:error, reason}
+    if Ingestion.can_access_file?(relative_path, socket.assigns.current_user) do
+      filename = Path.basename(relative_path)
+      ext = relative_path |> Path.extname() |> String.downcase()
+
+      result =
+        with {:ok, full_path} <- FileExplorer.resolve_path(relative_path),
+             false <- File.dir?(full_path),
+             {:ok, stat} <- File.stat(full_path, time: :posix) do
+          {:ok, full_path, stat}
+        else
+          true -> {:error, :is_directory}
+          {:error, reason} -> {:error, reason}
+        end
+
+      case result do
+        {:ok, full_path, stat} ->
+          {kind, content, rendered_html} = load_content(full_path, ext)
+
+          {:ok,
+           assign(socket,
+             current_path: "/bo/ingestion",
+             relative_path: relative_path,
+             filename: filename,
+             ext: ext,
+             kind: kind,
+             content: content,
+             rendered_html: rendered_html,
+             file_size: stat.size,
+             modified_at: stat.mtime |> DateTime.from_unix!(),
+             raw_url: "/bo/files/#{relative_path}"
+           )}
+
+        {:error, _} ->
+          {:ok,
+           socket
+           |> assign(
+             current_path: "/bo/ingestion",
+             relative_path: relative_path,
+             filename: filename,
+             ext: ext,
+             kind: :not_found,
+             content: nil,
+             rendered_html: nil,
+             file_size: nil,
+             modified_at: nil,
+             raw_url: nil
+           )}
       end
-
-    case result do
-      {:ok, full_path, stat} ->
-        {kind, content, rendered_html} = load_content(full_path, ext)
-
-        {:ok,
-         assign(socket,
-           current_path: "/bo/ingestion",
-           relative_path: relative_path,
-           filename: filename,
-           ext: ext,
-           kind: kind,
-           content: content,
-           rendered_html: rendered_html,
-           file_size: stat.size,
-           modified_at: stat.mtime |> DateTime.from_unix!(),
-           raw_url: "/bo/files/#{relative_path}"
-         )}
-
-      {:error, _} ->
-        {:ok,
-         socket
-         |> assign(
-           current_path: "/bo/ingestion",
-           relative_path: relative_path,
-           filename: filename,
-           ext: ext,
-           kind: :not_found,
-           content: nil,
-           rendered_html: nil,
-           file_size: nil,
-           modified_at: nil,
-           raw_url: nil
-         )}
+    else
+      {:ok,
+       socket
+       |> put_flash(:error, "You do not have access to this file.")
+       |> push_navigate(to: "/bo/ingestion")}
     end
   end
 

--- a/lib/zaq_web/live/bo/ai/ingestion_components.ex
+++ b/lib/zaq_web/live/bo/ai/ingestion_components.ex
@@ -527,7 +527,10 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
                       </svg>
                     </button>
                     <button
-                      :if={entry.type == :file}
+                      :if={
+                        entry.type == :file and
+                          Map.get(@ingestion_map, entry.name, %{can_share?: false}).can_share?
+                      }
                       phx-click="share_item"
                       phx-value-path={Path.join(@current_dir, entry.name)}
                       class="p-1.5 hover:bg-[#03b6d4]/10 rounded-lg text-black/30 hover:text-[#03b6d4] transition-colors"
@@ -571,7 +574,13 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
               </td>
               <td class="px-4 py-3">
                 <%= if entry.type == :file do %>
-                  <% status = Map.get(@ingestion_map, entry.name, %{ingested_at: nil, stale?: false}) %>
+                  <% status =
+                    Map.get(@ingestion_map, entry.name, %{
+                      ingested_at: nil,
+                      stale?: false,
+                      shared_role_ids: [],
+                      can_share?: false
+                    }) %>
                   <%= cond do %>
                     <% status.stale? -> %>
                       <div class="flex flex-col gap-0.5">
@@ -636,7 +645,29 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
                         </span>
                       </div>
                     <% true -> %>
-                      <span class="font-mono text-[0.65rem] text-black/20">—</span>
+                      <div class="flex items-center gap-1 flex-wrap">
+                        <span class="font-mono text-[0.65rem] text-black/20">—</span>
+                        <span
+                          :if={status.shared_role_ids != []}
+                          class="inline-flex items-center gap-1 font-mono text-[0.65rem] px-2 py-0.5 rounded bg-[#03b6d4]/10 text-[#03b6d4] cursor-default"
+                          title={"Shared with: #{@all_roles |> Enum.filter(&(&1.id in status.shared_role_ids)) |> Enum.map(& &1.name) |> Enum.join(", ")}"}
+                        >
+                          <svg
+                            class="w-3 h-3"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                            />
+                          </svg>
+                          shared
+                        </span>
+                      </div>
                   <% end %>
                 <% else %>
                   <span class="font-mono text-[0.65rem] text-black/20">—</span>
@@ -817,7 +848,10 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
               </svg>
             </button>
             <button
-              :if={entry.type == :file}
+              :if={
+                entry.type == :file and
+                  Map.get(@ingestion_map, entry.name, %{can_share?: false}).can_share?
+              }
               phx-click="share_item"
               phx-value-path={Path.join(@current_dir, entry.name)}
               class="p-1 hover:bg-[#03b6d4]/10 rounded-lg text-black/30 hover:text-[#03b6d4] transition-colors"
@@ -899,6 +933,13 @@ defmodule ZaqWeb.Live.BO.AI.IngestionComponents do
                     </span>
                   </div>
                 <% true -> %>
+                  <span
+                    :if={status.shared_role_ids != []}
+                    class="font-mono text-[0.55rem] px-1.5 py-0.5 rounded bg-[#03b6d4]/10 text-[#03b6d4] cursor-default mt-1"
+                    title={"Shared with: #{@all_roles |> Enum.filter(&(&1.id in status.shared_role_ids)) |> Enum.map(& &1.name) |> Enum.join(", ")}"}
+                  >
+                    shared
+                  </span>
               <% end %>
               <a
                 :if={Map.get(entry, :related_md)}

--- a/lib/zaq_web/live/bo/ai/ingestion_live.ex
+++ b/lib/zaq_web/live/bo/ai/ingestion_live.ex
@@ -8,7 +8,7 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
 
   alias Zaq.Accounts
   alias Zaq.Ingestion
-  alias Zaq.Ingestion.{Chunk, Document, FileExplorer}
+  alias Zaq.Ingestion.{Document, FileExplorer}
   alias Zaq.Repo
 
   @allowed_extensions ~w(.md .txt .pdf .docx .xlsx .csv)
@@ -97,17 +97,13 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   def handle_event("confirm_share", _params, socket) do
     source = normalize_source(socket.assigns.modal_path)
 
-    case Ingestion.share_file(source, socket.assigns.share_modal_role_ids) do
-      {:ok, _} ->
-        {:noreply,
-         socket
-         |> assign(modal: nil, modal_error: nil)
-         |> load_entries()
-         |> put_flash(:info, "Sharing updated for \"#{socket.assigns.modal_name}\".")}
+    {:ok, _} = Ingestion.share_file(source, socket.assigns.share_modal_role_ids)
 
-      {:error, :not_found} ->
-        {:noreply, assign(socket, modal_error: "File has not been ingested yet.")}
-    end
+    {:noreply,
+     socket
+     |> assign(modal: nil, modal_error: nil)
+     |> load_entries()
+     |> put_flash(:info, "Sharing updated for \"#{socket.assigns.modal_name}\".")}
   end
 
   # Volume
@@ -456,12 +452,17 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
 
   def handle_event("upload", _params, socket) do
     volume = socket.assigns.current_volume
+    role_id = socket.assigns.current_user.role_id
 
     uploaded =
       consume_uploaded_entries(socket, :files, fn %{path: tmp_path}, entry ->
         binary = File.read!(tmp_path)
         dest = Path.join(socket.assigns.current_dir, entry.client_name)
-        FileExplorer.upload(volume, dest, binary)
+
+        with {:ok, _full_path} <- FileExplorer.upload(volume, dest, binary) do
+          Ingestion.track_upload(dest, role_id)
+          {:ok, dest}
+        end
       end)
 
     {:noreply,
@@ -496,11 +497,17 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   defp load_ingestion_status(socket) do
     current_dir = socket.assigns.current_dir
     current_role_id = socket.assigns.current_user.role_id
+    super_admin? = socket.assigns.current_user.role.name == "super_admin"
+
+    public_role_id =
+      Enum.find_value(socket.assigns.all_roles, fn r ->
+        if r.name == "public", do: r.id
+      end)
+
+    file_entries = Enum.filter(socket.assigns.entries, &(&1.type == :file))
 
     sources =
-      socket.assigns.entries
-      |> Enum.filter(&(&1.type == :file))
-      |> Enum.map(fn entry ->
+      Enum.map(file_entries, fn entry ->
         normalize_source(Path.join(current_dir, entry.name))
       end)
 
@@ -509,37 +516,55 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
       |> Repo.all()
       |> Map.new(fn d -> {d.source, d} end)
 
-    doc_ids = documents |> Map.values() |> Enum.map(& &1.id)
-    shared_by_doc = Chunk.shared_role_ids_by_documents(doc_ids)
-
-    ingestion_map =
-      socket.assigns.entries
-      |> Enum.filter(&(&1.type == :file))
-      |> Map.new(fn entry ->
+    {ingestion_map, visible_names} =
+      Enum.reduce(file_entries, {%{}, MapSet.new()}, fn entry, {map, visible} ->
         source = normalize_source(Path.join(current_dir, entry.name))
+        doc = Map.get(documents, source)
 
-        status =
-          case Map.get(documents, source) do
-            nil -> %{ingested_at: nil, stale?: false, shared_role_ids: []}
-            doc -> entry_ingestion_status(entry, doc, shared_by_doc, current_role_id)
-          end
+        {status, visible?} =
+          resolve_entry_status(entry, doc, super_admin?, current_role_id, public_role_id)
 
-        {entry.name, status}
+        map = Map.put(map, entry.name, status)
+        visible = if visible?, do: MapSet.put(visible, entry.name), else: visible
+        {map, visible}
       end)
 
-    assign(socket, ingestion_map: ingestion_map)
+    visible_entries =
+      Enum.filter(socket.assigns.entries, fn e ->
+        e.type == :directory or MapSet.member?(visible_names, e.name)
+      end)
+
+    socket
+    |> assign(ingestion_map: ingestion_map)
+    |> assign(entries: visible_entries)
   end
 
-  defp entry_ingestion_status(entry, doc, shared_by_doc, current_role_id) do
-    shared = Map.get(shared_by_doc, doc.id, [])
-    visible? = is_nil(doc.role_id) or doc.role_id == current_role_id or current_role_id in shared
+  defp resolve_entry_status(_entry, nil, _super_admin?, _current_role_id, _public_role_id) do
+    {%{ingested_at: nil, stale?: false, shared_role_ids: [], can_share?: true}, true}
+  end
 
-    if visible? do
-      stale? = DateTime.compare(entry.modified_at, doc.updated_at) == :gt
-      %{ingested_at: doc.updated_at, stale?: stale?, shared_role_ids: shared}
-    else
-      %{ingested_at: nil, stale?: false, shared_role_ids: []}
-    end
+  defp resolve_entry_status(entry, doc, super_admin?, current_role_id, public_role_id) do
+    shared = doc.shared_role_ids
+    public? = not is_nil(public_role_id) and public_role_id in shared
+
+    visible? =
+      super_admin? or public? or is_nil(doc.role_id) or
+        doc.role_id == current_role_id or current_role_id in shared
+
+    can_share? = super_admin? or is_nil(doc.role_id) or doc.role_id == current_role_id
+    {entry_ingestion_status(entry, doc, can_share?), visible?}
+  end
+
+  defp entry_ingestion_status(entry, doc, can_share?) do
+    ingested_at = if doc.content, do: doc.updated_at, else: nil
+    stale? = not is_nil(ingested_at) and DateTime.compare(entry.modified_at, ingested_at) == :gt
+
+    %{
+      ingested_at: ingested_at,
+      stale?: stale?,
+      shared_role_ids: doc.shared_role_ids,
+      can_share?: can_share?
+    }
   end
 
   defp parent_dir("."), do: "."

--- a/priv/repo/migrations/20260317091138_seed_default_roles_and_admin_user.exs
+++ b/priv/repo/migrations/20260317091138_seed_default_roles_and_admin_user.exs
@@ -1,7 +1,7 @@
 defmodule Zaq.Repo.Migrations.SeedDefaultRolesAndAdminUser do
   use Ecto.Migration
 
-  @default_roles ["super_admin", "admin", "staff"]
+  @default_roles ["super_admin", "admin", "staff", "public"]
 
   def up do
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)

--- a/priv/repo/migrations/20260320000004_add_shared_role_ids_to_documents.exs
+++ b/priv/repo/migrations/20260320000004_add_shared_role_ids_to_documents.exs
@@ -1,0 +1,9 @@
+defmodule Zaq.Repo.Migrations.AddSharedRoleIdsToDocuments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:documents) do
+      add :shared_role_ids, {:array, :integer}, default: [], null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260320000005_make_document_content_nullable.exs
+++ b/priv/repo/migrations/20260320000005_make_document_content_nullable.exs
@@ -1,0 +1,9 @@
+defmodule Zaq.Repo.Migrations.MakeDocumentContentNullable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:documents) do
+      modify :content, :text, null: true
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,7 +1,7 @@
 alias Zaq.Repo
 alias Zaq.Accounts.Role
 
-roles = ["super_admin", "admin", "staff"]
+roles = ["super_admin", "admin", "staff", "public"]
 
 Enum.each(roles, fn name ->
   unless Repo.get_by(Role, name: name) do

--- a/test/zaq/ingestion/access_control_test.exs
+++ b/test/zaq/ingestion/access_control_test.exs
@@ -1,0 +1,185 @@
+defmodule Zaq.Ingestion.AccessControlTest do
+  use Zaq.DataCase, async: true
+
+  alias Zaq.Ingestion
+  alias Zaq.Ingestion.Document
+
+  # Builds a user-like struct with role preloaded, matching what
+  # Accounts.get_user!/1 returns (used by AuthHook and Plugs.Auth).
+  defp user_with_role(role) do
+    user = user_fixture(%{role: role})
+    Repo.preload(user, :role)
+  end
+
+  defp unique_source, do: "file_#{System.unique_integer([:positive])}.md"
+
+  setup do
+    super_admin_role = role_fixture(%{name: "super_admin"})
+    admin_role = role_fixture(%{name: "admin"})
+    staff_role = role_fixture(%{name: "staff"})
+    public_role = role_fixture(%{name: "public"})
+
+    super_admin = user_with_role(super_admin_role)
+    admin = user_with_role(admin_role)
+    staff = user_with_role(staff_role)
+
+    %{
+      super_admin: super_admin,
+      admin: admin,
+      staff: staff,
+      super_admin_role: super_admin_role,
+      admin_role: admin_role,
+      staff_role: staff_role,
+      public_role: public_role
+    }
+  end
+
+  describe "can_access_file?/2 — no document record" do
+    test "returns true when no document exists for the path (backward compat)", %{admin: admin} do
+      assert Ingestion.can_access_file?("untracked/file.md", admin)
+    end
+
+    test "normalizes leading ./ before lookup", %{admin: admin} do
+      assert Ingestion.can_access_file?("./also/untracked.md", admin)
+    end
+  end
+
+  describe "can_access_file?/2 — owner access" do
+    test "owner role can access their own file", %{admin: admin, admin_role: admin_role} do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, admin_role.id)
+
+      assert Ingestion.can_access_file?(source, admin)
+    end
+
+    test "different role cannot access without sharing", %{admin: admin, staff_role: staff_role} do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, staff_role.id)
+
+      refute Ingestion.can_access_file?(source, admin)
+    end
+  end
+
+  describe "can_access_file?/2 — super admin bypass" do
+    test "super admin can access files owned by any role",
+         %{super_admin: super_admin, admin_role: admin_role, staff_role: staff_role} do
+      admin_file = unique_source()
+      staff_file = unique_source()
+
+      {:ok, _} = Ingestion.track_upload(admin_file, admin_role.id)
+      {:ok, _} = Ingestion.track_upload(staff_file, staff_role.id)
+
+      assert Ingestion.can_access_file?(admin_file, super_admin)
+      assert Ingestion.can_access_file?(staff_file, super_admin)
+    end
+
+    test "super admin can access files with no role_id", %{super_admin: super_admin} do
+      source = unique_source()
+      {:ok, _} = Document.upsert(%{source: source})
+
+      assert Ingestion.can_access_file?(source, super_admin)
+    end
+  end
+
+  describe "can_access_file?/2 — explicit role sharing" do
+    test "file shared with user's role is accessible", %{
+      admin: admin,
+      staff_role: staff_role,
+      admin_role: admin_role
+    } do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, staff_role.id)
+      {:ok, _} = Ingestion.share_file(source, [admin_role.id])
+
+      assert Ingestion.can_access_file?(source, admin)
+    end
+
+    test "file not shared with user's role is inaccessible", %{
+      admin: admin,
+      staff: staff,
+      staff_role: staff_role,
+      admin_role: admin_role
+    } do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, staff_role.id)
+      {:ok, _} = Ingestion.share_file(source, [admin_role.id])
+
+      # staff uploaded it but it's shared with admin, not staff
+      # staff is the owner so they can access it; admin can access via sharing
+      assert Ingestion.can_access_file?(source, admin)
+      assert Ingestion.can_access_file?(source, staff)
+    end
+
+    test "access is revoked when sharing is cleared", %{
+      admin: admin,
+      staff_role: staff_role,
+      admin_role: admin_role
+    } do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, staff_role.id)
+      {:ok, _} = Ingestion.share_file(source, [admin_role.id])
+
+      assert Ingestion.can_access_file?(source, admin)
+
+      {:ok, _} = Ingestion.share_file(source, [])
+
+      refute Ingestion.can_access_file?(source, admin)
+    end
+  end
+
+  describe "can_access_file?/2 — public role" do
+    test "file shared with public is accessible to all roles", %{
+      admin: admin,
+      staff: staff,
+      super_admin: super_admin,
+      admin_role: admin_role,
+      public_role: public_role
+    } do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, admin_role.id)
+      {:ok, _} = Ingestion.share_file(source, [public_role.id])
+
+      assert Ingestion.can_access_file?(source, admin)
+      assert Ingestion.can_access_file?(source, staff)
+      assert Ingestion.can_access_file?(source, super_admin)
+    end
+
+    test "file not shared with public is not universally accessible", %{
+      admin: admin,
+      staff: staff,
+      admin_role: admin_role
+    } do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, admin_role.id)
+
+      assert Ingestion.can_access_file?(source, admin)
+      refute Ingestion.can_access_file?(source, staff)
+    end
+
+    test "removing public from sharing revokes universal access", %{
+      staff: staff,
+      admin_role: admin_role,
+      public_role: public_role
+    } do
+      source = unique_source()
+      {:ok, _} = Ingestion.track_upload(source, admin_role.id)
+      {:ok, _} = Ingestion.share_file(source, [public_role.id])
+
+      assert Ingestion.can_access_file?(source, staff)
+
+      {:ok, _} = Ingestion.share_file(source, [])
+
+      refute Ingestion.can_access_file?(source, staff)
+    end
+  end
+
+  describe "can_access_file?/2 — unscoped document (no role_id)" do
+    test "document with nil role_id is accessible to all", %{admin: admin, staff: staff} do
+      source = unique_source()
+      {:ok, _} = Document.upsert(%{source: source})
+
+      assert Ingestion.can_access_file?(source, admin)
+      assert Ingestion.can_access_file?(source, staff)
+    end
+  end
+end

--- a/test/zaq/ingestion/document_processor_test.exs
+++ b/test/zaq/ingestion/document_processor_test.exs
@@ -174,7 +174,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
 
     test "returns changeset error when required fields are invalid" do
       assert {:error, changeset} = DocumentProcessor.store_document(nil, nil)
-      assert %{content: [_ | _], source: [_ | _]} = errors_on(changeset)
+      assert %{source: [_ | _]} = errors_on(changeset)
     end
   end
 

--- a/test/zaq/ingestion/document_test.exs
+++ b/test/zaq/ingestion/document_test.exs
@@ -21,10 +21,10 @@ defmodule Zaq.Ingestion.DocumentTest do
       refute changeset.valid?
     end
 
-    test "invalid without content" do
+    test "valid without content (content is optional for upload tracking)" do
       attrs = Map.delete(@valid_attrs, :content)
       changeset = Document.changeset(%Document{}, attrs)
-      refute changeset.valid?
+      assert changeset.valid?
     end
 
     test "invalid with unsupported content_type" do

--- a/test/zaq/ingestion/ingestion_test.exs
+++ b/test/zaq/ingestion/ingestion_test.exs
@@ -4,8 +4,7 @@ defmodule Zaq.IngestionTest do
   import Mox
 
   alias Zaq.Ingestion
-  alias Zaq.Ingestion.FileExplorer
-  alias Zaq.Ingestion.IngestJob
+  alias Zaq.Ingestion.{Document, FileExplorer, IngestJob}
   alias Zaq.Repo
 
   setup do
@@ -201,6 +200,82 @@ defmodule Zaq.IngestionTest do
 
       assert {:ok, job} = Ingestion.ingest_file("docs/file.md", :inline)
       assert job.volume_name == nil
+    end
+  end
+
+  describe "track_upload/2" do
+    test "creates a document record with the uploader's role_id" do
+      role = role_fixture()
+      source = "file_#{System.unique_integer([:positive])}.md"
+
+      assert {:ok, doc} = Ingestion.track_upload(source, role.id)
+      assert doc.source == source
+      assert doc.role_id == role.id
+      assert doc.content == nil
+    end
+
+    test "normalizes leading ./ from path" do
+      role = role_fixture()
+      source = "file_#{System.unique_integer([:positive])}.md"
+
+      assert {:ok, doc} = Ingestion.track_upload("./#{source}", role.id)
+      assert doc.source == source
+    end
+
+    test "upserts: does not duplicate when called again for the same source" do
+      role1 = role_fixture()
+      role2 = role_fixture()
+      source = "file_#{System.unique_integer([:positive])}.md"
+
+      assert {:ok, _} = Ingestion.track_upload(source, role1.id)
+      assert {:ok, doc} = Ingestion.track_upload(source, role2.id)
+      assert doc.role_id == role2.id
+      assert Repo.aggregate(Document, :count) >= 1
+    end
+  end
+
+  describe "share_file/2" do
+    test "updates shared_role_ids on an existing document" do
+      role1 = role_fixture()
+      role2 = role_fixture()
+      source = "file_#{System.unique_integer([:positive])}.md"
+
+      {:ok, _} = Ingestion.track_upload(source, role1.id)
+
+      assert {:ok, _} = Ingestion.share_file(source, [role2.id])
+      assert Document.get_by_source(source).shared_role_ids == [role2.id]
+    end
+
+    test "creates a minimal document when none exists yet" do
+      role = role_fixture()
+      source = "file_#{System.unique_integer([:positive])}.md"
+
+      assert {:ok, _} = Ingestion.share_file(source, [role.id])
+
+      doc = Document.get_by_source(source)
+      assert doc.shared_role_ids == [role.id]
+      assert doc.role_id == nil
+    end
+
+    test "does not overwrite ingested content" do
+      role = role_fixture()
+      source = "file_#{System.unique_integer([:positive])}.md"
+
+      {:ok, _} = Document.upsert(%{source: source, content: "# Hello", role_id: role.id})
+      {:ok, _} = Ingestion.share_file(source, [role.id])
+
+      assert Document.get_by_source(source).content == "# Hello"
+    end
+
+    test "clears sharing when called with empty list" do
+      role = role_fixture()
+      source = "file_#{System.unique_integer([:positive])}.md"
+
+      {:ok, _} = Ingestion.track_upload(source, role.id)
+      {:ok, _} = Ingestion.share_file(source, [role.id])
+      {:ok, _} = Ingestion.share_file(source, [])
+
+      assert Document.get_by_source(source).shared_role_ids == []
     end
   end
 


### PR DESCRIPTION
  Track uploaded files in the documents table immediately at upload time,
  stamping the uploader's role_id so the file browser enforces visibility
  before any ingestion runs. Files are hidden from roles that don't own or
  share them, with three override paths: the public role (visible to
  everyone), explicit role sharing, and super_admin (bypasses all checks).

  Changes:
  - Document.role_id is set on upload via Ingestion.track_upload/2; content is now nullable so tracking records can exist before ingestion
  - Ingestion.share_file/2 persists shared_role_ids on the Document (not only on chunks), enabling the shared tag to display on non-ingested files
  - Ingestion.can_access_file?/2 is the single visibility predicate reused by the file browser, FilePreviewLive, and FileController
  - Super admins bypass all role filters and always see real status
  - Share button hidden from users who can see a file only via sharing
  - /bo/preview and /bo/files return 403/redirect for unauthorized access
  - Seed the "public" role alongside existing defaults
  - Migrations: shared_role_ids[] on documents, nullable content column
  - 14 new unit tests covering all access control rules

  Closes #97