### PR TITLE
fix(ingestion): keep dotted literals matchable in BM25 search

### DIFF
--- a/lib/zaq/ingestion/fts_backend.ex
+++ b/lib/zaq/ingestion/fts_backend.ex
@@ -179,14 +179,47 @@ defmodule Zaq.Ingestion.FTSBackend do
   end
 
   @doc """
-  Sanitizes free-form user input for PostgreSQL full-text query functions.
+  Aggressive sanitization that neutralizes query-language operators for the
+  ParadeDB/tantivy backend (`parse_with_field`), which interprets characters such
+  as `:`, `^`, `(`, `)` as syntax. Strips all punctuation except dots that sit
+  between alphanumerics, so dotted literals (IPv4 `10.0.0.42`, versions `1.2.3`,
+  decimals) survive as single tokens.
+
+  The Native (PostgreSQL) backend does NOT use this — `websearch_to_tsquery/2` is
+  injection-safe and tokenizes identically to `to_tsvector`, so it only needs
+  `sanitize_query_minimal/1`.
   """
   def sanitize_query_text(text) do
     text
     |> sanitize_utf8_text()
     |> unicode_normalize()
-    |> String.replace(~r/[^\p{L}\p{N}]+/u, " ")
+    # Collapse runs of disallowed characters to a space, but KEEP dots so dotted
+    # literals (IPv4 like "10.0.0.42", versions like "1.2.3", decimals) are not
+    # shattered into separate tokens — that mismatch is why a raw IP query never
+    # matched the single FTS token produced by to_tsvector for the same string.
+    |> String.replace(~r/[^\p{L}\p{N}.]+/u, " ")
+    # Drop dots that are not flanked by alphanumerics on both sides (leading,
+    # trailing, or standalone), so only intra-token dots survive.
+    |> String.replace(~r/(?<![\p{L}\p{N}])\.+|\.+(?![\p{L}\p{N}])/u, " ")
     |> String.replace(~r/ {2,}/, " ")
+    |> String.trim()
+    |> String.slice(0, 512)
+  end
+
+  @doc """
+  Minimal, security-only sanitization for PostgreSQL `websearch_to_tsquery/2`.
+
+  `websearch_to_tsquery` never errors on user input and applies the same parser
+  as `to_tsvector` at index time, so the query must NOT be pre-tokenized. We only
+  strip invalid/null bytes, normalize unicode, collapse whitespace and cap length
+  — preserving IPs, versions, emails and phrases so the query tokenizes the same
+  way the indexed content did (analyzer symmetry).
+  """
+  def sanitize_query_minimal(text) do
+    text
+    |> sanitize_utf8_text()
+    |> unicode_normalize()
+    |> String.replace(~r/\s+/u, " ")
     |> String.trim()
     |> String.slice(0, 512)
   end

--- a/lib/zaq/ingestion/fts_backend.ex
+++ b/lib/zaq/ingestion/fts_backend.ex
@@ -193,14 +193,7 @@ defmodule Zaq.Ingestion.FTSBackend do
     text
     |> sanitize_utf8_text()
     |> unicode_normalize()
-    # Collapse runs of disallowed characters to a space, but KEEP dots so dotted
-    # literals (IPv4 like "10.0.0.42", versions like "1.2.3", decimals) are not
-    # shattered into separate tokens — that mismatch is why a raw IP query never
-    # matched the single FTS token produced by to_tsvector for the same string.
-    |> String.replace(~r/[^\p{L}\p{N}.]+/u, " ")
-    # Drop dots that are not flanked by alphanumerics on both sides (leading,
-    # trailing, or standalone), so only intra-token dots survive.
-    |> String.replace(~r/(?<![\p{L}\p{N}])\.+|\.+(?![\p{L}\p{N}])/u, " ")
+    |> strip_punctuation_keep_dotted_literals()
     |> String.replace(~r/ {2,}/, " ")
     |> String.trim()
     |> String.slice(0, 512)
@@ -249,6 +242,20 @@ defmodule Zaq.Ingestion.FTSBackend do
     |> Map.new(fn {doc_id, items} ->
       {doc_id, Enum.group_by(items, & &1.section_path)}
     end)
