### PR TITLE
feat(llm): added anthropic llm

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -279,7 +279,7 @@ const liveSocket = new LiveSocket("/live", Socket, {
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault()
             const form = el.closest("form")
-            if (form) form.dispatchEvent(new Event("submit", { bubbles: true }))
+            if (form) form.requestSubmit()
           } else if (e.key === "Enter" && e.shiftKey) {
             // newline inserted by browser — resize after DOM updates
             setTimeout(this.resize, 0)

--- a/lib/zaq/agent/llm.ex
+++ b/lib/zaq/agent/llm.ex
@@ -88,14 +88,10 @@ defmodule Zaq.Agent.LLM do
       model: cfg.model,
       temperature: cfg.temperature,
       top_p: cfg.top_p,
-      endpoint: endpoint_for(cfg),
+      endpoint: cfg.endpoint <> cfg.path,
       api_key: cfg.api_key
     }
 
     Map.merge(base, Map.new(overrides))
   end
-
-  defp endpoint_for(%{provider: "anthropic", endpoint: ep}) when ep not in [nil, ""], do: ep
-  defp endpoint_for(%{provider: "anthropic"}), do: "https://api.anthropic.com/v1/messages"
-  defp endpoint_for(%{endpoint: ep}), do: ep <> "/chat/completions"
 end

--- a/lib/zaq/agent/llm.ex
+++ b/lib/zaq/agent/llm.ex
@@ -94,4 +94,24 @@ defmodule Zaq.Agent.LLM do
 
     Map.merge(base, Map.new(overrides))
   end
+
+  @doc """
+  Builds a LangChain chat model struct from an LLM config map.
+
+  Dispatches to `ChatAnthropic` for `provider: "anthropic"`, and falls
+  back to `ChatOpenAI` (which covers all OpenAI-compatible endpoints) for
+  everything else.
+  """
+  def build_model(%{provider: "anthropic"} = config) do
+    LangChain.ChatModels.ChatAnthropic.new!(%{
+      model: config.model,
+      temperature: config.temperature,
+      api_key: config.api_key,
+      endpoint: config.endpoint
+    })
+  end
+
+  def build_model(config) do
+    LangChain.ChatModels.ChatOpenAI.new!(config)
+  end
 end

--- a/lib/zaq/agent/llm.ex
+++ b/lib/zaq/agent/llm.ex
@@ -84,13 +84,18 @@ defmodule Zaq.Agent.LLM do
     cfg = Zaq.System.get_llm_config()
 
     base = %{
+      provider: cfg.provider,
       model: cfg.model,
       temperature: cfg.temperature,
       top_p: cfg.top_p,
-      endpoint: cfg.endpoint <> "/chat/completions",
+      endpoint: endpoint_for(cfg),
       api_key: cfg.api_key
     }
 
     Map.merge(base, Map.new(overrides))
   end
+
+  defp endpoint_for(%{provider: "anthropic", endpoint: ep}) when ep not in [nil, ""], do: ep
+  defp endpoint_for(%{provider: "anthropic"}), do: "https://api.anthropic.com/v1/messages"
+  defp endpoint_for(%{endpoint: ep}), do: ep <> "/chat/completions"
 end

--- a/lib/zaq/agent/llm.ex
+++ b/lib/zaq/agent/llm.ex
@@ -80,6 +80,9 @@ defmodule Zaq.Agent.LLM do
       #   api_key: ""
       # }
   """
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.ChatModels.ChatOpenAI
+
   def chat_config(overrides \\ []) do
     cfg = Zaq.System.get_llm_config()
 
@@ -103,7 +106,7 @@ defmodule Zaq.Agent.LLM do
   everything else.
   """
   def build_model(%{provider: "anthropic"} = config) do
-    LangChain.ChatModels.ChatAnthropic.new!(%{
+    ChatAnthropic.new!(%{
       model: config.model,
       temperature: config.temperature,
       api_key: config.api_key,
@@ -112,6 +115,6 @@ defmodule Zaq.Agent.LLM do
   end
 
   def build_model(config) do
-    LangChain.ChatModels.ChatOpenAI.new!(config)
+    ChatOpenAI.new!(config)
   end
 end

--- a/lib/zaq/agent/llm_runner.ex
+++ b/lib/zaq/agent/llm_runner.ex
@@ -4,6 +4,7 @@ defmodule Zaq.Agent.LLMRunner do
   require Logger
 
   alias LangChain.Chains.LLMChain
+  alias LangChain.ChatModels.ChatAnthropic
   alias LangChain.ChatModels.ChatOpenAI
   alias LangChain.Message
   alias LangChain.Message.ContentPart
@@ -22,7 +23,7 @@ defmodule Zaq.Agent.LLMRunner do
 
     try do
       chain =
-        LLMChain.new!(%{llm: ChatOpenAI.new!(llm_config)})
+        LLMChain.new!(%{llm: build_llm_model(llm_config)})
         |> maybe_add_system_message(system_prompt)
         |> maybe_add_history(history)
         |> maybe_add_user_message(question)
@@ -200,6 +201,23 @@ defmodule Zaq.Agent.LLMRunner do
   end
 
   defp normalized_text(_), do: :error
+
+  defp build_llm_model(config) when is_map(config) do
+    if anthropic?(config) do
+      ChatAnthropic.new!(%{
+        model: config.model,
+        temperature: config.temperature,
+        api_key: config.api_key,
+        endpoint: config.endpoint
+      })
+    else
+      ChatOpenAI.new!(config)
+    end
+  end
+
+  defp anthropic?(%{provider: "anthropic"}), do: true
+  defp anthropic?(%{endpoint: ep}) when is_binary(ep), do: String.contains?(ep, "anthropic.com")
+  defp anthropic?(_), do: false
 
   defp maybe_add_system_message(chain, prompt) when is_binary(prompt) and prompt != "",
     do: LLMChain.add_message(chain, Message.new_system!(prompt))

--- a/lib/zaq/agent/llm_runner.ex
+++ b/lib/zaq/agent/llm_runner.ex
@@ -4,9 +4,8 @@ defmodule Zaq.Agent.LLMRunner do
   require Logger
 
   alias LangChain.Chains.LLMChain
-  alias LangChain.ChatModels.ChatAnthropic
-  alias LangChain.ChatModels.ChatOpenAI
   alias LangChain.Message
+  alias Zaq.Agent.LLM
   alias LangChain.Message.ContentPart
   alias LangChain.Utils.ChainResult
 
@@ -202,18 +201,7 @@ defmodule Zaq.Agent.LLMRunner do
 
   defp normalized_text(_), do: :error
 
-  defp build_llm_model(%{provider: "anthropic"} = config) do
-    ChatAnthropic.new!(%{
-      model: config.model,
-      temperature: config.temperature,
-      api_key: config.api_key,
-      endpoint: config.endpoint
-    })
-  end
-
-  defp build_llm_model(config) do
-    ChatOpenAI.new!(config)
-  end
+  defp build_llm_model(config), do: LLM.build_model(config)
 
   defp maybe_add_system_message(chain, prompt) when is_binary(prompt) and prompt != "",
     do: LLMChain.add_message(chain, Message.new_system!(prompt))

--- a/lib/zaq/agent/llm_runner.ex
+++ b/lib/zaq/agent/llm_runner.ex
@@ -5,9 +5,9 @@ defmodule Zaq.Agent.LLMRunner do
 
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
-  alias Zaq.Agent.LLM
   alias LangChain.Message.ContentPart
   alias LangChain.Utils.ChainResult
+  alias Zaq.Agent.LLM
 
   @empty_content_log_ttl_ms 60_000
   @diag_table :zaq_llm_runner_diag

--- a/lib/zaq/agent/llm_runner.ex
+++ b/lib/zaq/agent/llm_runner.ex
@@ -202,22 +202,18 @@ defmodule Zaq.Agent.LLMRunner do
 
   defp normalized_text(_), do: :error
 
-  defp build_llm_model(config) when is_map(config) do
-    if anthropic?(config) do
-      ChatAnthropic.new!(%{
-        model: config.model,
-        temperature: config.temperature,
-        api_key: config.api_key,
-        endpoint: config.endpoint
-      })
-    else
-      ChatOpenAI.new!(config)
-    end
+  defp build_llm_model(%{provider: "anthropic"} = config) do
+    ChatAnthropic.new!(%{
+      model: config.model,
+      temperature: config.temperature,
+      api_key: config.api_key,
+      endpoint: config.endpoint
+    })
   end
 
-  defp anthropic?(%{provider: "anthropic"}), do: true
-  defp anthropic?(%{endpoint: ep}) when is_binary(ep), do: String.contains?(ep, "anthropic.com")
-  defp anthropic?(_), do: false
+  defp build_llm_model(config) do
+    ChatOpenAI.new!(config)
+  end
 
   defp maybe_add_system_message(chain, prompt) when is_binary(prompt) and prompt != "",
     do: LLMChain.add_message(chain, Message.new_system!(prompt))

--- a/lib/zaq/engine/conversations/title_generator.ex
+++ b/lib/zaq/engine/conversations/title_generator.ex
@@ -13,6 +13,7 @@ defmodule Zaq.Engine.Conversations.TitleGenerator do
 
   alias LangChain.Chains.LLMChain
   alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.ChatModels.ChatAnthropic
   alias LangChain.Message
   alias Zaq.Agent.{LLM, LLMRunner}
   alias Zaq.Utils.TextUtils
@@ -61,7 +62,7 @@ defmodule Zaq.Engine.Conversations.TitleGenerator do
 
     try do
       {:ok, updated_chain} =
-        LLMChain.new!(%{llm: ChatOpenAI.new!(llm_config)})
+        LLMChain.new!(%{llm: build_llm_model(llm_config)})
         |> LLMChain.add_message(Message.new_user!(prompt))
         |> LLMChain.run()
 
@@ -90,6 +91,19 @@ defmodule Zaq.Engine.Conversations.TitleGenerator do
   # ---------------------------------------------------------------------------
   # Private
   # ---------------------------------------------------------------------------
+
+  defp build_llm_model(%{provider: "anthropic"} = config) do
+    ChatAnthropic.new!(%{
+      model: config.model,
+      temperature: config.temperature,
+      api_key: config.api_key,
+      endpoint: config.endpoint
+    })
+  end
+
+  defp build_llm_model(config) do
+    ChatOpenAI.new!(config)
+  end
 
   defp remove_quotes(text) do
     text

--- a/lib/zaq/engine/conversations/title_generator.ex
+++ b/lib/zaq/engine/conversations/title_generator.ex
@@ -12,8 +12,6 @@ defmodule Zaq.Engine.Conversations.TitleGenerator do
   require Logger
 
   alias LangChain.Chains.LLMChain
-  alias LangChain.ChatModels.ChatAnthropic
-  alias LangChain.ChatModels.ChatOpenAI
   alias LangChain.Message
   alias Zaq.Agent.{LLM, LLMRunner}
   alias Zaq.Utils.TextUtils
@@ -92,18 +90,7 @@ defmodule Zaq.Engine.Conversations.TitleGenerator do
   # Private
   # ---------------------------------------------------------------------------
 
-  defp build_llm_model(%{provider: "anthropic"} = config) do
-    ChatAnthropic.new!(%{
-      model: config.model,
-      temperature: config.temperature,
-      api_key: config.api_key,
-      endpoint: config.endpoint
-    })
-  end
-
-  defp build_llm_model(config) do
-    ChatOpenAI.new!(config)
-  end
+  defp build_llm_model(config), do: LLM.build_model(config)
 
   defp remove_quotes(text) do
     text

--- a/lib/zaq/engine/conversations/title_generator.ex
+++ b/lib/zaq/engine/conversations/title_generator.ex
@@ -12,8 +12,8 @@ defmodule Zaq.Engine.Conversations.TitleGenerator do
   require Logger
 
   alias LangChain.Chains.LLMChain
-  alias LangChain.ChatModels.ChatOpenAI
   alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.ChatModels.ChatOpenAI
   alias LangChain.Message
   alias Zaq.Agent.{LLM, LLMRunner}
   alias Zaq.Utils.TextUtils

--- a/lib/zaq/system.ex
+++ b/lib/zaq/system.ex
@@ -25,7 +25,7 @@ defmodule Zaq.System do
     no_answer_alert_threshold_percent
     conversation_response_sla_ms
   )
-  @llm_fields ~w(provider endpoint api_key model temperature top_p supports_logprobs supports_json_mode max_context_window distance_threshold)
+  @llm_fields ~w(provider endpoint api_key model temperature top_p path supports_logprobs supports_json_mode max_context_window distance_threshold)
   @embedding_fields ~w(provider endpoint api_key model dimension chunk_min_tokens chunk_max_tokens)
   @image_to_text_fields ~w(provider endpoint api_key model)
 
@@ -109,6 +109,7 @@ defmodule Zaq.System do
       model: raw["model"] || "llama-3.3-70b-instruct",
       temperature: parse_float(raw["temperature"], 0.0),
       top_p: parse_float(raw["top_p"], 0.9),
+      path: raw["path"] || "/chat/completions",
       supports_logprobs: parse_bool(raw["supports_logprobs"], true),
       supports_json_mode: parse_bool(raw["supports_json_mode"], true),
       max_context_window: parse_int(raw["max_context_window"], 5_000),

--- a/lib/zaq/system/llm_config.ex
+++ b/lib/zaq/system/llm_config.ex
@@ -11,6 +11,7 @@ defmodule Zaq.System.LLMConfig do
     field :model, :string, default: "llama-3.3-70b-instruct"
     field :temperature, :float, default: 0.0
     field :top_p, :float, default: 0.9
+    field :path, :string, default: "/chat/completions"
     field :supports_logprobs, :boolean, default: true
     field :supports_json_mode, :boolean, default: true
     field :max_context_window, :integer, default: 5_000
@@ -26,6 +27,7 @@ defmodule Zaq.System.LLMConfig do
       :model,
       :temperature,
       :top_p,
+      :path,
       :supports_logprobs,
       :supports_json_mode,
       :max_context_window,

--- a/lib/zaq_web/live/bo/system/system_config_live.ex
+++ b/lib/zaq_web/live/bo/system/system_config_live.ex
@@ -83,7 +83,9 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
 
     params =
       if provider_id != previous_provider do
-        Map.put(params, "endpoint", llm_provider_endpoint(provider_id))
+        params
+        |> Map.put("endpoint", llm_provider_endpoint(provider_id))
+        |> Map.put("path", llm_provider_path(provider_id))
       else
         params
       end
@@ -372,6 +374,23 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
     ArgumentError -> ""
   end
 
+  # Returns the execution path for the first active model of a provider, or "/chat/completions".
+  defp provider_path("custom"), do: "/chat/completions"
+
+  defp provider_path(provider_id) do
+    provider_atom = String.to_existing_atom(provider_id)
+
+    model = LLMDB.models(provider_atom) |> Enum.find(&(not &1.deprecated and not &1.retired))
+
+    path =
+      model
+      |> then(fn m -> m && m.execution && m.execution[:text] && m.execution[:text][:path] end)
+
+    if is_binary(path), do: path, else: "/chat/completions"
+  rescue
+    ArgumentError -> "/chat/completions"
+  end
+
   # Returns [{display_name, provider_id_string}] for providers whose models satisfy
   # model_filter, plus a "Custom" fallback. Pass `fn _ -> true end` for no filter.
   defp provider_options(model_filter) do
@@ -408,6 +427,7 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
   defp llm_provider_options, do: provider_options(fn _ -> true end)
   defp llm_model_options(provider_id), do: model_options(provider_id, fn _ -> true end)
   defp llm_provider_endpoint(provider_id), do: provider_endpoint(provider_id)
+  defp llm_provider_path(provider_id), do: provider_path(provider_id)
 
   # ── Embedding-specific helpers ─────────────────────────────────────────
 
@@ -664,6 +684,7 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
           phx-change="validate_llm"
           class="space-y-5"
         >
+          <input type="hidden" name="llm_config[path]" value={@form[:path].value} />
           <div class="grid grid-cols-2 gap-4">
             <div>
               <label class="font-mono text-[0.7rem] font-semibold text-black/60 uppercase tracking-wider block mb-2">

--- a/lib/zaq_web/live/bo/system/system_config_live.ex
+++ b/lib/zaq_web/live/bo/system/system_config_live.ex
@@ -85,7 +85,7 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
       if provider_id != previous_provider do
         params
         |> Map.put("endpoint", llm_provider_endpoint(provider_id))
-        |> Map.put("path", llm_provider_path(provider_id))
+        |> Map.put("path", llm_provider_path(provider_id, model_id))
       else
         params
       end
@@ -374,13 +374,13 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
     ArgumentError -> ""
   end
 
-  # Returns the execution path for the first active model of a provider, or "/chat/completions".
-  defp provider_path("custom"), do: "/chat/completions"
+  # Returns the execution path for the selected model of a provider, or "/chat/completions".
+  defp provider_path("custom", _model_id), do: "/chat/completions"
 
-  defp provider_path(provider_id) do
+  defp provider_path(provider_id, model_id) do
     provider_atom = String.to_existing_atom(provider_id)
 
-    model = LLMDB.models(provider_atom) |> Enum.find(&(not &1.deprecated and not &1.retired))
+    model = LLMDB.models(provider_atom) |> Enum.find(&(&1.id == model_id))
 
     path =
       model
@@ -427,7 +427,7 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
   defp llm_provider_options, do: provider_options(fn _ -> true end)
   defp llm_model_options(provider_id), do: model_options(provider_id, fn _ -> true end)
   defp llm_provider_endpoint(provider_id), do: provider_endpoint(provider_id)
-  defp llm_provider_path(provider_id), do: provider_path(provider_id)
+  defp llm_provider_path(provider_id, model_id), do: provider_path(provider_id, model_id)
 
   # ── Embedding-specific helpers ─────────────────────────────────────────
 

--- a/lib/zaq_web/live/bo/system/system_config_live.ex
+++ b/lib/zaq_web/live/bo/system/system_config_live.ex
@@ -682,25 +682,19 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
               <label class="font-mono text-[0.7rem] font-semibold text-black/60 uppercase tracking-wider block mb-2">
                 Model
               </label>
-              <.searchable_select
-                :if={@model_options != []}
-                id="llm-model-select"
-                name="llm_config[model]"
-                value={@form[:model].value}
-                options={@model_options}
-                placeholder="Search models..."
-                empty_label="Select a model..."
-              />
               <input
-                :if={@model_options == []}
                 type="text"
                 name="llm_config[model]"
                 value={@form[:model].value}
                 required
                 phx-debounce="400"
                 placeholder="llama-3.3-70b-instruct"
+                list="llm-model-datalist"
                 class="w-full font-mono text-[0.88rem] text-black border border-black/10 rounded-xl h-11 px-4 bg-[#fafafa] placeholder:text-black/25 focus:outline-none focus:ring-2 focus:ring-[#03b6d4]/20 focus:border-[#03b6d4] transition-all"
               />
+              <datalist id="llm-model-datalist">
+                <option :for={{label, value} <- @model_options} value={value}>{label}</option>
+              </datalist>
               <p
                 :for={{msg, opts} <- @form[:model].errors}
                 class="font-mono text-[0.72rem] text-red-500 mt-1.5"
@@ -832,7 +826,7 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
                 {translate_error({msg, opts})}
               </p>
             </div>
-            <div>
+            <div :if={@form[:provider].value != "anthropic"}>
               <label class="font-mono text-[0.7rem] font-semibold text-black/60 uppercase tracking-wider block mb-2">
                 Top-P
               </label>

--- a/lib/zaq_web/live/bo/system/system_config_live.ex
+++ b/lib/zaq_web/live/bo/system/system_config_live.ex
@@ -682,19 +682,25 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
               <label class="font-mono text-[0.7rem] font-semibold text-black/60 uppercase tracking-wider block mb-2">
                 Model
               </label>
+              <.searchable_select
+                :if={@model_options != []}
+                id="llm-model-select"
+                name="llm_config[model]"
+                value={@form[:model].value}
+                options={@model_options}
+                placeholder="Search models..."
+                empty_label="Select a model..."
+              />
               <input
+                :if={@model_options == []}
                 type="text"
                 name="llm_config[model]"
                 value={@form[:model].value}
                 required
                 phx-debounce="400"
                 placeholder="llama-3.3-70b-instruct"
-                list="llm-model-datalist"
                 class="w-full font-mono text-[0.88rem] text-black border border-black/10 rounded-xl h-11 px-4 bg-[#fafafa] placeholder:text-black/25 focus:outline-none focus:ring-2 focus:ring-[#03b6d4]/20 focus:border-[#03b6d4] transition-all"
               />
-              <datalist id="llm-model-datalist">
-                <option :for={{label, value} <- @model_options} value={value}>{label}</option>
-              </datalist>
               <p
                 :for={{msg, opts} <- @form[:model].errors}
                 class="font-mono text-[0.72rem] text-red-500 mt-1.5"
@@ -826,7 +832,7 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLive do
                 {translate_error({msg, opts})}
               </p>
             </div>
-            <div :if={@form[:provider].value != "anthropic"}>
+            <div>
               <label class="font-mono text-[0.7rem] font-semibold text-black/60 uppercase tracking-wider block mb-2">
                 Top-P
               </label>


### PR DESCRIPTION
## Summary
Add Anthropic provider support to allow using Claude models alongside OpenAI, plus fix form submission in the chat interface.

## Changes
- **Anthropic LLM Support**: Added provider-aware configuration to support both OpenAI and Anthropic APIs
- Routes to correct endpoints based on provider
- Instantiates appropriate LangChain models (ChatAnthropic or ChatOpenAI)
- Updated system config UI to handle both providers

- **Form Submission Fix**: Replaced manual submit event dispatching with `requestSubmit()` for proper form handling. (Previously pressing enter would refresh the browser and make the chat disapear)
