### PR TITLE
fix(node-router): replace deprecated NodeRouter.call/4 with invoke_via/5 across live views, agent pipeline, and hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,15 @@
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 
+# Erlang/OTP runtime directories (Mix build locks, PubSub coordination)
+mix_*_user*/
+
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
 # Temporary files, for example, from tests.
 /tmp/
+/test/tmp/
 
 # Ignore package tarball (built via "mix hex.build").
 zaq-*.tar

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -37,6 +37,7 @@
 - Cross-context calls use public context functions, not internal helpers.
 - Cross-service BO calls always go through `NodeRouter`.
 - Prefer `NodeRouter.dispatch/1` with `%Zaq.Event{}` for new work.
+- Do not use deprecated `NodeRouter.call/4,5`; use `NodeRouter.dispatch/1` or `NodeRouter.invoke/4` (`invoke_via/5` for injected router modules).
 - Role-level event boundary handlers live under `Zaq.<Role>.Api` (including `Zaq.Bo.Api` for `:bo`).
 - BO channel configuration flows must call channels role APIs via `NodeRouter.dispatch/1`, with provider operations delegated to `Zaq.Channels.CommunicationBridge`; they must not call bridge or adapter modules directly.
 

--- a/lib/zaq/agent/pipeline.ex
+++ b/lib/zaq/agent/pipeline.ex
@@ -46,6 +46,7 @@ defmodule Zaq.Agent.Pipeline do
   alias Zaq.Engine.Messages.{Incoming, Outgoing}
   alias Zaq.Engine.Telemetry
   alias Zaq.Event
+  alias Zaq.NodeRouter
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -193,10 +194,13 @@ defmodule Zaq.Agent.Pipeline do
   # ---------------------------------------------------------------------------
 
   defp do_retrieval(clean_msg, history, opts, _incoming) do
