### PR TITLE
fix(agents): display stale tool keys with Removed badge and unblock editing

### DIFF
--- a/docs/exec-plans/active/GH381_broken_tools_display.md
+++ b/docs/exec-plans/active/GH381_broken_tools_display.md
@@ -1,0 +1,59 @@
+# GH#381 — Display Saved Broken Tools for Safe Removal
+
+## Problem
+
+An agent stores tool references as `enabled_tool_keys: {:array, :string}`. When a
+developer removes a tool from `Registry.@tools`, affected agents hit a deadlock:
+
+1. **Changeset blocks** — `validate_tool_keys/1` rejects ghost keys → agent cannot be
+   saved, renamed, or have its model changed.
+2. **UI is blind** — `selected_tools_panel` only renders keys present in `@tools`, so
+   ghost keys are invisible and cannot be removed.
+
+---
+
+## Step 1 — Backend: Unblock changeset + Registry helper
+
+**Files:** `lib/zaq/agent/tools/registry.ex`, `lib/zaq/agent/configured_agent.ex`
+
+**Changes:**
+- `Registry.ghost_keys/1` — returns the subset of a key list not in `@tools`.
+- `validate_tool_keys/1` — only errors on *newly-added* unknown keys; keys that already
+  exist in `changeset.data.enabled_tool_keys` are allowed through so the agent stays
+  editable.
+
+**Tests (`test/zaq/agent/configured_agent_test.exs`):**
+- Ghost key already in `data.enabled_tool_keys` → changeset valid
+- Adding a brand-new unknown key → `enabled_tool_keys` error
+- Removing a ghost key → changeset valid
+
+**Status:** ✅ Done
+
+---
+
+## Step 2 — Frontend: Display ghost tools with visual indicator
+
+**Files:** `lib/zaq_web/live/bo/ai/agents_live.ex`
+
+**Changes:**
+- `selected_tools_panel/1` builds a `tool_index` then maps each `selected_key` to either
+  its known descriptor or a ghost descriptor
+  `%{key: key, label: key, description: "This tool has been removed from the system.", ghost: true}`.
+- Ghost rows render in red with a "Removed" badge; remove button works identically to
+  valid tools (reuses existing `remove_tool` event).
+
+**Tests (`test/zaq_web/live/bo/ai/agents_live_test.exs`):**
+- Agent with ghost key → ghost row visible with "Removed" label
+- Remove ghost tool → key disappears; agent saves successfully
+- Agent with only valid tools → behaviour unchanged
+
+**Status:** ✅ Done
+
+---
+
+## Definition of Done
+
+- [ ] `mix precommit` passes
+- [ ] Coverage ≥ 95% on touched files
+- [ ] Ghost rows visible in BO with Removed badge
+- [ ] Agent with ghost keys can be saved / ghost keys can be removed

--- a/lib/zaq/agent/configured_agent.ex
+++ b/lib/zaq/agent/configured_agent.ex
@@ -52,21 +52,22 @@ defmodule Zaq.Agent.ConfiguredAgent do
     put_change(changeset, :enabled_mcp_endpoint_ids, Enum.uniq(ids))
   end
 
-  defp validate_tool_keys(changeset) do
+  defp validate_tool_keys(%Ecto.Changeset{data: data} = changeset) do
     keys = get_field(changeset, :enabled_tool_keys) || []
+    original_keys = Map.get(data, :enabled_tool_keys) || []
 
-    unknown =
+    newly_unknown =
       keys
       |> Enum.uniq()
-      |> Enum.reject(&Registry.valid_tool_key?/1)
+      |> Enum.reject(&(Registry.valid_tool_key?(&1) or &1 in original_keys))
 
-    if unknown == [] do
+    if newly_unknown == [] do
       changeset
     else
       add_error(
         changeset,
         :enabled_tool_keys,
-        "contains unknown tools: #{Enum.join(unknown, ", ")}"
+        "contains unknown tools: #{Enum.join(newly_unknown, ", ")}"
       )
     end
   end

--- a/lib/zaq/agent/tools/registry.ex
+++ b/lib/zaq/agent/tools/registry.ex
@@ -180,6 +180,16 @@ defmodule Zaq.Agent.Tools.Registry do
 
   def valid_tool_key?(_), do: false
 
+  @doc """
+  Returns the subset of `keys` that are no longer registered in `@tools`.
+
+  Useful for detecting saved tool references that became stale after a tool was removed
+  from the registry.
+  """
+  @spec ghost_keys([String.t()]) :: [String.t()]
+  def ghost_keys(keys) when is_list(keys), do: Enum.reject(keys, &valid_tool_key?/1)
+  def ghost_keys(_), do: []
+
   @spec resolve_modules([String.t()]) ::
           {:ok, [module()]} | {:error, {:unknown_tools, [String.t()]}}
   def resolve_modules(tool_keys) when is_list(tool_keys) do

