### PR TITLE
fix(ingestion): resolve paths against volume root, not hardcoded base…

### DIFF
--- a/lib/zaq/ingestion/document_processor.ex
+++ b/lib/zaq/ingestion/document_processor.ex
@@ -185,14 +185,15 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   end
 
   @doc """
-  Extracts the source as a relative path from the ingestion base_path.
-  Falls back to basename if the path is not under base_path.
+  Extracts the source as a relative path from its volume root.
+  Checks all configured volumes to find the matching root.
+  Falls back to basename if the path is not under any known volume.
 
-  Example: "/app/priv/documents/docs/guide.md" => "docs/guide.md"
+  Example: "/zaq/volumes/docs/guide.md" => "docs/guide.md"
   """
   def extract_source(_content, file_path) do
-    base = FileExplorer.base_path() |> Path.expand()
     expanded = Path.expand(file_path)
+    base = find_volume_root(expanded)
 
     relative =
       case String.split(expanded, base <> "/", parts: 2) do
@@ -201,6 +202,16 @@ defmodule Zaq.Ingestion.DocumentProcessor do
       end
 
     {:ok, relative}
+  end
+
+  defp find_volume_root(expanded_path) do
+    FileExplorer.list_volumes()
+    |> Map.values()
+    |> Enum.find(fn vol_root -> String.starts_with?(expanded_path, vol_root <> "/") end)
+    |> case do
+      nil -> FileExplorer.base_path() |> Path.expand()
+      vol_root -> vol_root
+    end
   end
 
   @doc """

--- a/lib/zaq/ingestion/ingest_worker.ex
+++ b/lib/zaq/ingestion/ingest_worker.ex
@@ -26,7 +26,7 @@ defmodule Zaq.Ingestion.IngestWorker do
       |> Repo.update!()
       |> broadcast_update()
 
-    file_path = resolve_file_path(updated_job.file_path)
+    file_path = resolve_file_path(updated_job.file_path, updated_job.volume_name)
 
     case safe_process(file_path, role_id, shared_role_ids) do
       {:ok, document} ->
@@ -90,8 +90,15 @@ defmodule Zaq.Ingestion.IngestWorker do
       {:error, inspect(reason)}
   end
 
-  defp resolve_file_path(path) do
+  defp resolve_file_path(path, nil) do
     case FileExplorer.resolve_path(path) do
+      {:ok, full_path} -> full_path
+      _ -> path
+    end
+  end
+
+  defp resolve_file_path(path, volume_name) do
+    case FileExplorer.resolve_path(volume_name, path) do
       {:ok, full_path} -> full_path
       _ -> path
     end

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -45,7 +45,7 @@ defmodule Zaq.Ingestion do
         role_id \\ nil,
         shared_role_ids \\ []
       ) do
-    with {:ok, entries} <- FileExplorer.list(path) do
+    with {:ok, entries} <- list_in_volume(volume_name, path) do
       jobs =
         entries
         |> Enum.filter(&(&1.type == :file))
@@ -173,6 +173,9 @@ defmodule Zaq.Ingestion do
   def subscribe, do: Phoenix.PubSub.subscribe(@pubsub, @topic)
 
   # --- Private ---
+
+  defp list_in_volume(nil, path), do: FileExplorer.list(path)
+  defp list_in_volume(volume_name, path), do: FileExplorer.list(volume_name, path)
 
   defp create_job(path, mode, volume_name, role_id, shared_role_ids) do
     attrs =

--- a/lib/zaq/ingestion/python/pipeline.ex
+++ b/lib/zaq/ingestion/python/pipeline.ex
@@ -33,7 +33,7 @@ defmodule Zaq.Ingestion.Python.Pipeline do
   def run(pdf_path, opts \\ []) do
     api_key = resolve_api_key(opts)
     md_path = opts[:output] || Path.rootname(pdf_path) <> ".md"
-    base = FileExplorer.base_path()
+    base = opts[:base] || resolve_volume_base(pdf_path)
     images_dir = opts[:images_dir] || Path.join(base, "images")
 
     pdf_name = Path.basename(pdf_path, ".pdf")
@@ -61,6 +61,18 @@ defmodule Zaq.Ingestion.Python.Pipeline do
   end
 
   # --- Private ---
+
+  defp resolve_volume_base(pdf_path) do
+    expanded = Path.expand(pdf_path)
+
+    FileExplorer.list_volumes()
+    |> Map.values()
+    |> Enum.find(fn vol_root -> String.starts_with?(expanded, vol_root <> "/") end)
+    |> case do
+      nil -> FileExplorer.base_path()
+      vol_root -> vol_root
+    end
+  end
 
   defp resolve_api_key(opts) do
     key =

--- a/test/zaq/ingestion/document_processor_test.exs
+++ b/test/zaq/ingestion/document_processor_test.exs
@@ -146,6 +146,16 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
       assert {:ok, "not-in-base.md"} =
                DocumentProcessor.extract_source("ignored", outside_path)
     end
+
+    test "strips named volume root when file lives in a configured volume" do
+      vol_dir = Path.join(System.tmp_dir!(), "zaq_vol_#{System.unique_integer([:positive])}")
+      Application.put_env(:zaq, Zaq.Ingestion, volumes: %{"docs" => vol_dir})
+
+      file_path = Path.join([vol_dir, "sub", "guide.md"])
+
+      assert {:ok, "sub/guide.md"} =
+               DocumentProcessor.extract_source("ignored", file_path)
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/zaq/ingestion/ingest_worker_test.exs
+++ b/test/zaq/ingestion/ingest_worker_test.exs
@@ -182,6 +182,42 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
                })
     end
 
+    test "resolves path against volume_name when job has one" do
+      vol_dir =
+        Path.join(System.tmp_dir!(), "zaq_worker_vol_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(vol_dir)
+
+      original = Application.get_env(:zaq, Zaq.Ingestion)
+
+      on_exit(fn ->
+        if is_nil(original) do
+          Application.delete_env(:zaq, Zaq.Ingestion)
+        else
+          Application.put_env(:zaq, Zaq.Ingestion, original)
+        end
+      end)
+
+      Application.put_env(:zaq, Zaq.Ingestion, volumes: %{"myvol" => vol_dir})
+
+      job = create_job(%{file_path: "report.md", volume_name: "myvol"})
+      expected_path = Path.join(vol_dir, "report.md")
+
+      expect(Zaq.DocumentProcessorMock, :process_single_file, fn path,
+                                                                 _role_id,
+                                                                 _shared_role_ids ->
+        assert path == expected_path
+        {:ok, create_document()}
+      end)
+
+      assert :ok =
+               IngestWorker.perform(%Oban.Job{
+                 args: %{"job_id" => job.id},
+                 attempt: 1,
+                 max_attempts: 3
+               })
+    end
+
     test "converts crashes to retries" do
       job = create_job()
 

--- a/test/zaq/ingestion/ingestion_test.exs
+++ b/test/zaq/ingestion/ingestion_test.exs
@@ -284,6 +284,25 @@ defmodule Zaq.IngestionTest do
       unique = System.unique_integer([:positive])
       folder = "ingestion_vol_test_#{unique}"
 
+      # Configure a "docs" volume pointing at the same base path so files
+      # created via FileExplorer.create_directory/upload are reachable.
+      base_dir = FileExplorer.base_path() |> Path.expand()
+      original = Application.get_env(:zaq, Zaq.Ingestion)
+
+      Application.put_env(
+        :zaq,
+        Zaq.Ingestion,
+        Keyword.merge(original || [], volumes: %{"docs" => base_dir})
+      )
+
+      on_exit(fn ->
+        if is_nil(original) do
+          Application.delete_env(:zaq, Zaq.Ingestion)
+        else
+          Application.put_env(:zaq, Zaq.Ingestion, original)
+        end
+      end)
+
       assert :ok = FileExplorer.create_directory(folder)
       assert {:ok, _} = FileExplorer.upload(Path.join(folder, "one.md"), "# one")
 


### PR DESCRIPTION
IngestWorker, DocumentProcessor, Pipeline, and ingest_folder were all
  ignoring the volume_name stored on the job and falling back to the
  legacy base_path. In Docker this caused RAG ingestion to fail because
  the hardcoded path didn't match the actual volume mount.

  - IngestWorker: resolve_file_path/2 now dispatches to FileExplorer.resolve_path/2 when volume_name is present
  - Ingestion.ingest_folder: list_in_volume/2 uses volume-aware FileExplorer.list/2 instead of the single-arg fallback
  - DocumentProcessor.extract_source: finds the matching volume root across all configured volumes instead of hardcoding base_path
  - Python.Pipeline: resolve_volume_base/1 derives images_dir and debugging/ from the PDF's actual volume root

Closes #103 Closes #96