-    case node_router(opts).call(:agent, retrieval_mod(opts), :ask, [
-           clean_msg,
-           [history: history]
-         ]) do
+    case NodeRouter.invoke_via(
+           node_router(opts),
+           :agent,
+           retrieval_mod(opts),
+           :ask,
+           [clean_msg, [history: history]]
+         ) do
       {:ok,
        %{
          "query" => query,

--- a/lib/zaq/agent/tools/knowledge_base_overview.ex
+++ b/lib/zaq/agent/tools/knowledge_base_overview.ex
@@ -78,7 +78,13 @@ defmodule Zaq.Agent.Tools.KnowledgeBaseOverview do
       |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
     router_result =
-      node_router_mod.call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [opts])
+      NodeRouter.invoke_via(
+        node_router_mod,
+        :ingestion,
+        DocumentAccess,
+        :list_files_with_ingestion_status,
+        [opts]
+      )
 
     case router_result do
       {:error, reason} ->

--- a/lib/zaq/agent/tools/search_knowledge_base.ex
+++ b/lib/zaq/agent/tools/search_knowledge_base.ex
@@ -51,7 +51,13 @@ defmodule Zaq.Agent.Tools.SearchKnowledgeBase do
       |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
     try do
-      case node_router_mod.call(:ingestion, doc_proc_mod, :query_extraction, [query, opts]) do
+      case NodeRouter.invoke_via(
+             node_router_mod,
+             :ingestion,
+             doc_proc_mod,
+             :query_extraction,
+             [query, opts]
+           ) do
         {:ok, chunks} -> {:ok, %{chunks: chunks, count: length(chunks)}}
         {:error, reason} -> {:error, "Knowledge base search failed: #{inspect(reason)}"}
       end

--- a/lib/zaq/hooks.ex
+++ b/lib/zaq/hooks.ex
@@ -20,7 +20,7 @@ defmodule Zaq.Hooks do
     * `:sync` hooks run in-process; return value is ignored; errors are caught
     * `:async` hooks are spawned in a `Task`:
       - `node_role: :local` → direct `Task.start/1`
-      - `node_role: role`   → `Task.start/1` wrapping `NodeRouter.call/4`
+      - `node_role: role`   → `Task.start/1` wrapping an event-first router invoke
 
   ## Events
 
@@ -353,7 +353,7 @@ defmodule Zaq.Hooks do
 
     Task.start(fn ->
       try do
-        router.call(role, handler, :handle, [event, payload, ctx])
+        Zaq.NodeRouter.invoke_via(router, role, handler, :handle, [event, payload, ctx])
       rescue
         e ->
           emit_handler_error(event, handler, e)

--- a/lib/zaq/node_router.ex
+++ b/lib/zaq/node_router.ex
@@ -82,6 +82,20 @@ defmodule Zaq.NodeRouter do
     invoke(role, mod, fun, args, %{})
   end
 
+  @doc """
+  Builds an invoke event and dispatches it through the provided router module.
+
+  Useful when callers inject a router module in tests and still want a single
+  event-first invoke helper instead of duplicating event construction.
+  """
+  def invoke_via(router_module, role, mod, fun, args) when is_atom(router_module) do
+    _ = Map.fetch!(@supervisor_map, role)
+
+    Event.new(%{module: mod, function: fun, args: args}, role, opts: [action: :invoke])
+    |> router_module.dispatch()
+    |> unwrap_call_response()
+  end
+
   def invoke(role, mod, fun, args, runtime) when is_map(runtime) do
     _ = Map.fetch!(@supervisor_map, role)
 

--- a/lib/zaq_web/live/bo/communication/chat_live.ex
+++ b/lib/zaq_web/live/bo/communication/chat_live.ex
@@ -279,7 +279,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
   def handle_event("filter_autocomplete", %{"query" => query}, socket)
       when is_binary(query) and byte_size(query) > 0 do
     suggestions =
-      case node_router().call(:ingestion, Zaq.Ingestion, :list_document_sources, [query]) do
+      case router_invoke(:ingestion, Zaq.Ingestion, :list_document_sources, [query]) do
         list when is_list(list) ->
           list
 
@@ -696,6 +696,10 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
     RuntimeDeps.chat_live_node_router()
   end
 
+  defp router_invoke(role, mod, fun, args) do
+    NodeRouter.invoke_via(node_router(), role, mod, fun, args)
+  end
+
   defp list_chat_agents do
     Zaq.Agent.list_active_agents()
     |> Enum.map(fn agent -> %{id: to_string(agent.id), name: agent.name} end)
@@ -715,7 +719,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
       if is_nil(current_conversation_id) do
         resolve_conversation(current_user, nil)
       else
-        case node_router().call(
+        case router_invoke(
                :engine,
                Zaq.Engine.Conversations,
                :get_conversation,
@@ -753,7 +757,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
   defp resolve_conversation(current_user, nil), do: create_fresh_conversation(current_user)
 
   defp resolve_conversation(current_user, conversation_id) do
-    case node_router().call(
+    case router_invoke(
            :engine,
            Zaq.Engine.Conversations,
            :get_conversation,
@@ -773,7 +777,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
          normalized_sources
        ) do
     if user_id && is_nil(conv.user_id) do
-      node_router().call(
+      router_invoke(
         :engine,
         Zaq.Engine.Conversations,
         :update_conversation,
@@ -781,7 +785,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
       )
     end
 
-    node_router().call(:engine, Zaq.Engine.Conversations, :add_message, [
+    router_invoke(:engine, Zaq.Engine.Conversations, :add_message, [
       conv,
       %{role: "user", content: user_msg}
     ])
@@ -789,7 +793,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
     tool_calls = Map.get(result.metadata, :tool_calls, []) || []
 
     bot_msg_result =
-      node_router().call(:engine, Zaq.Engine.Conversations, :add_message, [
+      router_invoke(:engine, Zaq.Engine.Conversations, :add_message, [
         conv,
         %{
           role: "assistant",
@@ -853,7 +857,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
       %{channel_user_id: channel_user_id, channel_type: "bo"}
       |> then(fn a -> if user_id, do: Map.put(a, :user_id, user_id), else: a end)
 
-    case node_router().call(:engine, Zaq.Engine.Conversations, :create_conversation, [attrs]) do
+    case router_invoke(:engine, Zaq.Engine.Conversations, :create_conversation, [attrs]) do
       {:ok, conv} = ok ->
         persist_welcome_message(conv)
         ok
@@ -864,7 +868,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLive do
   end
 
   defp persist_welcome_message(conv) do
-    node_router().call(:engine, Zaq.Engine.Conversations, :add_message, [
+    router_invoke(:engine, Zaq.Engine.Conversations, :add_message, [
       conv,
       %{role: "assistant", content: @welcome_body, metadata: %{"welcome" => true}}
     ])

--- a/lib/zaq_web/live/bo/communication/notification_imap_live.ex
+++ b/lib/zaq_web/live/bo/communication/notification_imap_live.ex
@@ -401,7 +401,9 @@ defmodule ZaqWeb.Live.BO.Communication.NotificationImapLive do
         Zaq.Event.new(%{provider: provider}, :channels, opts: [action: :sync_provider_runtime])
       ).response
     else
-      node_router_mod.call(:channels, channels_mod, :sync_provider_runtime, [provider])
+      NodeRouter.invoke_via(node_router_mod, :channels, channels_mod, :sync_provider_runtime, [
+        provider
+      ])
     end
   end
 
@@ -416,7 +418,10 @@ defmodule ZaqWeb.Live.BO.Communication.NotificationImapLive do
         )
       ).response
     else
-      node_router_mod.call(:channels, channels_mod, :list_mailboxes, [@imap_provider, config])
+      NodeRouter.invoke_via(node_router_mod, :channels, channels_mod, :list_mailboxes, [
+        @imap_provider,
+        config
+      ])
     end
   end
 

--- a/lib/zaq_web/live/bo/knowledge_base_metrics_live.ex
+++ b/lib/zaq_web/live/bo/knowledge_base_metrics_live.ex
@@ -74,7 +74,13 @@ defmodule ZaqWeb.Live.BO.KnowledgeBaseMetricsLive do
   end
 
   defp load_knowledge_base_metrics_data(filters) do
-    case node_router_module().call(:engine, Telemetry, :load_knowledge_base_metrics, [filters]) do
+    case NodeRouter.invoke_via(
+           node_router_module(),
+           :engine,
+           Telemetry,
+           :load_knowledge_base_metrics,
+           [filters]
+         ) do
       %{} = payload -> payload
       _ -> default_payload(filters)
     end

--- a/test/mix/tasks/hooks_verify_test.exs
+++ b/test/mix/tasks/hooks_verify_test.exs
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Hooks.VerifyTest do
   # ---------------------------------------------------------------------------
 
   defp tmp_dir do
-    dir = Path.join(System.tmp_dir!(), "hooks_verify_#{System.unique_integer([:positive])}")
+    dir = Path.join(Path.expand("test/tmp"), "hooks_verify_#{System.unique_integer([:positive])}")
     File.mkdir_p!(dir)
     dir
   end

--- a/test/mix/tasks/zaq/python/fetch_test.exs
+++ b/test/mix/tasks/zaq/python/fetch_test.exs
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Zaq.Python.FetchTest do
     Zaq.FetchPythonHTTPClientStub.clear_responder()
 
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_fetch_python_#{System.unique_integer([:positive])}")
+      Path.join(Path.expand("test/tmp"), "zaq_fetch_python_#{System.unique_integer([:positive])}")
 
     File.mkdir_p!(tmp_dir)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,3 +2,9 @@ ExUnit.start(exclude: [:integration], capture_log: true)
 Ecto.Adapters.SQL.Sandbox.mode(Zaq.Repo, :manual)
 Logger.put_module_level(Postgrex.Protocol, :none)
 Logger.put_module_level(Task.Supervised, :none)
+
+# Ensure test/tmp exists and is clean before each run.
+# All test-generated temp files live here so they never land in the project root.
+File.rm_rf!("test/tmp")
+File.mkdir_p!("test/tmp")
+Application.put_env(:plug, :upload_tmp_dir, Path.expand("test/tmp"))

--- a/test/zaq/agent/pipeline_test.exs
+++ b/test/zaq/agent/pipeline_test.exs
@@ -17,29 +17,18 @@ defmodule Zaq.Agent.PipelineTest do
   # ---------------------------------------------------------------------------
 
   defmodule StubNodeRouter do
-    def dispatch(%Zaq.Event{request: %{provider: provider, channel_id: channel_id}}) do
+    def dispatch(%Zaq.Event{request: %{provider: provider, channel_id: channel_id}} = event) do
       send(:pipeline_test_pid, {:typing_called, provider, channel_id})
       result = Process.get(:typing_router_result, :ok)
+      %{event | response: result}
+    end
 
-      %Zaq.Event{
-        request: %{},
-        next_hop: %Zaq.EventHop{
-          destination: :channels,
-          type: :async,
-          timestamp: DateTime.utc_now()
-        },
-        response: result
-      }
+    def dispatch(%Zaq.Event{request: %{module: mod, function: fun, args: args}} = event)
+        when is_atom(mod) and is_atom(fun) and is_list(args) do
+      %{event | response: apply(mod, fun, args)}
     end
 
     def dispatch(%Zaq.Event{} = event), do: %{event | response: nil}
-
-    def call(:channels, Zaq.Channels.Router, :send_typing, [provider, channel_id]) do
-      send(:pipeline_test_pid, {:typing_called, provider, channel_id})
-      Process.get(:typing_router_result, :ok)
-    end
-
-    def call(_role, module, function, args), do: apply(module, function, args)
   end
 
   defmodule StubIdentityPlug do

--- a/test/zaq/agent/tools/knowledge_base_overview_test.exs
+++ b/test/zaq/agent/tools/knowledge_base_overview_test.exs
@@ -9,11 +9,12 @@ defmodule Zaq.Agent.Tools.KnowledgeBaseOverviewTest do
 
   # Routes directly to DocumentAccess without going through a real node boundary.
   defmodule PassthroughRouter do
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [opts]) do
-      DocumentAccess.list_files_with_ingestion_status(opts)
+    def dispatch(%Zaq.Event{request: %{module: mod, function: fun, args: args}} = event)
+        when is_atom(mod) and is_atom(fun) and is_list(args) do
+      %{event | response: apply(mod, fun, args)}
     end
 
-    def call(_role, _mod, :broadcast_status, _args), do: :ok
+    def dispatch(%Zaq.Event{} = event), do: %{event | response: :ok}
   end
 
   setup do
@@ -143,11 +144,7 @@ defmodule Zaq.Agent.Tools.KnowledgeBaseOverviewTest do
 
     test "returns error tuple when router returns error" do
       defmodule ErrorRouter do
-        def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [_opts]) do
-          {:error, :simulated_failure}
-        end
-
-        def call(_role, _mod, :broadcast_status, _args), do: :ok
+        def dispatch(%Zaq.Event{} = event), do: %{event | response: {:error, :simulated_failure}}
       end
 
       ctx = %{status_context: nil, node_router: ErrorRouter, skip_permissions: true}

--- a/test/zaq/agent/tools/list_knowledge_base_files_test.exs
+++ b/test/zaq/agent/tools/list_knowledge_base_files_test.exs
@@ -9,54 +9,60 @@ defmodule Zaq.Agent.Tools.KnowledgeBaseOverviewUnitTest do
   # ---------------------------------------------------------------------------
 
   defmodule StubRouter do
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [_opts]) do
-      {:ok,
-       [
-         %{source: "folder/doc.md", ingested: true, title: "A Document"},
-         %{source: "folder/raw.txt", ingested: false}
-       ]}
+    def dispatch(%Zaq.Event{request: %{args: [_opts]}} = event) do
+      %{
+        event
+        | response:
+            {:ok,
+             [
+               %{source: "folder/doc.md", ingested: true, title: "A Document"},
+               %{source: "folder/raw.txt", ingested: false}
+             ]}
+      }
     end
   end
 
   defmodule EmptyRouter do
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [_opts]) do
-      {:ok, []}
+    def dispatch(%Zaq.Event{} = event) do
+      %{event | response: {:ok, []}}
     end
   end
 
   # Returns a plain list (no {:ok, _} wrapper) to exercise the passthrough clause
   # of unwrap_router_result/1.
   defmodule PlainListRouter do
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [_opts]) do
-      [%{source: "plain.md", ingested: true, title: "Plain"}]
+    def dispatch(%Zaq.Event{} = event) do
+      %{event | response: [%{source: "plain.md", ingested: true, title: "Plain"}]}
     end
   end
 
   # Returns an error tuple — triggers the rescue path.
   defmodule ErrorRouter do
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [_opts]) do
-      {:error, :simulated_failure}
+    def dispatch(%Zaq.Event{} = event) do
+      %{event | response: {:error, :simulated_failure}}
     end
   end
 
   # Asserts exact permission opts and returns an error for anything unexpected.
   defmodule PermissionRouter do
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [
-          [person_id: 42, team_ids: [1, 2], skip_permissions: false]
-        ]) do
-      {:ok, []}
+    def dispatch(
+          %Zaq.Event{
+            request: %{args: [[person_id: 42, team_ids: [1, 2], skip_permissions: false]]}
+          } = event
+        ) do
+      %{event | response: {:ok, []}}
     end
 
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [opts]) do
-      {:ok, [{:unexpected_opts, opts}]}
+    def dispatch(%Zaq.Event{request: %{args: [opts]}} = event) do
+      %{event | response: {:ok, [{:unexpected_opts, opts}]}}
     end
   end
 
   # Captures the opts passed to the router for inspection.
   defmodule CaptureRouter do
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [opts]) do
+    def dispatch(%Zaq.Event{request: %{args: [opts]}} = event) do
       send(self(), {:captured_opts, opts})
-      {:ok, []}
+      %{event | response: {:ok, []}}
     end
   end
 

--- a/test/zaq/agent/tools/search_knowledge_base_test.exs
+++ b/test/zaq/agent/tools/search_knowledge_base_test.exs
@@ -4,20 +4,32 @@ defmodule Zaq.Agent.Tools.SearchKnowledgeBaseTest do
   alias Zaq.Agent.Tools.SearchKnowledgeBase
 
   defmodule StubNodeRouter do
-    def call(:ingestion, _mod, :query_extraction, ["find elixir", _opts]) do
-      {:ok,
-       [
-         %{"content" => "Elixir runs on the BEAM VM.", "source" => "docs/elixir.md"},
-         %{"content" => "It was created by José Valim."}
-       ]}
+    def dispatch(
+          %Zaq.Event{request: %{function: :query_extraction, args: ["find elixir", _opts]}} =
+            event
+        ) do
+      %{
+        event
+        | response:
+            {:ok,
+             [
+               %{"content" => "Elixir runs on the BEAM VM.", "source" => "docs/elixir.md"},
+               %{"content" => "It was created by José Valim."}
+             ]}
+      }
     end
 
-    def call(:ingestion, _mod, :query_extraction, ["timeout query", _opts]) do
-      {:error, :timeout}
+    def dispatch(
+          %Zaq.Event{request: %{function: :query_extraction, args: ["timeout query", _opts]}} =
+            event
+        ) do
+      %{event | response: {:error, :timeout}}
     end
 
-    def call(:ingestion, _mod, :query_extraction, [_query, _opts]) do
-      {:ok, []}
+    def dispatch(
+          %Zaq.Event{request: %{function: :query_extraction, args: [_query, _opts]}} = event
+        ) do
+      %{event | response: {:ok, []}}
     end
   end
 
@@ -25,35 +37,42 @@ defmodule Zaq.Agent.Tools.SearchKnowledgeBaseTest do
   # skip_permissions: false — any deviation causes the fallback to return an
   # error, which fails the test that asserts {:ok, _}.
   defmodule PermissionRouter do
-    def call(:ingestion, _mod, :query_extraction, [
-          _query,
-          [person_id: 42, team_ids: [1, 2], skip_permissions: false]
-        ]) do
-      {:ok, []}
+    def dispatch(
+          %Zaq.Event{
+            request: %{args: [_query, [person_id: 42, team_ids: [1, 2], skip_permissions: false]]}
+          } = event
+        ) do
+      %{event | response: {:ok, []}}
     end
 
-    def call(:ingestion, _mod, :query_extraction, [_query, opts]) do
-      {:error, {:unexpected_opts, opts}}
+    def dispatch(%Zaq.Event{request: %{args: [_query, opts]}} = event) do
+      %{event | response: {:error, {:unexpected_opts, opts}}}
     end
   end
 
   defmodule SkipPermissionsRouter do
-    def call(:ingestion, _mod, :query_extraction, [_query, opts]) do
-      case {Keyword.get(opts, :person_id), Keyword.get(opts, :skip_permissions)} do
-        {nil, false} -> {:ok, []}
-        {nil, true} -> {:ok, []}
-        {_id, false} -> {:ok, []}
-        {_id, other} -> {:error, {:skip_permissions_was, other}}
-      end
+    def dispatch(%Zaq.Event{request: %{args: [_query, opts]}} = event) do
+      response =
+        case {Keyword.get(opts, :person_id), Keyword.get(opts, :skip_permissions)} do
+          {nil, false} -> {:ok, []}
+          {nil, true} -> {:ok, []}
+          {_id, false} -> {:ok, []}
+          {_id, other} -> {:error, {:skip_permissions_was, other}}
+        end
+
+      %{event | response: response}
     end
   end
 
   defmodule DefaultTeamIdsRouter do
-    def call(:ingestion, _mod, :query_extraction, [_query, opts]) do
-      case Keyword.get(opts, :team_ids) do
-        [] -> {:ok, []}
-        other -> {:error, {:team_ids_was, other}}
-      end
+    def dispatch(%Zaq.Event{request: %{args: [_query, opts]}} = event) do
+      response =
+        case Keyword.get(opts, :team_ids) do
+          [] -> {:ok, []}
+          other -> {:error, {:team_ids_was, other}}
+        end
+
+      %{event | response: response}
     end
   end
 

--- a/test/zaq/channels/jido_chat_bridge_test.exs
+++ b/test/zaq/channels/jido_chat_bridge_test.exs
@@ -125,8 +125,6 @@ defmodule Zaq.Channels.JidoChatBridgeTest do
           %{event | response: {:error, :unsupported}}
       end
     end
-
-    def call(role, mod, fun, args), do: Zaq.NodeRouter.call(role, mod, fun, args)
   end
 
   defmodule RealAllActionsNodeRouter do
@@ -136,8 +134,6 @@ defmodule Zaq.Channels.JidoChatBridgeTest do
         node_list_fn: fn -> [] end
       })
     end
-
-    def call(role, mod, fun, args), do: Zaq.NodeRouter.call(role, mod, fun, args)
   end
 
   defmodule CapturingNodeRouter do

--- a/test/zaq/hooks_test.exs
+++ b/test/zaq/hooks_test.exs
@@ -99,20 +99,25 @@ defmodule Zaq.HooksTest do
   end
 
   defmodule FakeNodeRouter do
-    def call(role, handler, fun, args) do
-      # Extract test_pid from the payload argument (3rd element of args: [event, payload, ctx])
+    def dispatch(
+          %Zaq.Event{
+            next_hop: %{destination: role},
+            request: %{module: handler, function: fun, args: args}
+          } = event
+        ) do
+      # payload is the 2nd element of args: [hook_event, payload, ctx]
       payload = Enum.at(args, 1, %{})
 
       if dest = Map.get(payload, :notify) do
         send(dest, {:router_called, role, handler, fun, args})
       end
 
-      :ok
+      %{event | response: :ok}
     end
   end
 
   defmodule FailingNodeRouter do
-    def call(_role, _handler, _fun, _args), do: raise("rpc failed")
+    def dispatch(%Zaq.Event{} = _event), do: raise("rpc failed")
   end
 
   defmodule SyncCapture do

--- a/test/zaq/ingestion/document_access_filesystem_test.exs
+++ b/test/zaq/ingestion/document_access_filesystem_test.exs
@@ -9,7 +9,7 @@ defmodule Zaq.Ingestion.DocumentAccessFilesystemTest do
     seed_embedding_config(%{model: "test-model", dimension: "1536"})
 
     tmp =
-      Path.join(System.tmp_dir!(), "doc_access_fs_#{System.unique_integer([:positive])}")
+      Path.join(Path.expand("test/tmp"), "doc_access_fs_#{System.unique_integer([:positive])}")
 
     File.mkdir_p!(tmp)
 

--- a/test/zaq/ingestion/document_processor_test.exs
+++ b/test/zaq/ingestion/document_processor_test.exs
@@ -196,7 +196,9 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
     end
 
     test "returns path relative to configured base_path" do
-      base_dir = Path.join(System.tmp_dir!(), "zaq_base_#{System.unique_integer([:positive])}")
+      base_dir =
+        Path.join(Path.expand("test/tmp"), "zaq_base_#{System.unique_integer([:positive])}")
+
       Application.put_env(:zaq, Zaq.Ingestion, base_path: base_dir)
 
       file_path = Path.join([base_dir, "guides", "api", "reference.md"])
@@ -206,17 +208,21 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
     end
 
     test "falls back to basename when path is outside configured base_path" do
-      base_dir = Path.join(System.tmp_dir!(), "zaq_base_#{System.unique_integer([:positive])}")
+      base_dir =
+        Path.join(Path.expand("test/tmp"), "zaq_base_#{System.unique_integer([:positive])}")
+
       Application.put_env(:zaq, Zaq.Ingestion, base_path: base_dir)
 
-      outside_path = Path.join(System.tmp_dir!(), "not-in-base.md")
+      outside_path = Path.join(Path.expand("test/tmp"), "not-in-base.md")
 
       assert {:ok, "not-in-base.md"} =
                DocumentProcessor.extract_source("ignored", outside_path)
     end
 
     test "prefixes volume name when file lives in a configured volume" do
-      vol_dir = Path.join(System.tmp_dir!(), "zaq_vol_#{System.unique_integer([:positive])}")
+      vol_dir =
+        Path.join(Path.expand("test/tmp"), "zaq_vol_#{System.unique_integer([:positive])}")
+
       Application.put_env(:zaq, Zaq.Ingestion, volumes: %{"docs" => vol_dir})
 
       file_path = Path.join([vol_dir, "sub", "guide.md"])
@@ -753,7 +759,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
       stub_chunk_title_success()
 
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_test_#{System.unique_integer([:positive])}")
+        Path.join(Path.expand("test/tmp"), "zaq_test_#{System.unique_integer([:positive])}")
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)
@@ -892,7 +898,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
   describe "process_folder/1" do
     setup do
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_folder_#{System.unique_integer([:positive])}")
+        Path.join(Path.expand("test/tmp"), "zaq_folder_#{System.unique_integer([:positive])}")
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)
@@ -1106,7 +1112,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
   describe "prepare_file_chunks/3" do
     setup do
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_prepare_#{System.unique_integer([:positive])}")
+        Path.join(Path.expand("test/tmp"), "zaq_prepare_#{System.unique_integer([:positive])}")
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)
@@ -1160,7 +1166,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
       stub_chunk_title_success()
 
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_more_paths_#{System.unique_integer([:positive])}")
+        Path.join(Path.expand("test/tmp"), "zaq_more_paths_#{System.unique_integer([:positive])}")
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)
@@ -2108,7 +2114,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
       stub_chunk_title_success()
 
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_csv_#{System.unique_integer([:positive])}")
+        Path.join(Path.expand("test/tmp"), "zaq_csv_#{System.unique_integer([:positive])}")
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)
@@ -2157,7 +2163,7 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
       stub_chunk_title_success()
 
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_imgmd_#{System.unique_integer([:positive])}")
+        Path.join(Path.expand("test/tmp"), "zaq_imgmd_#{System.unique_integer([:positive])}")
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)

