### PR TITLE
fix: support async EventHop types in NodeRouter.dispatch/2

### DIFF
--- a/lib/zaq/node_router.ex
+++ b/lib/zaq/node_router.ex
@@ -64,23 +64,11 @@ defmodule Zaq.NodeRouter do
     supervisor = Map.fetch!(@supervisor_map, role)
     api_module = Map.fetch!(@role_api_map, role)
     action = action_for(event)
+    hop_type = hop_type_for(event)
     current = current_node(runtime)
     target = find_node(supervisor, runtime) || current
 
-    if target == current do
-      api_module.handle_event(event, action, nil)
-    else
-      case rpc_call(runtime, target, api_module, :handle_event, [event, action, nil]) do
-        {:badrpc, reason} ->
-          %{event | response: {:error, {:rpc_failed, target, reason}}}
-
-        %Event{} = routed_event ->
-          routed_event
-
-        other ->
-          %{event | response: {:error, {:invalid_event_response, target, other}}}
-      end
-    end
+    do_dispatch(event, hop_type, api_module, action, current, target, runtime)
   end
 
   def dispatch(%Event{} = event, _runtime) do
@@ -166,6 +154,12 @@ defmodule Zaq.NodeRouter do
     |> then(& &1.(n, mod, fun, args))
   end
 
+  defp async_start(runtime, fun) when is_function(fun, 0) do
+    runtime
+    |> Map.get(:async_start_fn, &Task.Supervisor.start_child(Zaq.TaskSupervisor, &1))
+    |> then(& &1.(fun))
+  end
+
   defp action_for(%Event{opts: opts}) when is_list(opts) do
     case Keyword.get(opts, :action, :invoke) do
       action when is_atom(action) -> action
@@ -174,6 +168,42 @@ defmodule Zaq.NodeRouter do
   end
 
   defp action_for(_event), do: :invoke
+
+  defp hop_type_for(%Event{next_hop: %EventHop{type: type}}) when type in [:sync, :async],
+    do: type
+
+  defp hop_type_for(_event), do: :sync
+
+  defp do_dispatch(event, :sync, api_module, action, current, target, runtime) do
+    do_dispatch_sync(event, api_module, action, current, target, runtime)
+  end
+
+  defp do_dispatch(event, :async, api_module, action, current, target, runtime) do
+    _ =
+      async_start(runtime, fn ->
+        _ = do_dispatch_sync(event, api_module, action, current, target, runtime)
+        :ok
+      end)
+
+    event
+  end
+
+  defp do_dispatch_sync(event, api_module, action, current, target, runtime) do
+    if target == current do
+      api_module.handle_event(event, action, nil)
+    else
+      case rpc_call(runtime, target, api_module, :handle_event, [event, action, nil]) do
+        {:badrpc, reason} ->
+          %{event | response: {:error, {:rpc_failed, target, reason}}}
+
+        %Event{} = routed_event ->
+          routed_event
+
+        other ->
+          %{event | response: {:error, {:invalid_event_response, target, other}}}
+      end
+    end
+  end
 
   defp unwrap_call_response(%Event{response: {:error, {:rpc_failed, _, _}} = error}), do: error
   defp unwrap_call_response(%Event{response: response}), do: response

--- a/test/zaq/agent/server_manager_test.exs
+++ b/test/zaq/agent/server_manager_test.exs
@@ -1105,7 +1105,6 @@ defmodule Zaq.Agent.ServerManagerTest do
     alias Jido.AI.Context, as: AIContext
     alias Zaq.Accounts.Person
     alias Zaq.Engine.Conversations.{Conversation, Message}
-    alias Zaq.Engine.Messages.Incoming
     alias Zaq.Repo
 
     defp insert_person_for_sm do

--- a/test/zaq/node_router_test.exs
+++ b/test/zaq/node_router_test.exs
@@ -213,7 +213,7 @@ defmodule Zaq.NodeRouterTest do
       assert result.hops == [result.next_hop]
     end
 
-    test "returns an event for async hops as well" do
+    test "returns the appended event immediately for async hops" do
       event = %Event{
         request: %{module: String, function: :upcase, args: ["hello"]},
         next_hop: %EventHop{destination: :bo, type: :async, timestamp: DateTime.utc_now()},
@@ -224,8 +224,41 @@ defmodule Zaq.NodeRouterTest do
       result = NodeRouter.dispatch(event)
 
       assert %Event{} = result
-      assert result.response == "HELLO"
+      assert result.response == nil
       assert result.hops == [result.next_hop]
+    end
+
+    test "executes async remote hops in background and returns immediately" do
+      event =
+        Event.new(%{module: String, function: :upcase, args: ["hello"]}, :agent,
+          type: :async,
+          opts: [action: :invoke]
+        )
+
+      parent = self()
+
+      runtime = %{
+        current_node_fn: fn -> :local@host end,
+        node_list_fn: fn -> [:remote@host] end,
+        whereis_fn: fn _ -> nil end,
+        rpc_call_fn: fn
+          :remote@host, Process, :whereis, [Zaq.Agent.Supervisor] ->
+            spawn(fn -> :ok end)
+
+          :remote@host, Zaq.Agent.Api, :handle_event, [%Event{} = routed, :invoke, _api_opts] ->
+            send(parent, {:async_remote_called, routed.trace_id})
+            %{routed | response: "HELLO FROM REMOTE"}
+        end
+      }
+
+      result = NodeRouter.dispatch(event, runtime)
+      trace_id = event.trace_id
+
+      assert %Event{} = result
+      assert result.trace_id == trace_id
+      assert result.response == nil
+      assert result.hops == [result.next_hop]
+      assert_receive {:async_remote_called, ^trace_id}
     end
 
     test "does not duplicate last hop when dispatching same event twice" do


### PR DESCRIPTION
add support for async hops in NodeRouter.dispatch/2 