### PR TITLE
feat(license): add upload UI and replace file watcher with startup loader

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,10 @@ config :zaq,
   ecto_repos: [Zaq.Repo],
   generators: [timestamp_type: :utc_datetime]
 
+config :mime, :types, %{
+  "application/vnd.zaq-license" => ["zaq-license"]
+}
+
 config :zaq, Oban,
   repo: Zaq.Repo,
   queues: [ingestion: 3, default: 10, conversations: 5]

--- a/lib/zaq/license/license_post_loader.ex
+++ b/lib/zaq/license/license_post_loader.ex
@@ -21,14 +21,16 @@ defmodule Zaq.License.LicensePostLoader do
 
   use GenServer
 
+  alias Zaq.License.Loader
+
   require Logger
 
   @doc """
   Notifies the GenServer that a license was loaded.
-  migration_files is a list of {filename, binary_content} tuples.
+  migration_files and view_files are lists of {filename, binary_content} tuples.
   """
-  def notify(license_data, migration_files \\ []) do
-    GenServer.cast(__MODULE__, {:license_loaded, license_data, migration_files})
+  def notify(license_data, migration_files \\ [], view_files \\ []) do
+    GenServer.cast(__MODULE__, {:license_loaded, license_data, migration_files, view_files})
   end
 
   def start_link(opts \\ []) do
@@ -39,17 +41,36 @@ defmodule Zaq.License.LicensePostLoader do
 
   @impl true
   def init(_opts) do
+    send(self(), :load_startup_license)
     {:ok, %{}}
   end
 
   @impl true
-  def handle_cast({:license_loaded, license_data, migration_files}, state) do
+  def handle_info(:load_startup_license, state) do
+    dir = Application.app_dir(:zaq, "priv/licenses")
+
+    case File.ls(dir) do
+      {:ok, files} ->
+        files
+        |> Enum.filter(&String.ends_with?(&1, ".zaq-license"))
+        |> Enum.each(&load_license_file(Path.join(dir, &1)))
+
+      {:error, _} ->
+        Logger.debug("[LicensePostLoader] No licenses directory at #{dir}, skipping.")
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:license_loaded, license_data, migration_files, view_files}, state) do
     license_key = Map.get(license_data, "license_key", "unknown")
     Logger.info("[LicensePostLoader] Running post-load steps for license: #{license_key}")
 
     run_migrations(migration_files)
+    compile_views(view_files)
 
-    # Broadcast that license has been updated (migrations complete)
+    # Broadcast that license has been updated (migrations + views complete)
     Phoenix.PubSub.broadcast(Zaq.PubSub, "license:updated", :license_updated)
     Logger.debug("[LicensePostLoader] Broadcast license:updated event")
 
@@ -57,6 +78,46 @@ defmodule Zaq.License.LicensePostLoader do
   end
 
   # --- Private ---