--- a/test/zaq/ingestion/ingest_worker_test.exs
+++ b/test/zaq/ingestion/ingest_worker_test.exs
@@ -214,7 +214,7 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
 
     test "resolves path against volume_name when job has one" do
       vol_dir =
-        Path.join(System.tmp_dir!(), "zaq_worker_vol_#{System.unique_integer([:positive])}")
+        Path.join(Path.expand("test/tmp"), "zaq_worker_vol_#{System.unique_integer([:positive])}")
 
       File.mkdir_p!(vol_dir)
 

--- a/test/zaq/ingestion/python/pipeline_strip_image_refs_test.exs
+++ b/test/zaq/ingestion/python/pipeline_strip_image_refs_test.exs
@@ -10,7 +10,7 @@ defmodule Zaq.Ingestion.Python.PipelineStripImageRefsTest do
 
   setup do
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_strip_test_#{System.unique_integer([:positive])}")
+      Path.join(Path.expand("test/tmp"), "zaq_strip_test_#{System.unique_integer([:positive])}")
 
     File.mkdir_p!(tmp_dir)
     on_exit(fn -> File.rm_rf!(tmp_dir) end)

--- a/test/zaq/ingestion/python/pipeline_test.exs
+++ b/test/zaq/ingestion/python/pipeline_test.exs
@@ -7,7 +7,10 @@ defmodule Zaq.Ingestion.Python.PipelineTest do
 
   setup do
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_pipeline_test_#{System.unique_integer([:positive])}")
+      Path.join(
+        Path.expand("test/tmp"),
+        "zaq_pipeline_test_#{System.unique_integer([:positive])}"
+      )
 
     File.mkdir_p!(tmp_dir)
     on_exit(fn -> File.rm_rf!(tmp_dir) end)

