### PR TITLE
fix(db): register Zaq.PostgrexTypes in production Repo config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,6 +35,7 @@ if config_env() == :prod do
   config :zaq, Zaq.Repo,
     # ssl: true,
     url: database_url,
+    types: Zaq.PostgrexTypes,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     # For machines with several cores, consider starting multiple pools of `pool_size`
     # pool_count: 4,


### PR DESCRIPTION
  The `types: Zaq.PostgrexTypes` option was set in dev.exs and test.exs
  but missing from the production block in runtime.exs, causing Postgrex
  to fail with "type `halfvec` can not be handled" on fresh deployments.

closes #104 