### PR TITLE
fix(ingestion): solid sanitize_bm25_query — fix Unicode whitespace and idempotency

### DIFF
--- a/lib/zaq/ingestion/document_processor.ex
+++ b/lib/zaq/ingestion/document_processor.ex
@@ -197,9 +197,18 @@ defmodule Zaq.Ingestion.DocumentProcessor do
   def sanitize_bm25_query(text) do
     text
     |> sanitize_utf8()
-    |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")
-    |> String.replace(~r/\s+/, " ")
+    |> unicode_normalize()
+    |> String.replace(~r/[^\p{L}\p{N}]+/u, " ")
+    |> String.replace(~r/ {2,}/, " ")
     |> String.trim()
+    |> String.slice(0, 512)
+  end
+
+  defp unicode_normalize(text) do
+    case :unicode.characters_to_nfc_binary(text) do
+      normalized when is_binary(normalized) -> normalized
+      _ -> text
+    end
   end
 
   defp sanitize_utf8(binary), do: sanitize_utf8(binary, [])

--- a/test/zaq/ingestion/document_processor_test.exs
+++ b/test/zaq/ingestion/document_processor_test.exs
@@ -2231,5 +2231,33 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
         assert once == twice
       end
     end
+
+    test "unicode whitespace variants are collapsed to plain space" do
+      # U+2004 THREE-PER-EM SPACE, U+00A0 NO-BREAK SPACE, U+3000 IDEOGRAPHIC SPACE
+      assert DocumentProcessor.sanitize_bm25_query("hello world") == "hello world"
+      assert DocumentProcessor.sanitize_bm25_query("hello world") == "hello world"
+      assert DocumentProcessor.sanitize_bm25_query("hello　world") == "hello world"
+    end
+
+    test "NFC combining chars are normalized before filtering" do
+      # e + combining acute accent (U+0301) normalizes to é (single codepoint), still a letter
+      combining = "café"
+      result = DocumentProcessor.sanitize_bm25_query(combining)
+      assert result == "café"
+    end
+
+    test "output is truncated at 512 graphemes" do
+      long = String.duplicate("a", 600)
+      result = DocumentProcessor.sanitize_bm25_query(long)
+      assert String.length(result) == 512
+    end
+
+    test "empty string returns empty string" do
+      assert DocumentProcessor.sanitize_bm25_query("") == ""
+    end
+
+    test "only punctuation returns empty string" do
+      assert DocumentProcessor.sanitize_bm25_query("!!!---???") == ""
+    end
   end
 end


### PR DESCRIPTION
fix #377