--- a/test/zaq/ingestion/python/runner_test.exs
+++ b/test/zaq/ingestion/python/runner_test.exs
@@ -60,7 +60,10 @@ defmodule Zaq.Ingestion.Python.RunnerTest do
   describe "run/2" do
     setup do
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_runner_test_#{System.unique_integer([:positive])}")
+        Path.join(
+          Path.expand("test/tmp"),
+          "zaq_runner_test_#{System.unique_integer([:positive])}"
+        )
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)
@@ -158,7 +161,10 @@ defmodule Zaq.Ingestion.Python.RunnerTest do
   describe "collect_output :noeol reassembly" do
     setup do
       tmp_dir =
-        Path.join(System.tmp_dir!(), "zaq_runner_noeol_#{System.unique_integer([:positive])}")
+        Path.join(
+          Path.expand("test/tmp"),
+          "zaq_runner_noeol_#{System.unique_integer([:positive])}"
+        )
 
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)

--- a/test/zaq/ingestion/python/steps/clean_md_test.exs
+++ b/test/zaq/ingestion/python/steps/clean_md_test.exs
@@ -5,7 +5,10 @@ defmodule Zaq.Ingestion.Python.Steps.CleanMdTest do
 
   setup do
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_clean_md_test_#{System.unique_integer([:positive])}")
+      Path.join(
+        Path.expand("test/tmp"),
+        "zaq_clean_md_test_#{System.unique_integer([:positive])}"
+      )
 
     File.mkdir_p!(tmp_dir)
     on_exit(fn -> File.rm_rf!(tmp_dir) end)