+  end
+
+  # Strips query-language punctuation while keeping dots that sit between
+  # alphanumerics, so dotted literals (IPv4 "10.0.0.42", versions "1.2.3",
+  # decimals) survive as single tokens.
+  defp strip_punctuation_keep_dotted_literals(text) do
+    text
+    # Collapse runs of disallowed characters to a space, but KEEP dots so dotted
+    # literals are not shattered into separate tokens — that mismatch is why a raw
+    # IP query never matched the single FTS token produced by to_tsvector.
+    |> String.replace(~r/[^\p{L}\p{N}.]+/u, " ")
+    # Drop dots that are not flanked by alphanumerics on both sides (leading,
+    # trailing, or standalone), so only intra-token dots survive.
+    |> String.replace(~r/(?<![\p{L}\p{N}])\.+|\.+(?![\p{L}\p{N}])/u, " ")
   end
 
   defp unicode_normalize(text) do

--- a/lib/zaq/ingestion/fts_backend/native.ex
+++ b/lib/zaq/ingestion/fts_backend/native.ex
@@ -16,7 +16,10 @@ defmodule Zaq.Ingestion.FTSBackend.Native do
 
   @impl true
   def sanitize_query(text) do
-    FTSBackend.sanitize_query_text(text)
+    # websearch_to_tsquery is injection-safe and tokenizes the query the same way
+    # to_tsvector tokenized the content, so only minimal sanitization is needed
+    # (preserves IPs/versions/emails). See FTSBackend.sanitize_query_minimal/1.
+    FTSBackend.sanitize_query_minimal(text)
   end
 
   @impl true

--- a/test/zaq/ingestion/bm25_fusion_validation_test.exs
+++ b/test/zaq/ingestion/bm25_fusion_validation_test.exs
@@ -770,4 +770,73 @@ defmodule Zaq.Ingestion.BM25FusionValidationTest do
              "section chunks must arrive in document (chunk_index) order"
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # §5 — "load balancer" retrieval regression (text.txt repro)
+  #
+  # Real-world bug: a French infra note whose Ingress section reads
+  # "IP du load balancer: `10.0.0.42`" could not be retrieved by the
+  # question "what is the load balancer". Chunking was already proven innocent
+  # (DocumentChunkerTest). This isolates the BM25 leg: the English term
+  # "load balancer" is literally present in the chunk content, so BM25 — which
+  # indexes to_tsvector('english', content) — must surface it.
+  # ---------------------------------------------------------------------------
+
+  @lb_chunk_content """
+  ## **Traefik Replaces Nginx‑Ingress March 2026**
+
+  J'ai installé traefik (nginx-ingress controller a été deprecié en mars 2026)
+  IP du load balancer: `10.0.0.42`
+  """
+
+  describe "§5 load balancer retrieval regression" do
+    defp insert_lb_chunk do
+      doc = create_doc()
+      insert_chunk(doc.id, @lb_chunk_content, "french", ["Cluster Kubernetes", "Ingress"], 5)
+      doc
+    end
+
+    defp lb_items(results) do
+      results |> Map.values() |> Enum.flat_map(&Map.values/1) |> List.flatten()
+    end
+
+    test "BM25 surfaces the load balancer chunk for an English keyword query" do
+      doc = insert_lb_chunk()
+
+      assert {:ok, results} = DocumentProcessor.bm25_search_group_by("load balancer", 20)
+
+      items = lb_items(results)
+
+      assert Enum.any?(items, &(&1.document_id == doc.id)),
+             "BM25 must surface the chunk containing 'load balancer'; got: #{inspect(items)}"
+    end
+
+    test "BM25 matches the IP literal — sanitize_query_text preserves dotted tokens" do
+      # REGRESSION: previously sanitize_query_text/1 replaced every dot with a
+      # space, so "10.0.0.42" became the four tokens "10 0 0 42" while
+      # to_tsvector('english', content) keeps the IP as one token — they never
+      # matched. The sanitizer now preserves intra-token dots, so a raw IP query
+      # tokenizes the same way as the indexed content and BM25 matches.
+      doc = insert_lb_chunk()
+
+      assert {:ok, results} = DocumentProcessor.bm25_search_group_by("10.0.0.42", 20)
+
+      assert Enum.any?(lb_items(results), &(&1.document_id == doc.id)),
+             "BM25 must surface the chunk when querying the load balancer IP literal"
+    end
+
+    test "query_extraction returns the load balancer content end-to-end" do
+      insert_lb_chunk()
+
+      assert {:ok, results} =
+               DocumentProcessor.query_extraction("load balancer", skip_permissions: true)
+
+      combined = Enum.map_join(results, "\n", & &1["content"])
+
+      assert String.contains?(combined, "load balancer"),
+             "query_extraction must return the load balancer content; got: #{combined}"
+
+      assert String.contains?(combined, "10.0.0.42")
+    end
+  end
 end

