### PR TITLE
feat(sharing): add public shared conversation view with copy-link UI (#161)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -44,6 +44,23 @@ const liveSocket = new LiveSocket("/live", Socket, {
         this.el.focus()
       }
     },
+    CopyToClipboard: {
+      mounted() {
+        this.el.addEventListener("click", () => {
+          const url = this.el.dataset.shareUrl
+          if (!url) return
+          navigator.clipboard.writeText(url).then(() => {
+            const orig = this.el.textContent
+            this.el.textContent = "Copied!"
+            setTimeout(() => { this.el.textContent = orig }, 1500)
+          }).catch(() => {
+            const orig = this.el.textContent
+            this.el.textContent = "Failed"
+            setTimeout(() => { this.el.textContent = orig }, 1500)
+          })
+        })
+      }
+    },
     ScrollBottom: {
       mounted() {
         this.el.scrollTop = this.el.scrollHeight

--- a/lib/zaq/engine/conversations/conversation_share.ex
+++ b/lib/zaq/engine/conversations/conversation_share.ex
@@ -23,7 +23,7 @@ defmodule Zaq.Engine.Conversations.ConversationShare do
     timestamps(type: :utc_datetime_usec, updated_at: false)
   end
 
-  @valid_permissions ~w[read comment]
+  @valid_permissions ~w[read]
 
   @doc "Changeset for creating a conversation share."
   def changeset(share, attrs) do

--- a/lib/zaq_web/live/bo/communication/conversation_detail_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/conversation_detail_live.html.heex
@@ -131,22 +131,37 @@
           <li
             :for={share <- @shares}
             id={"share-#{share.id}"}
-            class="px-4 py-3 flex items-center justify-between gap-2"
+            class="px-4 py-3 space-y-1.5"
           >
-            <div class="min-w-0">
-              <p class="font-mono text-[0.62rem] text-black/40 truncate">{share.share_token}</p>
+            <div class="flex items-center gap-1.5">
               <span class="font-mono text-[0.62rem] px-1.5 py-0.5 rounded bg-black/5 text-black/40">
                 {share.permission}
               </span>
+              <button
+                phx-click="revoke_share"
+                phx-value-id={share.id}
+                data-confirm="Revoke this share?"
+                class="font-mono text-[0.62rem] text-red-500 hover:underline ml-auto"
+              >
+                Revoke
+              </button>
             </div>
-            <button
-              phx-click="revoke_share"
-              phx-value-id={share.id}
-              data-confirm="Revoke this share?"
-              class="font-mono text-[0.7rem] text-red-500 hover:underline flex-shrink-0"
-            >
-              Revoke
-            </button>
+            <div class="flex items-center gap-1">
+              <input
+                type="text"
+                readonly
+                value={url(~p"/s/#{share.share_token}")}
+                class="font-mono text-[0.6rem] text-black/50 bg-black/[0.03] border border-black/10 rounded px-1.5 py-1 w-full min-w-0 select-all focus:outline-none"
+              />
+              <button
+                id={"copy-#{share.id}"}
+                data-share-url={url(~p"/s/#{share.share_token}")}
+                phx-hook="CopyToClipboard"
+                class="flex-shrink-0 font-mono text-[0.62rem] px-2 py-1 rounded border border-black/10 text-black/50 hover:bg-black/5 transition-colors"
+              >
+                Copy
+              </button>
+            </div>
           </li>
         </ul>
       </div>
@@ -169,7 +184,6 @@
           class="font-mono text-[0.78rem] text-black w-full border border-black/10 rounded-lg px-2.5 py-1.5 bg-white focus:outline-none focus:ring-1 focus:ring-[#03b6d4] mb-5"
         >
           <option value="read">Read</option>
-          <option value="comment">Comment</option>
         </select>
         <div class="flex gap-2 justify-end">
           <button

--- a/lib/zaq_web/live/shared_conversation_live.ex
+++ b/lib/zaq_web/live/shared_conversation_live.ex
@@ -1,0 +1,31 @@
+defmodule ZaqWeb.Live.SharedConversationLive do
+  @moduledoc "Public read-only view for a shared conversation."
+
+  use ZaqWeb, :live_view
+
+  alias Zaq.NodeRouter
+
+  @impl true
+  def mount(%{"token" => token}, _session, socket) do
+    conversation =
+      NodeRouter.call(:engine, Zaq.Engine.Conversations, :get_conversation_by_token, [token])
+
+    case conversation do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Share link is invalid or has been revoked.")
+         |> redirect(to: ~p"/")}
+
+      conv ->
+        messages =
+          NodeRouter.call(:engine, Zaq.Engine.Conversations, :list_messages, [conv])
+
+        {:ok,
+         socket
+         |> assign(:page_title, conv.title || "Shared Conversation")
+         |> assign(:conversation, conv)
+         |> assign(:messages, messages), layout: {ZaqWeb.Layouts, :root}}
+    end
+  end
+end

--- a/lib/zaq_web/live/shared_conversation_live.html.heex
+++ b/lib/zaq_web/live/shared_conversation_live.html.heex
@@ -1,0 +1,34 @@
+<div class="min-h-screen bg-[#f7f6f3]">
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <div class="mb-6">
+      <p class="font-mono text-[0.7rem] text-black/40 uppercase tracking-wider mb-1">
+        Shared Conversation
+      </p>
+      <h1 class="font-mono text-lg font-bold text-[#2c3a50]">
+        {@conversation.title || "Untitled"}
+      </h1>
+    </div>
+
+    <div class="space-y-5">
+      <div :for={msg <- @messages}>
+        <ZaqWeb.Components.ChatMessage.user_bubble
+          :if={msg.role == "user"}
+          content={msg.content}
+          timestamp={msg.inserted_at}
+        />
+        <ZaqWeb.Components.ChatMessage.assistant_bubble
+          :if={msg.role != "user"}
+          content={msg.content}
+          timestamp={msg.inserted_at}
+          html_content={true}
+          confidence={msg.confidence_score}
+          sources={[]}
+        />
+      </div>
+
+      <div :if={@messages == []} class="py-16 text-center">
+        <p class="font-mono text-sm text-black/30">No messages yet.</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/zaq_web/router.ex
+++ b/lib/zaq_web/router.ex
@@ -24,6 +24,7 @@ defmodule ZaqWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    live "/s/:token", Live.SharedConversationLive
   end
 
   scope "/api", ZaqWeb do

--- a/test/zaq/engine/conversations/schemas_test.exs
+++ b/test/zaq/engine/conversations/schemas_test.exs
@@ -260,16 +260,14 @@ defmodule Zaq.Engine.Conversations.SchemasTest do
       assert %{permission: _} = errors_on(cs)
     end
 
-    test "accepts both valid permissions" do
-      for p <- ~w[read comment] do
-        cs =
-          ConversationShare.changeset(%ConversationShare{}, %{
-            conversation_id: @valid_conv_id,
-            permission: p
-          })
+    test "accepts valid permission" do
+      cs =
+        ConversationShare.changeset(%ConversationShare{}, %{
+          conversation_id: @valid_conv_id,
+          permission: "read"
+        })
 
-        assert cs.valid?, "expected permission #{p} to be valid"
-      end
+      assert cs.valid?
     end
 
     test "does not overwrite existing share_token" do

--- a/test/zaq/engine/conversations_test.exs
+++ b/test/zaq/engine/conversations_test.exs
@@ -334,11 +334,11 @@ defmodule Zaq.Engine.ConversationsTest do
       assert {:ok, share} =
                Conversations.share_conversation(conv, %{
                  shared_with_user_id: user.id,
-                 permission: "comment"
+                 permission: "read"
                })
 
       assert share.shared_with_user_id == user.id
-      assert share.permission == "comment"
+      assert share.permission == "read"
     end
 
     test "token is unique across shares" do
@@ -551,7 +551,7 @@ defmodule Zaq.Engine.ConversationsTest do
     test "returns all shares for a conversation" do
       {:ok, conv} = Conversations.create_conversation(conv_attrs())
       {:ok, _s1} = Conversations.share_conversation(conv, %{permission: "read"})
-      {:ok, _s2} = Conversations.share_conversation(conv, %{permission: "comment"})
+      {:ok, _s2} = Conversations.share_conversation(conv, %{permission: "read"})
 
       shares = Conversations.list_shares(conv)
       assert length(shares) == 2

--- a/test/zaq_web/live/bo/communication/conversation_detail_live_test.exs
+++ b/test/zaq_web/live/bo/communication/conversation_detail_live_test.exs
@@ -81,7 +81,7 @@ defmodule ZaqWeb.Live.BO.Communication.ConversationDetailLiveTest do
       assert html =~ "Share Conversation"
     end
 
-    test "creates a share and shows token", %{conn: conn, user: user} do
+    test "creates a share and shows link with copy button", %{conn: conn, user: user} do
       {conv, _} = create_conv_with_messages(user.id)
       {:ok, view, _html} = live(conn, ~p"/bo/conversations/#{conv.id}")
 
@@ -94,7 +94,11 @@ defmodule ZaqWeb.Live.BO.Communication.ConversationDetailLiveTest do
 
       shares = Conversations.list_shares(conv)
       assert length(shares) == 1
-      assert html =~ shares |> hd() |> Map.get(:share_token)
+
+      share = hd(shares)
+      assert html =~ "/s/#{share.share_token}"
+      assert has_element?(view, "#copy-#{share.id}")
+      assert has_element?(view, "#copy-#{share.id}[phx-hook='CopyToClipboard']")
     end
 
     test "revokes a share", %{conn: conn, user: user} do

--- a/test/zaq_web/live/shared_conversation_live_test.exs
+++ b/test/zaq_web/live/shared_conversation_live_test.exs
@@ -1,0 +1,86 @@
+defmodule ZaqWeb.Live.SharedConversationLiveTest do
+  use ZaqWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Zaq.Engine.Conversations
+
+  defp create_shared_conversation do
+    {:ok, conv} =
+      Conversations.create_conversation(%{
+        channel_type: "bo",
+        channel_user_id: "u_#{System.unique_integer([:positive])}",
+        title: "Shared Test Conv"
+      })
+
+    {:ok, _} = Conversations.add_message(conv, %{role: "user", content: "Hello from user"})
+
+    {:ok, _} =
+      Conversations.add_message(conv, %{
+        role: "assistant",
+        content: "Hello from assistant.",
+        model: "gpt-4",
+        confidence_score: 0.85
+      })
+
+    {:ok, share} = Conversations.share_conversation(conv, %{permission: "read"})
+
+    {conv, share}
+  end
+
+  describe "mount" do
+    test "renders shared conversation with messages", %{conn: conn} do
+      {_conv, share} = create_shared_conversation()
+
+      {:ok, _view, html} = live(conn, ~p"/s/#{share.share_token}")
+
+      assert html =~ "Shared Conversation"
+      assert html =~ "Shared Test Conv"
+      assert html =~ "Hello from user"
+      assert html =~ "Hello from assistant."
+    end
+
+    test "redirects for invalid token", %{conn: conn} do
+      {:error, {:redirect, %{to: path}}} = live(conn, ~p"/s/bogus-token-value")
+
+      assert path == "/"
+    end
+
+    test "is accessible without authentication", %{conn: conn} do
+      {_conv, share} = create_shared_conversation()
+
+      {:ok, _view, html} = live(conn, ~p"/s/#{share.share_token}")
+
+      assert html =~ "Shared Test Conv"
+    end
+
+    test "redirects after share is revoked", %{conn: conn} do
+      {_conv, share} = create_shared_conversation()
+
+      {:ok, _view, _html} = live(conn, ~p"/s/#{share.share_token}")
+
+      Conversations.revoke_share(share)
+
+      {:error, {:redirect, %{to: path}}} = live(conn, ~p"/s/#{share.share_token}")
+      assert path == "/"
+    end
+  end
+
+  describe "read-only view" do
+    test "does not show rating buttons", %{conn: conn} do
+      {_conv, share} = create_shared_conversation()
+
+      {:ok, view, _html} = live(conn, ~p"/s/#{share.share_token}")
+
+      refute has_element?(view, "button[phx-click='rate_message']")
+    end
+
+    test "does not show share button", %{conn: conn} do
+      {_conv, share} = create_shared_conversation()
+
+      {:ok, view, _html} = live(conn, ~p"/s/#{share.share_token}")
+
+      refute has_element?(view, "button", "Share")
+    end
+  end
+end


### PR DESCRIPTION

  - Add /s/:token public route rendering shared conversations read-only
  - Show full share URL in conversation detail panel with copy-to-clipboard button
  - Add CopyToClipboard JS hook with "Copied!" feedback
  - Cover with LiveView tests for both shared view and updated detail panel

Closes #161