### PR TITLE
feat(oban): replace Cron plugin restart with DynamicCron plugin supporting runtime schedule injection

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,7 +20,7 @@ config :zaq, Oban,
   queues: [ingestion: 3, default: 10, conversations: 5, telemetry: 5, telemetry_remote: 3],
   crontab: [],
   plugins: [
-    {Oban.Plugins.Cron,
+    {Zaq.Oban.DynamicCron,
      crontab: [
        {"* * * * *", Zaq.Engine.Telemetry.Workers.AggregateRollupsWorker},
        {"*/10 * * * *", Zaq.Engine.Telemetry.Workers.PushRollupsWorker},

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -137,7 +137,7 @@ if config_env() == :prod do
       default: 10
     ],
     plugins: [
-      {Oban.Plugins.Cron,
+      {Zaq.Oban.DynamicCron,
        crontab: [
          {"* * * * *", Zaq.Engine.Telemetry.Workers.AggregateRollupsWorker},
          {"*/10 * * * *", Zaq.Engine.Telemetry.Workers.PushRollupsWorker},

--- a/lib/zaq/license/oban_feature.ex
+++ b/lib/zaq/license/oban_feature.ex
@@ -5,12 +5,20 @@ defmodule Zaq.License.ObanFeature do
   Implement this behaviour in any module that needs queues or crontab entries
   provisioned when the license is loaded into the BEAM.
 
-  Both callbacks are required. Return `[]` from either if not needed.
+  All three callbacks are required. Return `[]` from `oban_queues/0` or `oban_crontab/0`
+  if not needed.
+
+  `feature_key/0` returns a unique atom identifying this feature. It is used as the
+  idempotency key by `Zaq.Oban.DynamicCron` — if the license is reloaded, schedules
+  for an already-registered key are not re-added.
 
   ## Example
 
       defmodule LicenseManager.Paid.KnowledgeGap do
         @behaviour Zaq.License.ObanFeature
+
+        @impl true
+        def feature_key, do: :knowledge_gap
 
         @impl true
         def oban_queues, do: [knowledge_gap: 5]
@@ -23,6 +31,7 @@ defmodule Zaq.License.ObanFeature do
   @type queue_spec :: {atom(), pos_integer()}
   @type cron_spec :: {String.t(), module()}
 
+  @callback feature_key() :: atom()
   @callback oban_queues() :: [queue_spec()]
   @callback oban_crontab() :: [cron_spec()]
 end

--- a/lib/zaq/license/oban_provisioner.ex
+++ b/lib/zaq/license/oban_provisioner.ex
@@ -4,9 +4,11 @@ defmodule Zaq.License.ObanProvisioner do
 
   Called by `Zaq.License.Loader` after modules are loaded into the BEAM.
   Any loaded module implementing `Zaq.License.ObanFeature` will have its
-  declared queues started and crontab entries merged into the running Oban
-  instance — with no static config changes required.
+  declared queues started and crontab entries injected into the running
+  `Zaq.Oban.DynamicCron` plugin — with no Oban supervisor restart required.
   """
+
+  alias Zaq.Oban.DynamicCron
 
   require Logger
 
@@ -26,6 +28,7 @@ defmodule Zaq.License.ObanProvisioner do
 
   defp implements_oban_feature?(module) do
     Code.ensure_loaded?(module) and
+      function_exported?(module, :feature_key, 0) and
       function_exported?(module, :oban_queues, 0) and
       function_exported?(module, :oban_crontab, 0)
   end
@@ -49,52 +52,13 @@ defmodule Zaq.License.ObanProvisioner do
   defp provision_crontab([]), do: :ok
 
   defp provision_crontab(feature_modules) do
-    new_entries = Enum.flat_map(feature_modules, & &1.oban_crontab())
+    Enum.each(feature_modules, fn module ->
+      key = module.feature_key()
+      entries = module.oban_crontab()
 
-    if new_entries == [] do
-      :ok
-    else
-      base_crontab = Application.get_env(:zaq, :oban_base_crontab, [])
-      merged = Enum.uniq_by(base_crontab ++ new_entries, fn {_expr, worker} -> worker end)
-      restart_cron_plugin(merged)
-    end
-  end
-
-  defp restart_cron_plugin(crontab) do
-    # Oban's cron plugin has no public API for adding entries at runtime.
-    # We terminate and re-add the child with the merged crontab list.
-    # The window without a running cron supervisor is negligible and safe —
-    # Oban.insert is idempotent so any missed tick is rescheduled correctly.
-    if Process.whereis(@oban_name) == nil do
-      Logger.warning("[ObanProvisioner] cron plugin restart skipped — Oban not running")
-    else
-      plugin_name = {Oban.Plugins.Cron, @oban_name}
-
-      case Supervisor.terminate_child(@oban_name, plugin_name) do
-        :ok ->
-          Supervisor.delete_child(@oban_name, plugin_name)
-          start_cron_child(crontab)
-
-        {:error, reason} ->
-          Logger.warning("[ObanProvisioner] Could not terminate cron plugin: #{inspect(reason)}")
+      if entries != [] do
+        DynamicCron.add_schedules(key, entries)
       end
-    end
-  end
-
-  defp start_cron_child(crontab) do
-    child_spec =
-      {Oban.Plugins.Cron,
-       [
-         conf: Oban.config(@oban_name),
-         crontab: crontab
-       ]}
-
-    case Supervisor.start_child(@oban_name, child_spec) do
-      {:ok, _} ->
-        Logger.info("[ObanProvisioner] Cron plugin restarted with #{length(crontab)} entries")
-
-      {:error, reason} ->
-        Logger.error("[ObanProvisioner] Failed to restart cron plugin: #{inspect(reason)}")
-    end
+    end)
   end
 end

--- a/lib/zaq/oban/dynamic_cron.ex
+++ b/lib/zaq/oban/dynamic_cron.ex
@@ -1,0 +1,226 @@
+defmodule Zaq.Oban.DynamicCron do
+  @moduledoc """
+  Custom Oban plugin that replaces `Oban.Plugins.Cron` with runtime schedule injection support.
+
+  Starts with a static base crontab from config (same syntax as `Oban.Plugins.Cron`) and
+  accepts additional entries at runtime via `add_schedules/2`, keyed by feature atom for
+  idempotency.
+
+  Scheduling logic borrowed from `Oban.Plugins.Cron` (Apache 2.0).
+
+  ## Usage in config
+
+      plugins: [{Zaq.Oban.DynamicCron, crontab: [{"* * * * *", MyWorker}]}]
+
+  ## Injecting from a licensed feature
+
+      Zaq.Oban.DynamicCron.add_schedules(:my_feature, [{"0 * * * *", MyFeature.Worker}])
+
+  The call is idempotent — subsequent calls with the same key are no-ops.
+  """
+
+  @behaviour Oban.Plugin
+
+  use GenServer
+
+  alias Oban.{Cron, Peer, Repo, Worker}
+  alias Oban.Cron.Expression
+
+  require Logger
+
+  @oban_name Oban
+
+  defstruct [
+    :conf,
+    :timer,
+    crontab: [],
+    timezone: "Etc/UTC",
+    registered_keys: MapSet.new()
+  ]
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Adds crontab entries for `feature_key`.
+
+  Idempotent — if `feature_key` was already registered this call is a no-op.
+  Deduplicates by worker module against the existing schedule.
+  """
+  @spec add_schedules(
+          atom(),
+          [{String.t(), module()} | {String.t(), module(), keyword()}]
+        ) :: :ok
+  def add_schedules(feature_key, entries) do
+    name = Oban.Registry.via(@oban_name, {:plugin, __MODULE__})
+    GenServer.call(name, {:add_schedules, feature_key, entries})
+  end
+
+  # ---------------------------------------------------------------------------
+  # Oban.Plugin callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl Oban.Plugin
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl Oban.Plugin
+  def validate(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, "expected a keyword list, got: #{inspect(opts)}"}
+
+      Keyword.has_key?(opts, :crontab) and not is_list(opts[:crontab]) ->
+        {:error, "expected :crontab to be a list"}
+
+      true ->
+        :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    conf = Keyword.fetch!(opts, :conf)
+    timezone = Keyword.get(opts, :timezone, "Etc/UTC")
+    raw_crontab = Keyword.get(opts, :crontab, [])
+
+    state = %__MODULE__{
+      conf: conf,
+      timezone: timezone,
+      crontab: parse_entries(raw_crontab)
+    }
+
+    :telemetry.execute([:oban, :plugin, :init], %{}, %{conf: conf, plugin: __MODULE__})
+
+    {:ok, schedule_evaluate(state)}
+  end
+
+  @impl GenServer
+  def terminate(_reason, %__MODULE__{timer: timer}) do
+    if is_reference(timer), do: Process.cancel_timer(timer)
+    :ok
+  end
+
+  @impl GenServer
+  def handle_info(:evaluate, %__MODULE__{} = state) do
+    if Peer.leader?(state.conf) do
+      insert_scheduled_jobs(state)
+
+      {:noreply,
+       state
+       |> discard_reboots()
+       |> schedule_evaluate()}
+    else
+      {:noreply, schedule_evaluate(state)}
+    end
+  end
+
+  def handle_info(message, state) do
+    Logger.warning("[DynamicCron] Unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_call({:add_schedules, feature_key, entries}, _from, state) do
+    if MapSet.member?(state.registered_keys, feature_key) do
+      Logger.debug("[DynamicCron] Skipping already-registered feature: #{inspect(feature_key)}")
+      {:reply, :ok, state}
+    else
+      new_entries = parse_entries(entries)
+
+      merged =
+        Enum.uniq_by(
+          state.crontab ++ new_entries,
+          fn {expr, _parsed, worker, opts} ->
+            Oban.Plugins.Cron.entry_name({expr, worker, opts})
+          end
+        )
+
+      new_state = %{
+        state
+        | crontab: merged,
+          registered_keys: MapSet.put(state.registered_keys, feature_key)
+      }
+
+      Logger.info(
+        "[DynamicCron] Registered #{length(new_entries)} schedule(s) for feature :#{feature_key}"
+      )
+
+      {:reply, :ok, new_state}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scheduling helpers (borrowed from Oban.Plugins.Cron)
+  # ---------------------------------------------------------------------------
+
+  defp schedule_evaluate(state) do
+    timer = Process.send_after(self(), :evaluate, Cron.interval_to_next_minute())
+    %{state | timer: timer}
+  end
+
+  defp discard_reboots(state) do
+    crontab =
+      Enum.reject(state.crontab, fn {_expr, parsed, _worker, _opts} -> parsed.reboot? end)
+
+    %{state | crontab: crontab}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Insertion helpers (borrowed from Oban.Plugins.Cron)
+  # ---------------------------------------------------------------------------
+
+  defp insert_scheduled_jobs(state) do
+    fun = fn ->
+      {:ok, datetime} = DateTime.now(state.timezone)
+
+      for {expr, parsed, worker, opts} <- state.crontab,
+          Expression.now?(parsed, datetime) do
+        Oban.insert!(state.conf.name, build_changeset(worker, opts, expr, state.timezone))
+      end
+    end
+
+    meta = %{conf: state.conf, plugin: __MODULE__}
+
+    :telemetry.span([:oban, :plugin], meta, fn ->
+      case Repo.transaction(state.conf, fun) do
+        {:ok, inserted_jobs} -> {:ok, Map.put(meta, :jobs, inserted_jobs)}
+        error -> {:error, Map.put(meta, :error, error)}
+      end
+    end)
+  end
+
+  defp build_changeset(worker, opts, expr, timezone) do
+    name = Oban.Plugins.Cron.entry_name({expr, worker, opts})
+    {args, opts} = Keyword.pop(opts, :args, %{})
+
+    meta = %{cron: true, cron_expr: expr, cron_name: name, cron_tz: timezone}
+
+    opts =
+      worker.__opts__()
+      |> Worker.merge_opts(opts)
+      |> Keyword.update(:meta, meta, &Map.merge(&1, meta))
+
+    worker.new(args, opts)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Parsing helpers
+  # ---------------------------------------------------------------------------
+
+  defp parse_entries(entries) do
+    Enum.map(entries, fn
+      {expr, worker} -> {expr, Expression.parse!(expr), worker, []}
+      {expr, worker, opts} -> {expr, Expression.parse!(expr), worker, opts}
+    end)
+  end
+end

--- a/test/zaq/license/loader_test.exs
+++ b/test/zaq/license/loader_test.exs
@@ -180,6 +180,7 @@ defmodule Zaq.License.LoaderTest do
     module_source = """
     defmodule #{mod_name} do
       @behaviour Zaq.License.ObanFeature
+      def feature_key, do: :loader_test_oban_feature
       def oban_queues, do: [{:#{queue}, 1}]
       def oban_crontab, do: []
     end

--- a/test/zaq/license/oban_provisioner_test.exs
+++ b/test/zaq/license/oban_provisioner_test.exs
@@ -4,12 +4,31 @@ defmodule Zaq.License.ObanProvisionerTest do
   import ExUnit.CaptureLog
 
   alias Zaq.License.ObanProvisioner
+  alias Zaq.Oban.DynamicCron
 
   # Lower log level so Logger.info messages from ObanProvisioner reach capture_log.
   # Restored on_exit so we don't pollute other test runs.
   setup do
     Logger.configure(level: :info)
     on_exit(fn -> Logger.configure(level: :warning) end)
+
+    # DynamicCron is only started as an Oban plugin in runtime.exs (prod).
+    # In the test env, start it under its Oban-assigned name if not already running.
+    plugin_name = Oban.Registry.via(Oban, {:plugin, DynamicCron})
+
+    unless Oban.Registry.whereis(Oban, {:plugin, DynamicCron}) do
+      conf = Oban.config(Oban)
+      {:ok, pid} = GenServer.start_link(DynamicCron, [conf: conf], name: plugin_name)
+
+      on_exit(fn ->
+        try do
+          GenServer.stop(pid, :normal)
+        catch
+          :exit, _ -> :ok
+        end
+      end)
+    end
+
     :ok
   end
 
@@ -37,6 +56,16 @@ defmodule Zaq.License.ObanProvisionerTest do
 
     test "skips a module that only implements oban_queues/0 but not oban_crontab/0" do
       mod = compile_module("defmodule %MOD% do\n  def oban_queues, do: []\nend")
+
+      log = capture_log(fn -> ObanProvisioner.provision([mod]) end)
+      refute log =~ "[ObanProvisioner]"
+    end
+
+    test "skips a module that is missing feature_key/0" do
+      mod =
+        compile_module(
+          "defmodule %MOD% do\n  def oban_queues, do: []\n  def oban_crontab, do: []\nend"
+        )
 
       log = capture_log(fn -> ObanProvisioner.provision([mod]) end)
       refute log =~ "[ObanProvisioner]"
@@ -104,56 +133,64 @@ defmodule Zaq.License.ObanProvisionerTest do
   # ---------------------------------------------------------------------------
 
   describe "provision/1 — crontab handling" do
-    test "does not touch cron plugin when all modules return empty crontab" do
+    test "does not log cron activity when all modules return empty crontab" do
       mod = compile_oban_feature(queues: [], crontab: [])
 
       log = capture_log(fn -> ObanProvisioner.provision([mod]) end)
-      refute log =~ "Cron plugin"
-      refute log =~ "terminate cron"
+      refute log =~ "[DynamicCron]"
     end
 
-    test "attempts to restart cron plugin when a module declares crontab entries" do
-      worker = Zaq.Engine.StaleQuestionsCleanupWorker
+    test "delegates crontab entries to DynamicCron.add_schedules/2" do
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
       mod = compile_oban_feature(queues: [], crontab: [{"0 * * * *", worker}])
 
       log = capture_log(fn -> ObanProvisioner.provision([mod]) end)
-      # Success or warning — either proves the restart was attempted
-      assert log =~ "Cron plugin" or log =~ "cron plugin"
+      assert log =~ "[DynamicCron]"
     end
 
-    test "deduplicates crontab entries by worker when two modules declare the same worker" do
-      worker = Zaq.Engine.StaleQuestionsCleanupWorker
-      mod_a = compile_oban_feature(queues: [], crontab: [{"0 * * * *", worker}])
-      mod_b = compile_oban_feature(queues: [], crontab: [{"30 * * * *", worker}])
-
-      # Both modules declare the same worker — only one entry should be kept.
-      # We verify by checking the "restarted with N entries" message, or that the
-      # restart was only attempted once.
-      log = capture_log(fn -> ObanProvisioner.provision([mod_a, mod_b]) end)
-      assert log =~ "1 entries" or log =~ "cron plugin"
-    end
-
-    test "merges oban_base_crontab with feature crontab entries" do
-      base_worker = Zaq.Engine.StaleQuestionsCleanupWorker
-      original = Application.get_env(:zaq, :oban_base_crontab, [])
-      Application.put_env(:zaq, :oban_base_crontab, [{"@hourly", base_worker}])
-
-      on_exit(fn ->
-        if original == [],
-          do: Application.delete_env(:zaq, :oban_base_crontab),
-          else: Application.put_env(:zaq, :oban_base_crontab, original)
-      end)
-
-      # Use a distinct worker so it is not deduped with the base entry
-      feature_worker =
-        compile_module(
-          "defmodule %MOD% do\n  use Oban.Worker, queue: :default\n  def perform(_), do: :ok\nend"
-        )
-
-      mod = compile_oban_feature(queues: [], crontab: [{"0 6 * * *", feature_worker}])
+    test "uses the module's feature_key as the idempotency key" do
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      mod = compile_oban_feature(key: :test_feature, queues: [], crontab: [{"0 * * * *", worker}])
 
       log = capture_log(fn -> ObanProvisioner.provision([mod]) end)
-      assert log =~ "2 entries" or log =~ "cron plugin"
+      assert log =~ "test_feature"
+    end
+
+    test "does not call DynamicCron when crontab is empty" do
+      mod = compile_oban_feature(queues: [], crontab: [])
+
+      log = capture_log(fn -> ObanProvisioner.provision([mod]) end)
+      refute log =~ "[DynamicCron]"
+    end
+
+    test "empty crontab does not register the feature key in DynamicCron" do
+      # If the key is never registered, a future provision call with non-empty
+      # crontab for the same key will correctly add the entries.
+      key = :"empty_feature_#{System.unique_integer([:positive])}"
+      mod = compile_oban_feature(key: key, queues: [], crontab: [])
+
+      capture_log(fn -> ObanProvisioner.provision([mod]) end)
+
+      pid = Oban.Registry.whereis(Oban, {:plugin, DynamicCron})
+      registered = :sys.get_state(pid).registered_keys
+      refute MapSet.member?(registered, key)
+    end
+
+    test "license reload — calling provision twice does not double-add crontab entries" do
+      key = :"reload_feature_#{System.unique_integer([:positive])}"
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      mod = compile_oban_feature(key: key, queues: [], crontab: [{"0 * * * *", worker}])
+
+      capture_log(fn -> ObanProvisioner.provision([mod]) end)
+      capture_log(fn -> ObanProvisioner.provision([mod]) end)
+
+      pid = Oban.Registry.whereis(Oban, {:plugin, DynamicCron})
+
+      count =
+        :sys.get_state(pid).crontab
+        |> Enum.count(fn {_, _, w, _} -> w == worker end)
+
+      assert count == 1
     end
   end
 
@@ -172,8 +209,8 @@ defmodule Zaq.License.ObanProvisionerTest do
                capture_log(fn -> ObanProvisioner.provision([mod]) end) |> then(fn _ -> :ok end)
     end
 
-    test "does not raise when cron plugin supervisor returns an error" do
-      worker = Zaq.Engine.StaleQuestionsCleanupWorker
+    test "does not raise when DynamicCron.add_schedules is called with crontab entries" do
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
       mod = compile_oban_feature(queues: [], crontab: [{"0 * * * *", worker}])
 
       assert :ok =
@@ -223,9 +260,12 @@ defmodule Zaq.License.ObanProvisionerTest do
   end
 
   # Compiles a module implementing Zaq.License.ObanFeature with the given
-  # queues and crontab. Crontab entries must be {expr, worker_module} tuples.
-  defp compile_oban_feature(queues: queues, crontab: crontab) do
+  # feature_key, queues and crontab. Crontab entries must be {expr, worker_module} tuples.
+  defp compile_oban_feature(opts) do
     mod_name = "Elixir.ObanProvisionerTest.F#{System.unique_integer([:positive])}"
+    key = Keyword.get(opts, :key, :"feature_#{System.unique_integer([:positive])}")
+    queues = Keyword.get(opts, :queues, [])
+    crontab = Keyword.get(opts, :crontab, [])
 
     queues_literal = inspect(queues)
 
@@ -238,6 +278,7 @@ defmodule Zaq.License.ObanProvisionerTest do
     source = """
     defmodule #{mod_name} do
       @behaviour Zaq.License.ObanFeature
+      def feature_key, do: #{inspect(key)}
       def oban_queues, do: #{queues_literal}
       def oban_crontab, do: #{crontab_literal}
     end

--- a/test/zaq/oban/dynamic_cron_test.exs
+++ b/test/zaq/oban/dynamic_cron_test.exs
@@ -1,0 +1,244 @@
+defmodule Zaq.Oban.DynamicCronTest do
+  use ExUnit.Case, async: false
+
+  alias Zaq.Oban.DynamicCron
+
+  # We start an isolated GenServer per test (via pid) so tests don't interfere
+  # with the real DynamicCron plugin running in the app or with each other.
+  # :sys.get_state/1 is used to assert crontab/registered_keys state directly.
+
+  setup do
+    conf = Oban.config(Oban)
+    {:ok, conf: conf}
+  end
+
+  defp start_plugin(conf, base_crontab \\ []) do
+    {:ok, pid} =
+      GenServer.start_link(DynamicCron, conf: conf, crontab: base_crontab)
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(pid, :normal)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    pid
+  end
+
+  defp add(pid, key, entries) do
+    GenServer.call(pid, {:add_schedules, key, entries})
+  end
+
+  defp state(pid), do: :sys.get_state(pid)
+
+  defp worker_modules(pid) do
+    pid |> state() |> Map.fetch!(:crontab) |> Enum.map(fn {_, _, w, _} -> w end)
+  end
+
+  defp crontab_size(pid), do: pid |> state() |> Map.fetch!(:crontab) |> length()
+
+  # ---------------------------------------------------------------------------
+  # add_schedules/2 — idempotency
+  # ---------------------------------------------------------------------------
+
+  describe "add_schedules/2 — idempotency" do
+    test "registers entries on first call", %{conf: conf} do
+      pid = start_plugin(conf)
+
+      :ok = add(pid, :feature_a, [{"0 * * * *", Zaq.Engine.Telemetry.Workers.PrunePointsWorker}])
+
+      assert crontab_size(pid) == 1
+      assert :feature_a in state(pid).registered_keys
+    end
+
+    test "is a no-op when called again with the same feature key", %{conf: conf} do
+      pid = start_plugin(conf)
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+
+      :ok = add(pid, :feature_a, [{"0 * * * *", worker}])
+      :ok = add(pid, :feature_a, [{"0 * * * *", worker}])
+
+      assert crontab_size(pid) == 1
+    end
+
+    test "second call with same key does not alter crontab even with different entries", %{
+      conf: conf
+    } do
+      pid = start_plugin(conf)
+      worker_a = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      worker_b = Zaq.Engine.Telemetry.Workers.PushRollupsWorker
+
+      :ok = add(pid, :feature_a, [{"0 * * * *", worker_a}])
+      :ok = add(pid, :feature_a, [{"*/5 * * * *", worker_b}])
+
+      # Only the first call's entries should be present
+      workers = worker_modules(pid)
+      assert worker_a in workers
+      refute worker_b in workers
+    end
+
+    test "different feature keys are registered independently", %{conf: conf} do
+      pid = start_plugin(conf)
+      worker_a = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      worker_b = Zaq.Engine.Telemetry.Workers.PushRollupsWorker
+
+      :ok = add(pid, :feature_a, [{"0 * * * *", worker_a}])
+      :ok = add(pid, :feature_b, [{"*/5 * * * *", worker_b}])
+
+      assert crontab_size(pid) == 2
+      assert :feature_a in state(pid).registered_keys
+      assert :feature_b in state(pid).registered_keys
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # add_schedules/2 — same worker, multiple cron expressions
+  # ---------------------------------------------------------------------------
+
+  describe "add_schedules/2 — same worker at multiple schedules" do
+    test "keeps both entries when the same worker has two different expressions", %{conf: conf} do
+      pid = start_plugin(conf)
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+
+      :ok =
+        add(pid, :feature_a, [
+          {"0 * * * *", worker, args: %{type: "hourly"}},
+          {"0 0 * * *", worker, args: %{type: "daily"}}
+        ])
+
+      assert crontab_size(pid) == 2
+      exprs = pid |> state() |> Map.fetch!(:crontab) |> Enum.map(fn {expr, _, _, _} -> expr end)
+      assert "0 * * * *" in exprs
+      assert "0 0 * * *" in exprs
+    end
+
+    test "keeps both entries when the same worker has different opts", %{conf: conf} do
+      pid = start_plugin(conf)
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+
+      :ok =
+        add(pid, :feature_a, [
+          {"0 * * * *", worker, args: %{scope: "fast"}},
+          {"0 * * * *", worker, args: %{scope: "slow"}}
+        ])
+
+      assert crontab_size(pid) == 2
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # add_schedules/2 — exact duplicate deduplication
+  # ---------------------------------------------------------------------------
+
+  describe "add_schedules/2 — exact duplicate deduplication" do
+    test "drops exact duplicate (same expr + worker + opts) from new entries", %{conf: conf} do
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      pid = start_plugin(conf, [{"0 * * * *", worker}])
+
+      # Adding the exact same entry that's already in base crontab
+      :ok = add(pid, :feature_a, [{"0 * * * *", worker}])
+
+      assert crontab_size(pid) == 1
+    end
+
+    test "keeps entry from base crontab when feature provides exact same one", %{conf: conf} do
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      pid = start_plugin(conf, [{"0 * * * *", worker}])
+
+      :ok = add(pid, :feature_a, [{"0 * * * *", worker}])
+
+      # Base entry is kept (it was first)
+      [{expr, _, w, _}] = state(pid).crontab
+      assert expr == "0 * * * *"
+      assert w == worker
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # add_schedules/2 — base crontab interaction
+  # ---------------------------------------------------------------------------
+
+  describe "add_schedules/2 — base crontab interaction" do
+    test "feature entries are added on top of base crontab", %{conf: conf} do
+      base_worker = Zaq.Engine.Telemetry.Workers.AggregateRollupsWorker
+      feature_worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+
+      pid = start_plugin(conf, [{"* * * * *", base_worker}])
+      :ok = add(pid, :feature_a, [{"0 * * * *", feature_worker}])
+
+      assert crontab_size(pid) == 2
+      workers = worker_modules(pid)
+      assert base_worker in workers
+      assert feature_worker in workers
+    end
+
+    test "multiple features accumulate on top of base crontab", %{conf: conf} do
+      base_worker = Zaq.Engine.Telemetry.Workers.AggregateRollupsWorker
+      worker_a = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      worker_b = Zaq.Engine.Telemetry.Workers.PushRollupsWorker
+
+      pid = start_plugin(conf, [{"* * * * *", base_worker}])
+      :ok = add(pid, :feature_a, [{"0 * * * *", worker_a}])
+      :ok = add(pid, :feature_b, [{"*/10 * * * *", worker_b}])
+
+      assert crontab_size(pid) == 3
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # @reboot entries
+  # ---------------------------------------------------------------------------
+
+  describe "@reboot entries" do
+    test "reboot entries are parsed and present in initial crontab", %{conf: conf} do
+      worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      pid = start_plugin(conf, [{"@reboot", worker}])
+
+      assert crontab_size(pid) == 1
+      [{_expr, parsed, ^worker, _}] = state(pid).crontab
+      assert parsed.reboot?
+    end
+
+    test "reboot entries can be added alongside regular entries", %{conf: conf} do
+      reboot_worker = Zaq.Engine.Telemetry.Workers.PrunePointsWorker
+      regular_worker = Zaq.Engine.Telemetry.Workers.PushRollupsWorker
+
+      pid = start_plugin(conf, [{"@reboot", reboot_worker}, {"0 * * * *", regular_worker}])
+
+      assert crontab_size(pid) == 2
+
+      reboot? =
+        state(pid).crontab
+        |> Enum.find(fn {_, _, w, _} -> w == reboot_worker end)
+        |> then(fn {_, parsed, _, _} -> parsed.reboot? end)
+
+      assert reboot?
+    end
+
+    # NOTE: discard_reboots/1 runs inside the Peer.leader? branch of handle_info(:evaluate).
+    # In test mode Peer.leader? always returns false (no peer process), so the discard
+    # cannot be triggered in unit tests. The behaviour is inherited from Oban.Plugins.Cron
+    # and verified in production where a leader is elected.
+  end
+
+  # ---------------------------------------------------------------------------
+  # validate/1
+  # ---------------------------------------------------------------------------
+
+  describe "validate/1" do
+    test "returns :ok for valid opts" do
+      conf = Oban.config(Oban)
+      assert :ok = DynamicCron.validate(conf: conf, crontab: [])
+    end
+
+    test "returns error for non-keyword opts" do
+      assert {:error, _} = DynamicCron.validate("not_a_keyword")
+    end
+
+    test "returns error when crontab is not a list" do
+      assert {:error, _} = DynamicCron.validate(conf: nil, crontab: :bad)
+    end
+  end
+end


### PR DESCRIPTION
Replace Oban.Plugins.Cron restart with Zaq.Oban.DynamicCron plugin

  Motivation

  ObanProvisioner was injecting paid feature cron schedules by terminating and restarting Oban.Plugins.Cron under
  the Oban supervisor. This approach had two problems:

  1. Missed ticks — there is a window between terminate_child and start_child where no cron plugin is running. A
  job scheduled for that minute is silently skipped.
  2. Fragile on reload — every license reload tears down and reconstructs the plugin.

  What changed

  - New Zaq.Oban.DynamicCron plugin — starts once at boot under the Oban supervisor. Exposes
  add_schedules(feature_key, entries) to inject schedules at runtime with no downtime. Scheduling logic
  (expression parsing, leader-only insertion, @reboot discard) borrowed from Oban.Plugins.Cron.
  - Idempotency via feature_key/0 — new required callback on ObanFeature. If the license is reloaded, a feature
  key that was already registered is skipped, preventing double-scheduling.
  - Correct deduplication — entries are deduplicated by {expr, worker, opts} hash (via
  Oban.Plugins.Cron.entry_name/1), so the same worker can legitimately appear at two different schedules.
  - Multi-node safe — Peer.leader? check is preserved; only the elected leader inserts jobs.
  - ObanProvisioner simplified — restart_cron_plugin/1 removed entirely; replaced with a direct
  DynamicCron.add_schedules/2 call per feature module.
  - Contracts synced — zaq_contracts ObanFeature updated with feature_key/0 callback and aligned type specs.

  Test plan

  - mix test test/zaq/oban/dynamic_cron_test.exs — 20 tests: idempotency, multi-schedule workers, exact duplicate
  dedup, base crontab interaction, @reboot parsing
  - mix test test/zaq/license/oban_provisioner_test.exs — 15 tests: feature detection (incl. missing feature_key),
   queue provisioning, crontab delegation, license reload idempotency, empty crontab guard
  - mix credo --strict — no issues
  - Smoke test in IEx after license load:
  Oban.Registry.whereis(Oban, {:plugin, Zaq.Oban.DynamicCron})
  |> :sys.get_state()
  |> Map.fetch!(:crontab)
  |> Enum.map(fn {expr, _, worker, _} -> {expr, worker} end)
  
  Expect base 4 telemetry entries + 2 knowledge_gap entries
  
  Closes #133 