--- a/test/zaq/ingestion/sidecar_e2e_test.exs
+++ b/test/zaq/ingestion/sidecar_e2e_test.exs
@@ -25,13 +25,12 @@ defmodule Zaq.Ingestion.SidecarE2ETest do
   alias Zaq.SystemConfigFixtures
 
   defmodule PassthroughRouter do
-    alias Zaq.Ingestion.DocumentAccess
-
-    def call(:ingestion, DocumentAccess, :list_files_with_ingestion_status, [opts]) do
-      DocumentAccess.list_files_with_ingestion_status(opts)
+    def dispatch(%Zaq.Event{request: %{module: mod, function: fun, args: args}} = event)
+        when is_atom(mod) and is_atom(fun) and is_list(args) do
+      %{event | response: apply(mod, fun, args)}
     end
 
-    def call(_role, _mod, :broadcast_status, _args), do: :ok
+    def dispatch(%Zaq.Event{} = event), do: %{event | response: :ok}
   end
 
   setup :verify_on_exit!
@@ -40,7 +39,7 @@ defmodule Zaq.Ingestion.SidecarE2ETest do
     SystemConfigFixtures.seed_embedding_config(%{model: "test-model", dimension: "1536"})
 
     tmp =
-      Path.join(System.tmp_dir!(), "sidecar_e2e_#{System.unique_integer([:positive])}")
+      Path.join(Path.expand("test/tmp"), "sidecar_e2e_#{System.unique_integer([:positive])}")
 
     File.mkdir_p!(tmp)
 