--- a/test/zaq/ingestion/document_processor_test.exs
+++ b/test/zaq/ingestion/document_processor_test.exs
@@ -2372,22 +2372,17 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
   # sanitize_fts_query/1 — property tests
   # ---------------------------------------------------------------------------
 
+  # sanitize_fts_query/1 delegates to the active FTS backend's sanitizer
+  # (FTSBackend.impl().sanitize_query/1), so its exact output is
+  # backend-specific — ParadeDB strips punctuation to letters/digits/dots while
+  # Native preserves it for websearch_to_tsquery. The per-backend contracts are
+  # tested directly in fts_backend_test.exs; here we only assert the invariants
+  # that must hold regardless of which backend is active.
   describe "sanitize_fts_query/1" do
-    test "original failing case: apostrophe in contraction" do
-      assert DocumentProcessor.sanitize_fts_query("what's happening") == "what s happening"
-    end
-
     property "never raises on any binary input" do
       check all(input <- StreamData.binary()) do
         # Must not raise even on raw non-UTF-8 bytes; the function guards with a Unicode regex
         assert is_binary(DocumentProcessor.sanitize_fts_query(input))
-      end
-    end
-
-    property "output contains only letters, digits, and single spaces" do
-      check all(input <- StreamData.string(:printable)) do
-        result = DocumentProcessor.sanitize_fts_query(input)
-        assert result == "" or String.match?(result, ~r/^[\p{L}\p{N} ]+$/u)
       end
     end
 
@@ -2435,10 +2430,6 @@ defmodule Zaq.Ingestion.DocumentProcessorTest do
 
     test "empty string returns empty string" do
       assert DocumentProcessor.sanitize_fts_query("") == ""
-    end
-
-    test "only punctuation returns empty string" do
-      assert DocumentProcessor.sanitize_fts_query("!!!---???") == ""
     end
   end
 

--- a/test/zaq/ingestion/fts_backend_test.exs
+++ b/test/zaq/ingestion/fts_backend_test.exs
@@ -250,6 +250,11 @@ defmodule Zaq.Ingestion.FTSBackendTest do
       assert FTSBackend.sanitize_query_text(".42") == "42"
     end
 
+    test "sanitize_query_text reduces punctuation-only input to an empty string" do
+      assert FTSBackend.sanitize_query_text("!!!---???") == ""
+      assert FTSBackend.sanitize_query_text("what's happening") == "what s happening"
+    end
+
     test "sanitize_query_minimal preserves dotted literals, emails, and phrase punctuation" do
       # Postgres' websearch_to_tsquery tokenizes these the same way to_tsvector
       # did at index time, so the minimal sanitizer must leave them intact.

--- a/test/zaq/ingestion/fts_backend_test.exs
+++ b/test/zaq/ingestion/fts_backend_test.exs
@@ -1,5 +1,6 @@
 defmodule Zaq.Ingestion.FTSBackendTest do
   use Zaq.DataCase, async: false
+  use ExUnitProperties
 
   import Ecto.Query
   import ExUnit.CaptureLog
@@ -303,6 +304,97 @@ defmodule Zaq.Ingestion.FTSBackendTest do
                1 => %{["A"] => [%{bm25_score: 2.0}, %{bm25_score: 1.0}]},
                2 => %{["B"] => [%{bm25_score: 3.0}]}
              } = FTSBackend.group_results(results)
