### PR TITLE
fix(e2e): seed telemetry rollups and add benchmark support to gauge and radar

### DIFF
--- a/lib/zaq/engine/telemetry/dashboard_data.ex
+++ b/lib/zaq/engine/telemetry/dashboard_data.ex
@@ -504,6 +504,15 @@ defmodule Zaq.Engine.Telemetry.DashboardData do
     feedback_total = sum_metric(local_rows, "feedback.rating")
     automation_score = strict_effectiveness_score(feedback_neg, feedback_total)
 
+    benchmark_score =
+      if filters.benchmark_opt_in and benchmark_rows != [] do
+        b_neg = sum_metric(benchmark_rows, "feedback.negative.count")
+        b_total = sum_metric(benchmark_rows, "feedback.rating")
+        strict_effectiveness_score(b_neg, b_total)
+      else
+        nil
+      end
+
     total_questions = sum_metric(local_rows, "qa.question.count")
     total_ingestions = sum_metric(local_rows, "ingestion.completed.count")
 
@@ -612,6 +621,7 @@ defmodule Zaq.Engine.Telemetry.DashboardData do
         series: [],
         summary: %{
           value: automation_score,
+          benchmark_value: benchmark_score,
           max: 100.0,
           label: "target 80%"
         },
@@ -658,7 +668,22 @@ defmodule Zaq.Engine.Telemetry.DashboardData do
               label: "Citations",
               value: max(60 + round(sum_metric(local_rows, "qa.answer.count") / 5), 60)
             }
-          ]
+          ],
+          benchmark_axes:
+            if filters.benchmark_opt_in and benchmark_rows != [] do
+              b_latency = metric_points(benchmark_rows, "qa.answer.latency_ms", labels.labels)
+              b_neg = sum_metric(benchmark_rows, "feedback.negative.count")
+
+              [
+                %{label: "Trust", value: benchmark_score},
+                %{label: "Speed", value: percentile_from_latency(b_latency)},
+                %{label: "Coverage", value: 70.0},
+                %{label: "Tone", value: max(100 - b_neg * 5, 35)},
+                %{label: "Citations", value: 65.0}
+              ]
+            else
+              []
+            end
         },
         meta: %{}
       }

--- a/lib/zaq_web/components/bo_telemetry_components.ex
+++ b/lib/zaq_web/components/bo_telemetry_components.ex
@@ -170,9 +170,12 @@ defmodule ZaqWeb.Components.BOTelemetryComponents do
   defp benchmark_points(payload, labels, primary_series) do
     key = series_key(primary_series)
 
-    payload.benchmarks
-    |> Map.get(key, Map.get(payload.benchmarks, to_string(key), []))
-    |> then(&series_points_if_present(labels, &1))
+    values =
+      Map.get(payload.benchmarks, key) ||
+        Map.get(payload.benchmarks, to_string(key)) ||
+        payload.benchmarks |> Map.values() |> List.first()
+
+    series_points_if_present(labels, values || [])
   end
 
   defp baseline_points(%{values: values}, labels) when is_list(values),

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "bootstrap": "sh -c 'cd ../.. && PORT=4002 MIX_ENV=test E2E=1 mix assets.setup && PORT=4002 MIX_ENV=test E2E=1 mix assets.build && PORT=4002 MIX_ENV=test E2E=1 mix ecto.create --quiet && PORT=4002 MIX_ENV=test E2E=1 mix ecto.migrate --quiet && PORT=4002 MIX_ENV=test E2E=1 mix run test/support/e2e/bootstrap.exs'",
     "test": "npm run bootstrap && playwright test",
-    "test:journeys": "npm run bootstrap && playwright test specs/knowledge_ops_lead.spec.js",
+    "test:journeys": "npm run bootstrap && playwright test specs/",
     "test:headed": "npm run bootstrap && playwright test --headed"
   },
   "devDependencies": {

--- a/test/support/e2e/bootstrap.exs
+++ b/test/support/e2e/bootstrap.exs
@@ -1,5 +1,7 @@
 alias Zaq.Accounts
 alias Zaq.Agent.PromptTemplate
+alias Zaq.Engine.Telemetry
+alias Zaq.Engine.Telemetry.Rollup
 alias Zaq.Ingestion.{Chunk, Document, IngestJob}
 alias Zaq.Repo
 
@@ -141,5 +143,48 @@ Enum.each(templates, fn attrs ->
       {:ok, _template} = PromptTemplate.update(template, attrs)
   end
 end)
+
+IO.puts("[e2e-bootstrap] Seeding telemetry rollups")
+
+Repo.delete_all(Rollup)
+
+now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+insert_rollup = fn metric_key, sum, count, opts ->
+  source = Keyword.get(opts, :source, "local")
+  bucket_start = Keyword.get(opts, :bucket_start, now)
+  dimensions = Keyword.get(opts, :dimensions, %{})
+
+  Repo.insert!(%Rollup{
+    metric_key: metric_key,
+    bucket_start: bucket_start,
+    bucket_size: "10m",
+    source: source,
+    dimensions: dimensions,
+    dimension_key: Telemetry.dimension_key(dimensions),
+    value_sum: sum * 1.0,
+    value_count: count,
+    value_min: sum * 1.0,
+    value_max: sum * 1.0,
+    last_value: sum * 1.0,
+    last_at: bucket_start
+  })
+end
+
+# Core QA metrics — drive time series, gauge, radar, donut, bar
+insert_rollup.("qa.question.count", 50.0, 50, [])
+insert_rollup.("qa.answer.count", 45.0, 45, [])
+insert_rollup.("qa.no_answer.count", 5.0, 5, [])
+insert_rollup.("qa.answer.latency_ms", 3000.0, 10, [])
+insert_rollup.("qa.answer.confidence", 0.88, 1, [])
+
+# Feedback — drives gauge automation_score > 60 and donut segments
+insert_rollup.("feedback.rating", 20.0, 20, [])
+insert_rollup.("feedback.negative.count", 2.0, 2, [])
+
+# Benchmark — drives the benchmark toggle assertions
+insert_rollup.("qa.answer.latency_ms", 3500.0, 10, source: "benchmark")
+insert_rollup.("feedback.rating", 18.0, 18, source: "benchmark")
+insert_rollup.("feedback.negative.count", 4.0, 4, source: "benchmark")
 
 IO.puts("[e2e-bootstrap] Done")


### PR DESCRIPTION
  Bootstrap now inserts local and benchmark rollups so the telemetry preview
  e2e test has real data to render. Dashboard data exposes benchmark_value on
  the gauge and benchmark_axes on the radar when opt-in is active.
  The time series benchmark line now falls back to any available benchmark key
  when the primary series has no direct match.