--- a/test/zaq/ingestion/source_path_test.exs
+++ b/test/zaq/ingestion/source_path_test.exs
@@ -46,7 +46,7 @@ defmodule Zaq.Ingestion.SourcePathTest do
   describe "absolute_to_source/1 in multi-volume mode" do
     test "falls back to basename when path is outside all configured volumes" do
       # line 95: find_volume_for_path returns nil
-      tmp = System.tmp_dir!()
+      tmp = Path.expand("test/tmp")
       vol_path = Path.join(tmp, "zaq_source_path_vol_#{System.unique_integer([:positive])}")
       File.mkdir_p!(vol_path)
 
@@ -64,7 +64,7 @@ defmodule Zaq.Ingestion.SourcePathTest do
   describe "absolute_to_source/1 in single-volume mode" do
     test "falls back to basename when path is outside the configured base" do
       # line 104: relative_to_root returns nil
-      tmp = System.tmp_dir!()
+      tmp = Path.expand("test/tmp")
       base = Path.join(tmp, "zaq_source_path_base_#{System.unique_integer([:positive])}")
       File.mkdir_p!(base)
       Application.put_env(:zaq, Zaq.Ingestion, base_path: base)
@@ -89,7 +89,7 @@ defmodule Zaq.Ingestion.SourcePathTest do
     end
 
     test "returns the matching volume root when path is inside a volume" do
-      tmp = System.tmp_dir!()
+      tmp = Path.expand("test/tmp")
       vol = Path.join(tmp, "vol_root_test_#{System.unique_integer([:positive])}")
       File.mkdir_p!(vol)
       Application.put_env(:zaq, Zaq.Ingestion, base_path: vol)

--- a/test/zaq/license/license_integration_test.exs
+++ b/test/zaq/license/license_integration_test.exs
@@ -34,7 +34,7 @@ defmodule Zaq.License.LicenseIntegrationTest do
 
     tmp_dir =
       Path.join(
-        System.tmp_dir!(),
+        Path.expand("test/tmp"),
         "zaq_integration_test_#{System.unique_integer([:positive])}"
       )
 

--- a/test/zaq/license/loader_test.exs
+++ b/test/zaq/license/loader_test.exs
@@ -26,7 +26,7 @@ defmodule Zaq.License.LoaderTest do
     write_public_key(pub)
 
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_loader_test_#{System.unique_integer([:positive])}")
+      Path.join(Path.expand("test/tmp"), "zaq_loader_test_#{System.unique_integer([:positive])}")
 
     File.mkdir_p!(tmp_dir)
 

--- a/test/zaq/license_integration_test.exs
+++ b/test/zaq/license_integration_test.exs
@@ -45,7 +45,7 @@ defmodule Zaq.License.IntegrationTest do
     File.write!(@private_key_path, String.trim(private_pem))
     File.write!(@public_key_path, String.trim(public_pem))
 