+    end
+  end
+
+  describe "sanitize_query_text properties" do
+    # Generates adversarial query text: alphanumeric runs interleaved with dots,
+    # tantivy operators, whitespace, null/invalid bytes, and non-ASCII letters.
+    defp messy_query_text do
+      fragment =
+        StreamData.one_of([
+          StreamData.string(:alphanumeric, min_length: 1, max_length: 5),
+          StreamData.constant("."),
+          StreamData.constant(".."),
+          StreamData.member_of([
+            ":",
+            "^",
+            "(",
+            ")",
+            "\"",
+            "[",
+            "]",
+            "{",
+            "}",
+            "\\",
+            "*",
+            "?",
+            "~",
+            "+",
+            "-",
+            "/",
+            "|",
+            "&",
+            "!",
+            "@",
+            "#",
+            "'",
+            "=",
+            "<",
+            ">"
+          ]),
+          StreamData.member_of([" ", "\t", "\n", <<0>>, <<0xFF>>]),
+          StreamData.string([?é, ?ü, ?ñ, ?ç, ?東, ?京], min_length: 1, max_length: 2)
+        ])
+
+      fragment
+      |> StreamData.list_of(max_length: 60)
+      |> StreamData.map(&Enum.join/1)
+    end
+
+    # Dotted literals: 2–4 digit groups joined by single dots (IPv4, versions).
+    defp dotted_literal do
+      ?0..?9
+      |> StreamData.string(min_length: 1, max_length: 4)
+      |> StreamData.list_of(min_length: 2, max_length: 4)
+      |> StreamData.map(&Enum.join(&1, "."))
+    end
+
+    property "output is valid, null-free, bounded, and uses only safe characters" do
+      check all(raw <- messy_query_text()) do
+        out = FTSBackend.sanitize_query_text(raw)
+
+        assert String.valid?(out), "output must be valid UTF-8"
+        refute String.contains?(out, <<0>>), "null bytes must be stripped"
+        assert String.length(out) <= 512, "output must be length-capped"
+        # Only letters, numbers, intra-token dots, and single spaces survive —
+        # every tantivy query operator is neutralized.
+        assert out =~ ~r/\A[\p{L}\p{N}. ]*\z/u
+        assert out == String.trim(out), "no leading/trailing whitespace"
+        refute out =~ ~r/  /, "whitespace runs must be collapsed"
+      end
+    end
+
+    property "every surviving dot is flanked by alphanumerics on both sides" do
+      check all(raw <- messy_query_text()) do
+        out = FTSBackend.sanitize_query_text(raw)
+
+        refute out =~ ~r/(?<![\p{L}\p{N}])\.|\.(?![\p{L}\p{N}])/u,
+               "leading/trailing/standalone dots must be dropped: #{inspect(out)}"
+      end
+    end
+
+    property "is idempotent" do
+      check all(raw <- messy_query_text()) do
+        once = FTSBackend.sanitize_query_text(raw)
+        assert FTSBackend.sanitize_query_text(once) == once
+      end
+    end
+
+    property "preserves dotted literals (IPv4 / versions) as single tokens" do
+      check all(literal <- dotted_literal()) do
+        assert FTSBackend.sanitize_query_text(literal) == literal
+      end
     end
   end
 

--- a/test/zaq/ingestion/fts_backend_test.exs
+++ b/test/zaq/ingestion/fts_backend_test.exs
@@ -237,6 +237,42 @@ defmodule Zaq.Ingestion.FTSBackendTest do
       assert FTSBackend.sanitize_query_text(raw) == ""
     end
 
+    test "sanitize_query_text preserves intra-token dots (IPs, versions, decimals)" do
+      assert FTSBackend.sanitize_query_text("10.0.0.42") == "10.0.0.42"
+      assert FTSBackend.sanitize_query_text("version 1.2.3") == "version 1.2.3"
+      assert FTSBackend.sanitize_query_text("price 19.99 today") == "price 19.99 today"
+    end
+
+    test "sanitize_query_text drops dots not flanked by alphanumerics" do
+      assert FTSBackend.sanitize_query_text("...load balancer...") == "load balancer"
+      assert FTSBackend.sanitize_query_text("end. Next") == "end Next"
+      assert FTSBackend.sanitize_query_text(".42") == "42"
+    end
+
+    test "sanitize_query_minimal preserves dotted literals, emails, and phrase punctuation" do
+      # Postgres' websearch_to_tsquery tokenizes these the same way to_tsvector
+      # did at index time, so the minimal sanitizer must leave them intact.
+      assert FTSBackend.sanitize_query_minimal("10.0.0.42 v1.2.3 a@b.com") ==
+               "10.0.0.42 v1.2.3 a@b.com"
+
+      assert FTSBackend.sanitize_query_minimal(~s("load balancer")) == ~s("load balancer")
+    end
+
+    test "sanitize_query_minimal strips invalid bytes, collapses whitespace, caps length" do
+      raw = "  hi\xFF\0   there  " <> String.duplicate("x", 600)
+
+      out = FTSBackend.sanitize_query_minimal(raw)
+
+      assert String.starts_with?(out, "hi there")
+      refute String.contains?(out, <<0>>)
+      refute String.contains?(out, <<0xFF>>)
+      assert byte_size(out) <= 512
+    end
+
+    test "Native.sanitize_query keeps dotted literals (websearch_to_tsquery is injection-safe)" do
+      assert FTSBackend.Native.sanitize_query("ip 10.0.0.42") == "ip 10.0.0.42"
+    end
+
     test "maybe_filter_source leaves an unfiltered query unchanged" do
       query = from(c in Chunk, select: c.id)
 

