### PR TITLE
fix(sidebar): refresh locked menu items on license activation (#159)

### DIFF
--- a/lib/zaq_web/components/bo_layout.ex
+++ b/lib/zaq_web/components/bo_layout.ex
@@ -12,6 +12,7 @@ defmodule ZaqWeb.Components.BOLayout do
   attr :page_title, :string, default: "Dashboard"
   attr :current_path, :string, default: ""
   attr :flash, :map, default: %{}
+  attr :features_version, :integer, default: 0
   slot :inner_block, required: true
 
   def bo_layout(assigns) do
@@ -268,14 +269,14 @@ defmodule ZaqWeb.Components.BOLayout do
               icon="ontology"
               label="Ontology"
               active={String.starts_with?(@current_path, "/bo/ontology")}
-              locked={feature_locked?("ontology")}
+              locked={feature_locked?("ontology", @features_version)}
             />
             <:item
               href={~p"/bo/knowledge-gap"}
               icon="knowledge_gap"
               label="Knowledge Gap"
               active={@current_path == "/bo/knowledge-gap"}
-              locked={feature_locked?("knowledge_gap")}
+              locked={feature_locked?("knowledge_gap", @features_version)}
             />
           </.nav_section>
           
@@ -963,7 +964,7 @@ defmodule ZaqWeb.Components.BOLayout do
     """
   end
 
-  defp feature_locked?(feature) do
+  defp feature_locked?(feature, _features_version) do
     not FeatureStore.feature_loaded?(feature)
   end
 end

--- a/lib/zaq_web/live/bo/accounts/profile_live.html.heex
+++ b/lib/zaq_web/live/bo/accounts/profile_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title={@page_title}
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div class="max-w-2xl space-y-6">
     <div class="bg-white rounded-2xl border border-black/[0.06] shadow-sm overflow-hidden">

--- a/lib/zaq_web/live/bo/accounts/roles_live.html.heex
+++ b/lib/zaq_web/live/bo/accounts/roles_live.html.heex
@@ -5,6 +5,7 @@
   flash={@flash}
   page_title="Roles"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div class="flex justify-between items-center mb-6">
     <p class="font-mono text-sm text-black/40">{length(@roles)} roles</p>

--- a/lib/zaq_web/live/bo/accounts/users_live.html.heex
+++ b/lib/zaq_web/live/bo/accounts/users_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="Users"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div class="flex justify-between items-center mb-6">
     <p class="font-mono text-sm text-black/50">{length(@users)} users</p>

--- a/lib/zaq_web/live/bo/ai/ai_diagnostics_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/ai_diagnostics_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="AI Diagnostics"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <!-- Metric Cards -->
   <div class="grid grid-cols-4 gap-4 mb-8">

--- a/lib/zaq_web/live/bo/ai/file_preview_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/file_preview_live.html.heex
@@ -4,6 +4,7 @@
   flash={@flash}
   page_title={@filename}
   current_path={@current_path}
+  features_version={@features_version}
 >
   <!-- Header bar -->
   <div class="flex items-center justify-between mb-6">

--- a/lib/zaq_web/live/bo/ai/ingestion_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/ingestion_live.html.heex
@@ -4,6 +4,7 @@
   flash={@flash}
   page_title="Ingestion"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div class="grid grid-cols-3 gap-6">
     <%!-- =============== LEFT: File Browser + Upload =============== --%>

--- a/lib/zaq_web/live/bo/ai/knowledge_gap_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/knowledge_gap_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="Knowledge Gap"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <ZaqWeb.Components.BOLayout.feature_gate
     :if={not @licensed}

--- a/lib/zaq_web/live/bo/ai/ontology_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/ontology_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="Ontology"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <ZaqWeb.Components.BOLayout.feature_gate :if={not @licensed} feature_name="Ontology" />
 </ZaqWeb.Components.BOLayout.bo_layout>

--- a/lib/zaq_web/live/bo/ai/prompt_templates_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/prompt_templates_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="Prompt Templates"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <!-- Tabs -->
   <div class="flex items-center gap-1 mb-6 border-b border-black/10">

--- a/lib/zaq_web/live/bo/auth_hook.ex
+++ b/lib/zaq_web/live/bo/auth_hook.ex
@@ -20,8 +20,27 @@ defmodule ZaqWeb.Live.BO.AuthHook do
         if user.must_change_password and socket.view != ZaqWeb.Live.BO.System.ChangePasswordLive do
           {:halt, push_navigate(socket, to: ~p"/bo/change-password")}
         else
-          {:cont, assign(socket, :current_user, user)}
+          {:cont, setup_license_hook(socket, user)}
         end
     end
+  end
+
+  defp setup_license_hook(socket, user) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Zaq.PubSub, "license:updated")
+    end
+
+    socket
+    |> assign(:current_user, user)
+    |> assign(:features_version, 0)
+    |> attach_hook(:license_updated, :handle_info, &handle_license_updated/2)
+  end
+
+  defp handle_license_updated(:license_updated, socket) do
+    {:cont, assign(socket, :features_version, socket.assigns.features_version + 1)}
+  end
+
+  defp handle_license_updated(_msg, socket) do
+    {:cont, socket}
   end
 end

--- a/lib/zaq_web/live/bo/communication/channels_index_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/channels_index_live.html.heex
@@ -11,6 +11,7 @@
     flash={@flash}
     page_title={@page_title}
     current_path={@current_path}
+    features_version={@features_version}
   >
     <%= if @kind == :index do %>
       <!-- ============================================================== -->

--- a/lib/zaq_web/live/bo/communication/channels_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/channels_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title={@provider_label}
   current_path={@current_path}
+  features_version={@features_version}
 >
   <!-- Back nav + Header -->
   <div class="mb-6">

--- a/lib/zaq_web/live/bo/communication/chat_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/chat_live.html.heex
@@ -11,6 +11,7 @@
     flash={@flash}
     page_title="Chat"
     current_path={@current_path}
+    features_version={@features_version}
   >
     <style>
       @keyframes slide-in-right {

--- a/lib/zaq_web/live/bo/communication/conversation_detail_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/conversation_detail_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title={@conversation.title || "Conversation"}
   current_path={@current_path}
+  features_version={@features_version}
 >
   <style>
     @keyframes slide-in-right {

--- a/lib/zaq_web/live/bo/communication/conversations_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/conversations_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="Conversations"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <%!-- Toolbar --%>
   <div class="flex items-center justify-between mb-6">

--- a/lib/zaq_web/live/bo/communication/history_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/history_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="History"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <%!-- Toolbar --%>
   <div class="flex items-center justify-between mb-6">

--- a/lib/zaq_web/live/bo/communication/notification_email_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/notification_email_live.html.heex
@@ -11,6 +11,7 @@
     flash={@flash}
     page_title={@page_title}
     current_path={@current_path}
+    features_version={@features_version}
   >
     <div class="mb-6">
       <.link

--- a/lib/zaq_web/live/bo/communication/notification_logs_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/notification_logs_live.html.heex
@@ -11,6 +11,7 @@
     flash={@flash}
     page_title={@page_title}
     current_path={@current_path}
+    features_version={@features_version}
   >
     <div class="mb-6">
       <.link

--- a/lib/zaq_web/live/bo/communication/notification_smtp_live.html.heex
+++ b/lib/zaq_web/live/bo/communication/notification_smtp_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title={@page_title}
   current_path={@current_path}
+  features_version={@features_version}
 >
   <!-- Breadcrumb -->
   <div class="mb-6">

--- a/lib/zaq_web/live/bo/conversations_metrics_live.html.heex
+++ b/lib/zaq_web/live/bo/conversations_metrics_live.html.heex
@@ -2,6 +2,7 @@
   current_user={@current_user}
   page_title="Conversations Metrics"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div id="conversations-metrics-page" class="space-y-6">
     <section class="rounded-xl border border-black/10 bg-white p-4">

--- a/lib/zaq_web/live/bo/dashboard_live.html.heex
+++ b/lib/zaq_web/live/bo/dashboard_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="Dashboard"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <%!-- <div class="mb-4 flex flex-col gap-3 rounded-xl border border-black/10 bg-white p-4 md:flex-row md:items-center md:justify-between">
     <p class="font-mono text-[0.7rem] text-black/45">

--- a/lib/zaq_web/live/bo/knowledge_base_metrics_live.html.heex
+++ b/lib/zaq_web/live/bo/knowledge_base_metrics_live.html.heex
@@ -2,6 +2,7 @@
   current_user={@current_user}
   page_title="Knowledge Base Metrics"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div id="knowledge-base-metrics-page" class="space-y-6">
     <section class="rounded-xl border border-black/10 bg-white p-4">

--- a/lib/zaq_web/live/bo/llm_performance_live.html.heex
+++ b/lib/zaq_web/live/bo/llm_performance_live.html.heex
@@ -2,6 +2,7 @@
   current_user={@current_user}
   page_title="LLM Performance"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div id="llm-performance-page" class="space-y-6">
     <section class="rounded-xl border border-black/10 bg-white p-4">

--- a/lib/zaq_web/live/bo/system/license_live.html.heex
+++ b/lib/zaq_web/live/bo/system/license_live.html.heex
@@ -3,6 +3,7 @@
   flash={@flash}
   page_title="License"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <%= if @license_data do %>
     <!-- Licensed State -->

--- a/lib/zaq_web/live/bo/telemetry_preview_live.html.heex
+++ b/lib/zaq_web/live/bo/telemetry_preview_live.html.heex
@@ -2,6 +2,7 @@
   current_user={@current_user}
   page_title="Telemetry Preview"
   current_path={@current_path}
+  features_version={@features_version}
 >
   <div id="telemetry-preview-page" class="space-y-8">
     <section

--- a/test/zaq_web/live/bo/auth_hook_test.exs
+++ b/test/zaq_web/live/bo/auth_hook_test.exs
@@ -6,8 +6,18 @@ defmodule ZaqWeb.Live.BO.AuthHookTest do
   alias Zaq.Accounts
   alias ZaqWeb.Live.BO.AuthHook
 
+  defp build_socket(view) do
+    %Phoenix.LiveView.Socket{
+      view: view,
+      private: %{
+        live_temp: %{},
+        lifecycle: %Phoenix.LiveView.Lifecycle{}
+      }
+    }
+  end
+
   test "halts and redirects to login when there is no session user" do
-    socket = %Phoenix.LiveView.Socket{view: ZaqWeb.Live.BO.DashboardLive}
+    socket = build_socket(ZaqWeb.Live.BO.DashboardLive)
 
     assert {:halt, halted_socket} = AuthHook.on_mount(:default, %{}, %{}, socket)
     assert {:live, :redirect, %{to: "/bo/login", kind: :push}} = halted_socket.redirected
@@ -15,7 +25,7 @@ defmodule ZaqWeb.Live.BO.AuthHookTest do
 
   test "halts and redirects to change-password when user must rotate password" do
     user = user_fixture(%{username: "bo_auth_hook_force_change"})
-    socket = %Phoenix.LiveView.Socket{view: ZaqWeb.Live.BO.DashboardLive}
+    socket = build_socket(ZaqWeb.Live.BO.DashboardLive)
 
     assert {:halt, halted_socket} =
              AuthHook.on_mount(:default, %{}, %{"user_id" => user.id}, socket)
@@ -26,7 +36,7 @@ defmodule ZaqWeb.Live.BO.AuthHookTest do
 
   test "continues on change-password route for users that must rotate password" do
     user = user_fixture(%{username: "bo_auth_hook_change_route"})
-    socket = %Phoenix.LiveView.Socket{view: ZaqWeb.Live.BO.System.ChangePasswordLive}
+    socket = build_socket(ZaqWeb.Live.BO.System.ChangePasswordLive)
 
     assert {:cont, continued_socket} =
              AuthHook.on_mount(:default, %{}, %{"user_id" => user.id}, socket)
@@ -37,7 +47,7 @@ defmodule ZaqWeb.Live.BO.AuthHookTest do
   test "continues and assigns current_user when password was already changed" do
     user = user_fixture(%{username: "bo_auth_hook_valid_user"})
     {:ok, user} = Accounts.change_password(user, %{password: "StrongPass1!"})
-    socket = %Phoenix.LiveView.Socket{view: ZaqWeb.Live.BO.DashboardLive}
+    socket = build_socket(ZaqWeb.Live.BO.DashboardLive)
 
     assert {:cont, continued_socket} =
              AuthHook.on_mount(:default, %{}, %{"user_id" => user.id}, socket)


### PR DESCRIPTION
  The sidebar menu items stayed visually locked after a license was
  activated because feature_locked? had no assign dependency, so HEEx
  treated it as static. Subscribe all BO LiveViews to license:updated
  via AuthHook and pass a features_version counter through bo_layout
  to force re-evaluation.

Closes #159 