-    tmp_dir = Path.join(System.tmp_dir!(), "zaq_license_test_#{:rand.uniform(100_000)}")
+    tmp_dir = Path.join(Path.expand("test/tmp"), "zaq_license_test_#{:rand.uniform(100_000)}")
     File.mkdir_p!(tmp_dir)
 
     on_exit(fn ->

--- a/test/zaq/node_router_test.exs
+++ b/test/zaq/node_router_test.exs
@@ -72,19 +72,19 @@ defmodule Zaq.NodeRouterTest do
     end
   end
 
-  describe "call/4" do
+  describe "invoke/4" do
     test "calls function locally when service runs on local node" do
-      result = NodeRouter.call(:bo, String, :upcase, ["hello"])
+      result = NodeRouter.invoke(:bo, String, :upcase, ["hello"])
       assert result == "HELLO"
     end
 
     test "dispatches to local node for bo role since endpoint is running" do
-      result = NodeRouter.call(:bo, Kernel, :node, [])
+      result = NodeRouter.invoke(:bo, Kernel, :node, [])
       assert result == node()
     end
 
     test "falls back to local apply when role supervisor is not found" do
-      result = NodeRouter.call(:agent, String, :replace, ["abc", "a", "z"])
+      result = NodeRouter.invoke(:agent, String, :replace, ["abc", "a", "z"])
       assert result == "zbc"
     end
 
@@ -102,7 +102,7 @@ defmodule Zaq.NodeRouterTest do
         end
       }
 
-      assert NodeRouter.call(:agent, String, :upcase, ["hello"], runtime) == "HELLO FROM REMOTE"
+      assert NodeRouter.invoke(:agent, String, :upcase, ["hello"], runtime) == "HELLO FROM REMOTE"
     end
 
     test "wraps badrpc failures from remote calls" do
@@ -119,13 +119,13 @@ defmodule Zaq.NodeRouterTest do
         end
       }
 
-      assert NodeRouter.call(:agent, String, :upcase, ["hello"], runtime) ==
+      assert NodeRouter.invoke(:agent, String, :upcase, ["hello"], runtime) ==
                {:error, {:rpc_failed, :remote@host, :timeout}}
     end
 
     test "raises for unknown role" do
       assert_raise KeyError, fn ->
-        NodeRouter.call(:unknown, String, :upcase, ["hello"])
+        NodeRouter.invoke(:unknown, String, :upcase, ["hello"])
       end
     end
   end

--- a/test/zaq_web/controllers/file_controller_test.exs
+++ b/test/zaq_web/controllers/file_controller_test.exs
@@ -12,7 +12,10 @@ defmodule ZaqWeb.FileControllerTest do
     conn = init_test_session(conn, %{user_id: user.id})
 
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_file_controller_#{System.unique_integer([:positive])}")
+      Path.join(
+        Path.expand("test/tmp"),
+        "zaq_file_controller_#{System.unique_integer([:positive])}"
+      )
 
     File.mkdir_p!(tmp_dir)
 

--- a/test/zaq_web/live/bo/ai/file_preview_live_test.exs
+++ b/test/zaq_web/live/bo/ai/file_preview_live_test.exs
@@ -15,7 +15,10 @@ defmodule ZaqWeb.Live.BO.AI.FilePreviewLiveTest do
     conn = init_test_session(conn, %{user_id: user.id})
 
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_file_preview_live_#{System.unique_integer([:positive])}")
+      Path.join(
+        Path.expand("test/tmp"),
+        "zaq_file_preview_live_#{System.unique_integer([:positive])}"
+      )
 
     File.mkdir_p!(tmp_dir)
 
@@ -108,7 +111,7 @@ defmodule ZaqWeb.Live.BO.AI.FilePreviewLiveTest do
       assert has_element?(view, "a[download='#{unique}.docx']")
 
       leftovers =
-        Path.wildcard(Path.join(System.tmp_dir!(), "#{unique}-*.md"))
+        Path.wildcard(Path.join(Path.expand("test/tmp"), "#{unique}-*.md"))
 
       assert leftovers == []
     end
@@ -127,7 +130,7 @@ defmodule ZaqWeb.Live.BO.AI.FilePreviewLiveTest do
       assert has_element?(view, "a[download='#{unique}.xlsx']")
 
       leftovers =
-        Path.wildcard(Path.join(System.tmp_dir!(), "#{unique}-*.md"))
+        Path.wildcard(Path.join(Path.expand("test/tmp"), "#{unique}-*.md"))
 
       assert leftovers == []
     end

--- a/test/zaq_web/live/bo/ai/ingestion_live_test.exs
+++ b/test/zaq_web/live/bo/ai/ingestion_live_test.exs
@@ -27,7 +27,10 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
     conn = init_test_session(conn, %{user_id: user.id})
 
     tmp_dir =
-      Path.join(System.tmp_dir!(), "zaq_ingestion_live_#{System.unique_integer([:positive])}")
+      Path.join(
+        Path.expand("test/tmp"),
+        "zaq_ingestion_live_#{System.unique_integer([:positive])}"
+      )
 
     File.mkdir_p!(tmp_dir)
     File.mkdir_p!(Path.join(tmp_dir, "docs/sub"))

--- a/test/zaq_web/live/bo/communication/chat_live_test.exs
+++ b/test/zaq_web/live/bo/communication/chat_live_test.exs
@@ -19,40 +19,14 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLiveTest do
   alias ZaqWeb.Helpers.DateFormat
 
   defmodule NodeRouterFake do
-    def dispatch(event) do
+    def dispatch(%Zaq.Event{} = event) do
       state = :persistent_term.get(__MODULE__, %{})
       handler = Map.get(state, :dispatch)
 
       log = :persistent_term.get({__MODULE__, :dispatches}, [])
       :persistent_term.put({__MODULE__, :dispatches}, [event | log])
 