--- a/test/zaq/ingestion/paradedb_dotted_literal_test.exs
+++ b/test/zaq/ingestion/paradedb_dotted_literal_test.exs
@@ -1,0 +1,76 @@
+defmodule Zaq.Ingestion.ParadeDBDottedLiteralTest do
+  @moduledoc """
+  Regression: dotted literals (IPv4, versions) must match through the ParadeDB
+  BM25 backend.
+
+  The BM25 index uses the default tokenizer, which splits on `.` at index time.
+  `parse_with_field` re-tokenizes each query term with that same analyzer, so a
+  query like `10.0.0.42` matches the indexed chunk regardless of whether the
+  query sanitizer preserves the dots. This pins that behaviour so a future
+  change to the sanitizer or the index tokenizer cannot silently break IP /
+  version retrieval on ParadeDB (the Native counterpart lives in
+  `bm25_fusion_validation_test.exs` §5).
+  """
+  use Zaq.DataCase, async: false
+
+  alias Zaq.Ingestion.{Chunk, Document, FTSBackend}
+  alias Zaq.Ingestion.FTSBackend.ParadeDB
+  alias Zaq.Repo
+
+  @embedding_dim 1536
+
+  @content """
+  ## Cluster Kubernetes
+
+  IP du load balancer: `10.0.0.42`
+  Version Traefik: 2.11.0
+  """
+
+  setup do
+    FTSBackend.reset_cache()
+    on_exit(fn -> FTSBackend.reset_cache() end)
+    :ok
+  end
+
+  defp insert_chunk(content) do
+    {:ok, doc} =
+      %Document{}
+      |> Document.changeset(%{
+        source: "dotted_#{System.unique_integer([:positive])}.md",
+        content: content
+      })
+      |> Repo.insert()
+
+    %Chunk{}
+    |> Chunk.changeset(%{
+      document_id: doc.id,
+      content: content,
+      chunk_index: 1,
+      section_path: ["Cluster Kubernetes"],
+      language: "french",
+      embedding: Pgvector.HalfVector.new(List.duplicate(0.1, @embedding_dim))
+    })
+    |> Repo.insert!()
+  end
+
+  @tag :paradedb
+  test "ParadeDB backend is active and matches the IPv4 literal via parse_with_field" do
+    Chunk.create_table(@embedding_dim)
+    FTSBackend.reset_cache()
+    assert FTSBackend.impl() == FTSBackend.ParadeDB, "expected ParadeDB to be the active backend"
+
+    insert_chunk(@content)
+
+    # Keyword leg
+    assert {:ok, kw} = ParadeDB.bm25_search_group_by("load balancer", 20)
+    assert map_size(kw) > 0, "ParadeDB must match the 'load balancer' keyword"
+
+    # Dotted literal leg — the Bug 1 case
+    assert {:ok, ip} = ParadeDB.bm25_search_group_by("10.0.0.42", 20)
+    assert map_size(ip) > 0, "ParadeDB must match the IPv4 literal 10.0.0.42"
+
+    # Version literal
+    assert {:ok, ver} = ParadeDB.bm25_search_group_by("2.11.0", 20)
+    assert map_size(ver) > 0, "ParadeDB must match the version literal 2.11.0"
+  end
+end


### PR DESCRIPTION
The query sanitizer split dotted literals (IPs, versions, decimals) into separate tokens while Postgres FTS indexes them whole, so IP/version queries never matched (analyzer asymmetry).

- Native (Postgres) now uses minimal, security-only sanitization and lets websearch_to_tsquery tokenize, matching how to_tsvector indexed the content.
- ParadeDB/tantivy keeps operator-neutralizing sanitization but preserves dots between alphanumerics.