--- a/lib/zaq_web/live/bo/ai/agents_live.ex
+++ b/lib/zaq_web/live/bo/ai/agents_live.ex
@@ -652,12 +652,20 @@ defmodule ZaqWeb.Live.BO.AI.AgentsLive do
   attr :selected_keys, :list, required: true
 
   defp selected_tools_panel(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :selected_tools,
-        Enum.filter(assigns.tools, &(&1.key in assigns.selected_keys))
-      )
+    tool_index = Map.new(assigns.tools, &{&1.key, &1})
+
+    selected_tools =
+      Enum.map(assigns.selected_keys, fn key ->
+        Map.get(tool_index, key) ||
+          %{
+            key: key,
+            label: key,
+            description: "This tool has been removed from the system.",
+            ghost: true
+          }
+      end)
+
+    assigns = assign(assigns, :selected_tools, selected_tools)
 
     ~H"""
     <div class="rounded-lg border border-[#efece6]">
@@ -668,10 +676,24 @@ defmodule ZaqWeb.Live.BO.AI.AgentsLive do
         <div
           :for={tool <- @selected_tools}
           data-selected-tool-key={tool.key}
-          class="flex items-start justify-between gap-3 px-3 py-2 hover:bg-[#faf8f5]"
+          class={[
+            "flex items-start justify-between gap-3 px-3 py-2",
+            if(Map.get(tool, :ghost), do: "bg-red-50 hover:bg-red-100", else: "hover:bg-[#faf8f5]")
+          ]}
         >
           <div>
-            <p class="font-mono text-[0.72rem] text-[#3e3b36]">{tool.label}</p>
+            <p class={[
+              "font-mono text-[0.72rem]",
+              if(Map.get(tool, :ghost), do: "text-red-600", else: "text-[#3e3b36]")
+            ]}>
+              {tool.label}
+              <span
+                :if={Map.get(tool, :ghost)}
+                class="ml-1.5 inline-block rounded bg-red-100 px-1 py-px font-mono text-[0.58rem] text-red-600"
+              >
+                Removed
+              </span>
+            </p>
             <p class="font-mono text-[0.64rem] text-[#8f8a82]">{tool.description}</p>
           </div>
           <button

--- a/test/zaq/agent/configured_agent_test.exs
+++ b/test/zaq/agent/configured_agent_test.exs
@@ -124,6 +124,87 @@ defmodule Zaq.Agent.ConfiguredAgentTest do
     assert "contains unknown tools: files.unknown" in errors_on(changeset).enabled_tool_keys
   end
 
+  test "changeset allows ghost keys already present in stored data" do
+    credential =
+      ai_credential_fixture(%{
+        name: "Ghost Tool Credential #{System.unique_integer([:positive, :monotonic])}",
+        provider: "openai"
+      })
+
+    existing_agent = %ConfiguredAgent{
+      name: "Agent #{System.unique_integer([:positive])}",
+      job: "do thing",
+      model: "gpt-4.1-mini",
+      credential_id: credential.id,
+      strategy: "react",
+      enabled_tool_keys: ["removed.ghost_tool"]
+    }
+
+    changeset =
+      ConfiguredAgent.changeset(existing_agent, %{
+        name: existing_agent.name,
+        job: existing_agent.job,
+        model: existing_agent.model,
+        credential_id: existing_agent.credential_id,
+        strategy: existing_agent.strategy,
+        enabled_tool_keys: ["removed.ghost_tool"]
+      })
+
+    assert changeset.valid?
+  end
+
+  test "changeset allows removing a ghost key from stored data" do
+    credential =
+      ai_credential_fixture(%{
+        name: "Ghost Remove Credential #{System.unique_integer([:positive, :monotonic])}",
+        provider: "openai"
+      })
+
+    existing_agent = %ConfiguredAgent{
+      name: "Agent #{System.unique_integer([:positive])}",
+      job: "do thing",
+      model: "gpt-4.1-mini",
+      credential_id: credential.id,
+      strategy: "react",
+      enabled_tool_keys: ["removed.ghost_tool"]
+    }
+
+    changeset =
+      ConfiguredAgent.changeset(existing_agent, %{
+        name: existing_agent.name,
+        job: existing_agent.job,
+        model: existing_agent.model,
+        credential_id: existing_agent.credential_id,
+        strategy: existing_agent.strategy,
+        enabled_tool_keys: []
+      })
+
+    assert changeset.valid?
+    assert Ecto.Changeset.get_field(changeset, :enabled_tool_keys) == []
+  end
+
+  test "changeset still rejects brand-new unknown tool keys on a new agent" do
+    credential =
+      ai_credential_fixture(%{
+        name: "New Unknown Credential #{System.unique_integer([:positive, :monotonic])}",
+        provider: "openai"
+      })
+
+    changeset =
+      ConfiguredAgent.changeset(%ConfiguredAgent{}, %{
+        name: "Agent #{System.unique_integer([:positive])}",
+        job: "do thing",
+        model: "gpt-4.1-mini",
+        credential_id: credential.id,
+        strategy: "react",
+        enabled_tool_keys: ["files.brand_new_unknown"]
+      })
+
+    refute changeset.valid?
+
+    assert "contains unknown tools: files.brand_new_unknown" in errors_on(changeset).enabled_tool_keys
+  end
+
   test "changeset normalizes enabled_mcp_endpoint_ids" do
     credential =
       ai_credential_fixture(%{

--- a/test/zaq/agent/tools/registry_test.exs
+++ b/test/zaq/agent/tools/registry_test.exs
@@ -84,6 +84,24 @@ defmodule Zaq.Agent.Tools.RegistryTest do
     assert {:error, {:unknown_tools, []}} = Registry.resolve_modules("files.read_file")
   end
 
+  test "ghost_keys returns keys not in the registry" do
+    assert Registry.ghost_keys(["basic.sleep", "removed.old_tool", "files.unknown"]) ==
+             ["removed.old_tool", "files.unknown"]
+  end
+
+  test "ghost_keys returns empty list when all keys are valid" do
+    assert Registry.ghost_keys(["basic.sleep", "basic.log"]) == []
+  end
+
+  test "ghost_keys returns empty list for empty input" do
+    assert Registry.ghost_keys([]) == []
+  end
+
+  test "ghost_keys returns empty list for non-list input" do
+    assert Registry.ghost_keys(nil) == []
+    assert Registry.ghost_keys("basic.sleep") == []
+  end
+
   test "model_supports_tools? treats unknown or missing values as false" do
     refute Registry.model_supports_tools?(nil, "gpt-4.1-mini")
     refute Registry.model_supports_tools?("openai", nil)

--- a/test/zaq_web/live/bo/ai/agents_live_test.exs
+++ b/test/zaq_web/live/bo/ai/agents_live_test.exs
@@ -59,6 +59,86 @@ defmodule ZaqWeb.Live.BO.AI.AgentsLiveTest do
     assert render(view) =~ "Create Agent"
   end
 
+  test "displays ghost tools with Removed badge when agent has stale tool keys", %{conn: conn} do
+    credential =
+      ai_credential_fixture(%{provider: "openai", endpoint: "https://api.openai.com/v1"})
+
+    {:ok, agent} =
+      Zaq.Agent.create_agent(%{
+        name: "Ghost Tool Agent #{System.unique_integer([:positive])}",
+        job: "test job",
+        model: "gpt-4.1-mini",
+        credential_id: credential.id,
+        strategy: "react",
+        enabled_tool_keys: []
+      })
+
+    Repo.update!(
+      Ecto.Changeset.change(
+        Repo.get!(Zaq.Agent.ConfiguredAgent, agent.id),
+        enabled_tool_keys: ["removed.ghost_tool"]
+      )
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/bo/agents")
+    render_click(element(view, "#agent-row-#{agent.id}"))
+
+    html = render(view)
+    assert html =~ "removed.ghost_tool"
+    assert html =~ "Removed"
+  end
+
+  test "ghost tool can be removed and agent saved successfully", %{conn: conn} do
+    credential =
+      ai_credential_fixture(%{provider: "openai", endpoint: "https://api.openai.com/v1"})
+
+    {:ok, agent} =
+      Zaq.Agent.create_agent(%{
+        name: "Ghost Remove Agent #{System.unique_integer([:positive])}",
+        job: "test job",
+        model: "gpt-4.1-mini",
+        credential_id: credential.id,
+        strategy: "react",
+        enabled_tool_keys: []
+      })
+
+    Repo.update!(
+      Ecto.Changeset.change(
+        Repo.get!(Zaq.Agent.ConfiguredAgent, agent.id),
+        enabled_tool_keys: ["removed.ghost_tool"]
+      )
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/bo/agents")
+
+    render_click(element(view, "#agent-row-#{agent.id}"))
+    assert has_element?(view, ~s([data-selected-tool-key="removed.ghost_tool"]))
+
+    view
+    |> element(
+      ~s(#configured-agent-form button[phx-click="remove_tool"][phx-value-key="removed.ghost_tool"])
+    )
+    |> render_click()
+
+    refute has_element?(view, ~s([data-selected-tool-key="removed.ghost_tool"]))
+
+    view
+    |> form("#configured-agent-form",
+      configured_agent: %{
+        "name" => agent.name,
+        "job" => agent.job,
+        "model" => "gpt-4.1-mini",
+        "credential_id" => to_string(agent.credential_id),
+        "strategy" => "react",
+        "enabled_tool_keys" => [""],
+        "advanced_options_json" => "{}"
+      }
+    )
+    |> render_submit()
+
+    assert render(view) =~ "Agent updated"
+  end
+
   test "shows unselected tools in searchable add-tools modal", %{conn: conn} do
     _credential =
       ai_credential_fixture(%{provider: "openai", endpoint: "https://api.openai.com/v1"})


### PR DESCRIPTION
Agents with tool keys referencing removed registry entries were completely locked: the changeset validation rejected ghost keys on every save attempt, and the BO UI silently dropped them so they could not be removed.

- Registry.ghost_keys/1: returns the subset of keys not in @tools
- ConfiguredAgent.changeset: allow ghost keys already stored in data; only reject newly-added unknown keys
- selected_tools_panel: maps each selected key to its descriptor or a ghost descriptor, rendering ghost rows in red with a Removed badge

fix #381 