+
+  defp load_license_file(path) do
+    case Loader.load(path) do
+      {:ok, _} ->
+        Logger.info("[LicensePostLoader] Loaded license from #{path}")
+
+      {:error, reason} ->
+        Logger.warning("[LicensePostLoader] Failed to load #{path}: #{inspect(reason)}")
+    end
+  end
+
+  defp compile_views([]) do
+    Logger.debug("[LicensePostLoader] No view files in license, skipping.")
+  end
+
+  defp compile_views(view_files) do
+    Logger.info("[LicensePostLoader] Compiling #{length(view_files)} view file(s)...")
+
+    tmp_dir = Path.join(System.tmp_dir!(), "zaq_views_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp_dir)
+
+    try do
+      Enum.each(view_files, fn {filename, content} ->
+        File.write!(Path.join(tmp_dir, filename), content)
+      end)
+
+      view_files
+      |> Enum.filter(fn {filename, _} -> String.ends_with?(filename, ".ex") end)
+      |> Enum.each(fn {filename, _} ->
+        path = Path.join(tmp_dir, filename)
+        Code.compile_file(path)
+        Logger.info("[LicensePostLoader] Compiled view: #{filename}")
+      end)
+    rescue
+      e ->
+        Logger.error("[LicensePostLoader] View compilation failed: #{Exception.message(e)}")
+    after
+      File.rm_rf!(tmp_dir)
+    end
+  end
 
   defp run_migrations([]) do
     Logger.debug("[LicensePostLoader] No migration files in license, skipping.")

--- a/lib/zaq/license/loader.ex
+++ b/lib/zaq/license/loader.ex
@@ -22,8 +22,9 @@ defmodule Zaq.License.Loader do
          key <- BeamDecryptor.derive_key(payload),
          {:ok, loaded_modules} <- decrypt_and_load_modules(files, key) do
       migration_files = extract_migration_files(files)
+      view_files = extract_view_files(files)
       FeatureStore.store(license_data, loaded_modules)
-      LicensePostLoader.notify(license_data, migration_files)
+      LicensePostLoader.notify(license_data, migration_files, view_files)
       Logger.info("License loaded successfully: #{license_data["license_key"]}")
       {:ok, license_data}
     else
@@ -103,6 +104,12 @@ defmodule Zaq.License.Loader do
   defp extract_migration_files(files) do
     files
     |> Enum.filter(fn {name, _} -> String.starts_with?(name, "migrations/") end)
+    |> Enum.map(fn {name, content} -> {Path.basename(name), content} end)
+  end
+
+  defp extract_view_files(files) do
+    files
+    |> Enum.filter(fn {name, _} -> String.starts_with?(name, "views/") end)
     |> Enum.map(fn {name, content} -> {Path.basename(name), content} end)
   end
 

--- a/lib/zaq_web/live/bo/system/license_live.ex
+++ b/lib/zaq_web/live/bo/system/license_live.ex
@@ -1,7 +1,7 @@
 defmodule ZaqWeb.Live.BO.System.LicenseLive do
   use ZaqWeb, :live_view
 
-  alias Zaq.License.FeatureStore
+  alias Zaq.License.{FeatureStore, Loader}
 
   @zaq_features [
     %{
@@ -43,6 +43,52 @@ defmodule ZaqWeb.Live.BO.System.LicenseLive do
   ]
 
   def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Zaq.PubSub, "license:updated")
+    end
+
+    {:ok,
+     socket
+     |> assign_license_state()
+     |> assign(current_path: "/bo/license", upload_error: nil)
+     |> allow_upload(:license_file, accept: ~w(.zaq-license), max_entries: 1)}
+  end
+
+  def handle_event("validate", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("upload_license", _params, socket) do
+    result =
+      consume_uploaded_entries(socket, :license_file, fn %{path: tmp_path}, entry ->
+        dest_dir = Application.app_dir(:zaq, "priv/licenses")
+        File.mkdir_p!(dest_dir)
+        dest = Path.join(dest_dir, entry.client_name)
+        File.cp!(tmp_path, dest)
+
+        case Loader.load(dest) do
+          {:ok, _license_data} -> {:ok, :loaded}
+          {:error, reason} -> {:ok, {:error, reason}}
+        end
+      end)
+
+    case result do
+      [:loaded] ->
+        {:noreply, socket |> assign_license_state() |> assign(upload_error: nil)}
+
+      [{:error, reason}] ->
+        {:noreply, assign(socket, upload_error: format_upload_error(reason))}
+
+      [] ->
+        {:noreply, assign(socket, upload_error: "No file selected.")}
+    end
+  end
+
+  def handle_info(:license_updated, socket) do
+    {:noreply, assign_license_state(socket)}
+  end
+
+  defp assign_license_state(socket) do
     license_data = FeatureStore.license_data()
     loaded_modules = FeatureStore.loaded_modules()
 
@@ -52,18 +98,30 @@ defmodule ZaqWeb.Live.BO.System.LicenseLive do
         data -> data |> Map.get("features", []) |> Enum.map(& &1["name"])
       end
 
-    locked_features =
-      Enum.reject(@zaq_features, fn f -> f.name in licensed_names end)
+    locked_features = Enum.reject(@zaq_features, fn f -> f.name in licensed_names end)
 
-    {:ok,
-     assign(socket,
-       license_data: license_data,
-       loaded_modules: loaded_modules,
-       zaq_features: @zaq_features,
-       locked_features: locked_features,
-       current_path: "/bo/license"
-     )}
+    assign(socket,
+      license_data: license_data,
+      loaded_modules: loaded_modules,
+      zaq_features: @zaq_features,
+      locked_features: locked_features
+    )
   end
+
+  def upload_entry_error(:too_large), do: "File is too large."
+  def upload_entry_error(:not_accepted), do: "Only .zaq-license files are accepted."
+  def upload_entry_error(:too_many_files), do: "Only one file at a time."
+  def upload_entry_error(_), do: "Upload failed."
+
+  defp format_upload_error(:license_expired), do: "This license has expired."
+
+  defp format_upload_error(:missing_license_dat),
+    do: "Invalid license file: missing license data."
+
+  defp format_upload_error(:invalid_payload_json), do: "Invalid license file: malformed payload."
+  defp format_upload_error(:invalid_license_dat_format), do: "Invalid license file format."
+  defp format_upload_error({:extract_failed, _}), do: "Could not read license file."
+  defp format_upload_error(reason), do: "Failed to load license: #{inspect(reason)}"
 
   defp days_left(nil), do: nil
 

--- a/lib/zaq_web/live/bo/system/license_live.html.heex
+++ b/lib/zaq_web/live/bo/system/license_live.html.heex
@@ -6,6 +6,52 @@
   <%= if @license_data do %>
     <!-- Licensed State -->
     <div class="space-y-6">
+      <!-- Upload New License -->
+      <div class="bg-white rounded-xl border border-black/10 p-6">
+        <p class="font-mono text-[0.7rem] text-black/40 uppercase tracking-wider mb-4">
+          Update License
+        </p>
+        <.form for={%{}} phx-submit="upload_license" phx-change="validate">
+          <div class="flex items-center gap-4">
+            <label class="flex-1 flex items-center gap-3 px-4 py-3 rounded-lg border border-dashed border-black/20 cursor-pointer hover:border-black/40 transition-colors">
+              <svg
+                class="w-4 h-4 text-black/30 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                viewBox="0 0 24 24"
+              >
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+              </svg>
+              <span class="font-mono text-[0.75rem] text-black/50">
+                {case @uploads.license_file.entries do
+                  [entry | _] -> entry.client_name
+                  [] -> "Select .zaq-license file…"
+                end}
+              </span>
+              <.live_file_input upload={@uploads.license_file} class="sr-only" />
+            </label>
+            <button
+              type="submit"
+              class="font-mono text-[0.8rem] font-bold px-4 py-2.5 rounded-lg bg-[#3c4b64] text-white hover:bg-[#3c4b64]/90 transition-colors flex-shrink-0"
+            >
+              Upload
+            </button>
+          </div>
+          <div class="mt-2 space-y-1">
+            <%= for entry <- @uploads.license_file.entries,
+                    err <- upload_errors(@uploads.license_file, entry) do %>
+              <p class="font-mono text-[0.75rem] text-red-600">
+                {upload_entry_error(err)}
+              </p>
+            <% end %>
+            <%= if @upload_error do %>
+              <p class="font-mono text-[0.75rem] text-red-600">{@upload_error}</p>
+            <% end %>
+          </div>
+        </.form>
+      </div>
       <!-- License Status Card -->
       <div class="bg-white rounded-xl border border-black/10 p-6">
         <div class="flex items-center justify-between mb-6">
@@ -167,6 +213,43 @@
         >
           Request a License
         </.link>
+        <div class="mt-6 pt-6 border-t border-black/10">
+          <p class="font-mono text-[0.7rem] text-black/40 uppercase tracking-wider mb-3">
+            Already have a license?
+          </p>
+          <.form for={%{}} phx-submit="upload_license" phx-change="validate">
+            <div class="flex items-center gap-3 max-w-sm mx-auto">
+              <label class="flex-1 flex items-center gap-2 px-4 py-2.5 rounded-lg border border-dashed border-black/20 cursor-pointer hover:border-black/40 transition-colors">
+                <svg
+                  class="w-4 h-4 text-black/30 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+                </svg>
+                <span class="font-mono text-[0.75rem] text-black/50">
+                  {case @uploads.license_file.entries do
+                    [entry | _] -> entry.client_name
+                    [] -> "Select .zaq-license file…"
+                  end}
+                </span>
+                <.live_file_input upload={@uploads.license_file} class="sr-only" />
+              </label>
+              <button
+                type="submit"
+                class="font-mono text-[0.8rem] font-bold px-4 py-2.5 rounded-lg bg-[#3c4b64] text-white hover:bg-[#3c4b64]/90 transition-colors flex-shrink-0"
+              >
+                Activate
+              </button>
+            </div>
+            <%= if @upload_error do %>
+              <p class="font-mono text-[0.75rem] text-red-600 mt-2">{@upload_error}</p>
+            <% end %>
+          </.form>
+        </div>
       </div>
       
 <!-- Feature Grid -->


### PR DESCRIPTION
  - Add .zaq-license file upload to the license page (both unlicensed and licensed states), persisting uploaded files to priv/licenses/
  - Replace the removed LicenseWatcher with startup scanning in LicensePostLoader.init/1 — loads any .zaq-license files found at boot
  - Compile bundled view files (views/*.ex + .html.heex) from the license package via Code.compile_file/1 so LiveView modules are available at runtime without a recompile
  - Register the application/vnd.zaq-license MIME type so allow_upload accepts .zaq-license files
  - Show both LiveView upload entry errors and server-side loader errors inline on the upload form
  
  Closes #117 