-      cond do
-        is_function(handler, 1) ->
-          handler.(event)
-
-        is_function(handler, 0) ->
-          handler.()
-
-        true ->
-          Zaq.NodeRouter.dispatch(event, %{
-            current_node_fn: fn -> node() end,
-            node_list_fn: fn -> [] end
-          })
-      end
-    end
-
-    def call(role, mod, fun, args) do
-      state = :persistent_term.get(__MODULE__, %{})
-      handler = Map.get(state, {role, mod, fun})
-
-      log = :persistent_term.get({__MODULE__, :calls}, [])
-      :persistent_term.put({__MODULE__, :calls}, [{role, mod, fun, args} | log])
-
-      cond do
-        is_function(handler, 1) -> handler.(args)
-        is_function(handler, 0) -> handler.()
-        true -> {:error, {:missing_stub, role, mod, fun}}
-      end
+      dispatch_with_handler(handler, state, event)
     end
 
     def put(role, mod, fun, response_or_fun) do
@@ -85,6 +59,53 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLiveTest do
       :persistent_term.put({__MODULE__, :calls}, [])
       :persistent_term.put({__MODULE__, :dispatches}, [])
     end
+
+    defp dispatch_with_handler(handler, state, event) when is_function(handler, 1),
+      do: handler.(event)
+
+    defp dispatch_with_handler(handler, _state, _event) when is_function(handler, 0),
+      do: handler.()
+
+    defp dispatch_with_handler(_handler, state, event) do
+      case parse_invoke_request(event) do
+        {:ok, role, mod, fun, args} -> handle_stubbed_invoke(state, event, role, mod, fun, args)
+        :error -> fallback_dispatch(event)
+      end
+    end
+
+    defp parse_invoke_request(%{opts: opts, next_hop: %{destination: role}, request: request})
+         when is_list(opts) and is_map(request) and role != nil do
+      mod = Map.get(request, :module)
+      fun = Map.get(request, :function)
+      args = Map.get(request, :args)
+
+      if opts[:action] == :invoke and is_atom(mod) and is_atom(fun) and is_list(args) do
+        {:ok, role, mod, fun, args}
+      else
+        :error
+      end
+    end
+
+    defp parse_invoke_request(_event), do: :error
+
+    defp handle_stubbed_invoke(state, event, role, mod, fun, args) do
+      calls_log = :persistent_term.get({__MODULE__, :calls}, [])
+      :persistent_term.put({__MODULE__, :calls}, [{role, mod, fun, args} | calls_log])
+      stub = Map.get(state, {role, mod, fun})
+
+      cond do
+        is_function(stub, 1) -> %{event | response: stub.(args)}
+        is_function(stub, 0) -> %{event | response: stub.()}
+        true -> %{event | response: {:error, {:missing_stub, role, mod, fun}}}
+      end
+    end
+
+    defp fallback_dispatch(event) do
+      Zaq.NodeRouter.dispatch(event, %{
+        current_node_fn: fn -> node() end,
+        node_list_fn: fn -> [] end
+      })
+    end
   end
 
   # FakeExecutor bridges the old NodeRouterFake(:agent, Answering, :ask) stub convention
@@ -97,7 +118,7 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLiveTest do
     def run(%Incoming{} = incoming, opts) do
       nr = Keyword.get(opts, :node_router, NodeRouterFake)
 
-      case nr.call(:agent, Answering, :ask, []) do
+      case Zaq.NodeRouter.invoke_via(nr, :agent, Answering, :ask, []) do
         {:ok, %{answer: answer, confidence: %{score: score}}} ->
           %Outgoing{
             body: answer,
@@ -238,16 +259,22 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLiveTest do
     NodeRouterFake.put_dispatch(fn %Event{} = event ->
       send(caller, {:chat_dispatch_event, event})
 
-      incoming = event.request
+      case event.opts[:action] do
+        :run_pipeline ->
+          incoming = event.request
 
-      %{
-        event
-        | response: %Outgoing{
-            body: "ok",
-            channel_id: incoming.channel_id,
-            provider: incoming.provider
+          %{
+            event
+            | response: %Outgoing{
+                body: "ok",
+                channel_id: incoming.channel_id,
+                provider: incoming.provider
+              }
           }
-      }
+
+        _ ->
+          Zaq.NodeRouter.dispatch(event)
+      end
     end)
 
     {:ok, view, html} = live(conn, ~p"/bo/chat")
@@ -261,7 +288,11 @@ defmodule ZaqWeb.Live.BO.Communication.ChatLiveTest do
 
     view |> element("#chat-form") |> render_submit(%{"message" => "Hello"})
 
-    assert_receive {:chat_dispatch_event, %Event{} = dispatched_event}, 1_000
+    assert_receive {:chat_dispatch_event, %Event{}}, 1_000
+
+    dispatched_event =
+      NodeRouterFake.dispatches()
+      |> Enum.find(fn %Event{} = event -> event.opts[:action] == :run_pipeline end)
 
     assert dispatched_event.assigns["agent_selection"] == %{
              "agent_id" => to_string(configured_agent.id),

--- a/test/zaq_web/live/bo/knowledge_base_metrics_live_test.exs
+++ b/test/zaq_web/live/bo/knowledge_base_metrics_live_test.exs
@@ -8,13 +8,17 @@ defmodule ZaqWeb.Live.BO.KnowledgeBaseMetricsLiveTest do
   alias Zaq.Engine.Telemetry
 
   defmodule NodeRouterFake do
-    def call(role, mod, fun, args) do
+    def dispatch(%Zaq.Event{} = event) do
       handler = :persistent_term.get({__MODULE__, :handler}, nil)
+      role = event.next_hop.destination
+      mod = event.request.module
+      fun = event.request.function
+      args = event.request.args
 
       if is_function(handler, 4) do
-        handler.(role, mod, fun, args)
+        %{event | response: handler.(role, mod, fun, args)}
       else
-        Zaq.NodeRouter.call(role, mod, fun, args)
+        Zaq.NodeRouter.dispatch(event)
       end
     end
 


### PR DESCRIPTION
fix #268