### PR TITLE
feat(ai-sdk): @zaq/ai-sdk — Vercel AI SDK adapter for the AG-UI transport

### DIFF
--- a/sdks/typescript/ai-sdk/.gitignore
+++ b/sdks/typescript/ai-sdk/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/sdks/typescript/ai-sdk/README.md
+++ b/sdks/typescript/ai-sdk/README.md
@@ -1,0 +1,188 @@
+# @zaq/ai-sdk
+
+Vercel AI SDK adapter for ZAQ's AG-UI transport.
+
+Turns a ZAQ `/ag-ui/runs` event stream into a `useChat`-compatible
+`UIMessage` stream — the missing bridge between ZAQ's AG-UI backend and
+the Vercel AI SDK's `useChat` hook.
+
+## What it does
+
+ZAQ exposes an AG-UI HTTP+SSE endpoint (`/ag-ui/runs`). The Vercel AI SDK's
+`useChat` hook expects a stream of `UIMessageChunk` objects. This package
+bridges the two:
+
+```
+useChat (browser)
+  └─ POST /api/chat (your proxy route)
+        └─ aguiHttpAgentEventStream → ZAQ /ag-ui/runs (SSE)
+              └─ aguiToUIMessageStream → ReadableStream<UIMessageChunk>
+                    └─ createUIMessageStreamResponse → Response
+```
+
+Key behaviours:
+
+- **Token streaming** — ZAQ token-streams its answer; each
+  `TEXT_MESSAGE_CONTENT` delta is forwarded 1:1 as a `text-delta`.
+- **Provenance marker stripping** — ZAQ annotates answers with
+  `[[source:…]]` / `[[memory:…]]` routing tags. These are stripped before the
+  text reaches the UI, even when a marker is split across streamed deltas.
+- **Citation → source-url** — `CUSTOM` events named `citation`, `source`,
+  `cite`, or `reference` are mapped to AI SDK `source-url` parts so the UI
+  can render footnotes.
+- **HITL interrupts** — `RUN_FINISHED` with `outcome.type === "interrupt"`
+  surfaces the pending interrupt descriptors as `data-zaqEvent` parts so your
+  UI can render an approval prompt.
+- **Tool call pass-through** — `TOOL_CALL_*` events are forwarded as AI SDK
+  `tool-input-*` / `tool-output-available` parts (dynamic tool mode).
+
+## Install
+
+```bash
+npm install @zaq/ai-sdk
+# peer dependency — must be installed separately
+npm install ai
+```
+
+## Usage
+
+### 1. Proxy route (server-side)
+
+Create a Next.js (or any Node) API route that holds the ZAQ bearer token
+server-side and proxies the AG-UI event stream to the browser as an AI SDK
+`UIMessageStream`.
+
+```ts
+// app/api/chat/route.ts  (Next.js App Router example)
+import { createUIMessageStreamResponse } from "ai";
+import {
+  aguiHttpAgentEventStream,
+  aguiToUIMessageStream,
+  toAGUIMessages,
+  type RunAgentInput,
+} from "@zaq/ai-sdk";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const { messages, threadId, runId } = await request.json();
+
+  const input: RunAgentInput = {
+    threadId,
+    runId,
+    state: {},
+    messages: toAGUIMessages(messages),
+    tools: [],
+    context: [],
+    forwardedProps: {},
+  };
+
+  const events = aguiHttpAgentEventStream({
+    url: process.env.ZAQ_AGUI_URL!,   // e.g. http://zaq-server/ag-ui/runs
+    token: process.env.ZAQ_API_KEY!,  // bearer token — never sent to the browser
+    input,
+    signal: request.signal,
+  });
+
+  return createUIMessageStreamResponse({ stream: aguiToUIMessageStream(events) });
+}
+```
+
+### 2. Client component
+
+Wire `useChat` to the proxy route as usual — no ZAQ-specific changes needed
+on the client.
+
+```tsx
+"use client";
+import { useChat } from "ai/react";
+import { useId } from "react";
+
+export function Chat() {
+  const threadId = useId();
+
+  const { messages, input, handleInputChange, handleSubmit } = useChat({
+    api: "/api/chat",
+    body: { threadId },
+    // Optional: generate a stable runId per submission
+    generateId: () => crypto.randomUUID(),
+  });
+
+  return (
+    <div>
+      <ul>
+        {messages.map((m) => (
+          <li key={m.id}>
+            <strong>{m.role}</strong>:{" "}
+            {m.parts.map((p, i) =>
+              p.type === "text" ? <span key={i}>{p.text}</span> : null,
+            )}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit}>
+        <input value={input} onChange={handleInputChange} />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+```
+
+### 3. Handling ZAQ-specific data parts
+
+ZAQ side-data (state snapshots, custom widget payloads) arrives as
+`data-zaqEvent` parts on each `UIMessage`. Access them via the message parts:
+
+```ts
+for (const part of message.parts) {
+  if (part.type === "data-zaqEvent") {
+    const { kind, value } = part.data; // ZaqEventDataPart
+    if (kind === "state-snapshot") {
+      // value is the ZAQ workflow state at this point in the run
+    }
+  }
+}
+```
+
+## API
+
+### `aguiToUIMessageStream(events, options?)`
+
+Core adapter. Converts `AsyncIterable<AGUIEvent>` → `ReadableStream<UIMessageChunk>`.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `onUnknownEvent` | `(event) => void` | — | Called for unrecognised CUSTOM events |
+| `generateId` | `() => string` | `zaq-N` counter | Override for deterministic IDs in tests |
+
+### `aguiHttpAgentEventStream(options)`
+
+Runs a ZAQ AG-UI agent via `@ag-ui/client`'s `HttpAgent` and yields the
+decoded, validated `BaseEvent` stream as `AsyncIterable<BaseEvent>`.
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `url` | `string` | yes | Full AG-UI runs endpoint |
+| `token` | `string` | yes | Bearer token (server-side only) |
+| `input` | `RunAgentInput` | yes | AG-UI run input (built from `toAGUIMessages`) |
+| `signal` | `AbortSignal` | no | Wired to `agent.abortRun()` on disconnect |
+
+### `toAGUIMessages(uiMessages)`
+
+Converts `UIMessage[]` (AI SDK conversation history) into `AGUIMessage[]`
+for `RunAgentInput.messages`. Strips client-only parts (reasoning, data,
+source, file) — only role and text content are forwarded.
+
+## Development
+
+```bash
+bun install
+bun run check-types   # TypeScript check
+bun run test          # Vitest
+bun run build         # tsc → dist/
+```
+
+## License
+
+MIT

--- a/sdks/typescript/ai-sdk/bun.lock
+++ b/sdks/typescript/ai-sdk/bun.lock
@@ -1,0 +1,217 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@zaq/ai-sdk",
+      "dependencies": {
+        "@ag-ui/client": "0.0.57",
+        "@ag-ui/core": "0.0.57",
+        "zod": "^3.24.0",
+      },
+      "devDependencies": {
+        "ai": "6.0.191",
+        "typescript": "^5.9.0",
+        "vitest": "^4.0.0",
+      },
+      "peerDependencies": {
+        "ai": ">=6",
+      },
+    },
+  },
+  "packages": {
+    "@ag-ui/client": ["@ag-ui/client@0.0.57", "", { "dependencies": { "@ag-ui/core": "0.0.57", "@ag-ui/encoder": "0.0.57", "@ag-ui/proto": "0.0.57", "@types/uuid": "^10.0.0", "compare-versions": "^6.1.1", "fast-json-patch": "^3.1.1", "rxjs": "7.8.1", "untruncate-json": "^0.0.1", "uuid": "^11.1.0", "zod": "^3.22.4" } }, "sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw=="],
+
+    "@ag-ui/core": ["@ag-ui/core@0.0.57", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q=="],
+
+    "@ag-ui/encoder": ["@ag-ui/encoder@0.0.57", "", { "dependencies": { "@ag-ui/core": "0.0.57", "@ag-ui/proto": "0.0.57" } }, "sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q=="],
+
+    "@ag-ui/proto": ["@ag-ui/proto@0.0.57", "", { "dependencies": { "@ag-ui/core": "0.0.57", "@bufbuild/protobuf": "^2.2.5", "@protobuf-ts/protoc": "^2.11.1" } }, "sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA=="],
+
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.120", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
+
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
+    "@protobuf-ts/protoc": ["@protobuf-ts/protoc@2.11.1", "", { "bin": { "protoc": "protoc.js" } }, "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
+
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
+    "ai": ["ai@6.0.191", "", { "dependencies": { "@ai-sdk/gateway": "3.0.120", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "compare-versions": ["compare-versions@6.1.1", "", {}, "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fast-json-patch": ["fast-json-patch@3.1.1", "", {}, "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "untruncate-json": ["untruncate-json@0.0.1", "", {}, "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA=="],
+
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/sdks/typescript/ai-sdk/example/server.ts
+++ b/sdks/typescript/ai-sdk/example/server.ts
@@ -1,0 +1,96 @@
+/**
+ * Runnable demo for @zaq/ai-sdk. One Bun server: the `/api/chat` route is the
+ * REAL adapter (aguiHttpAgentEventStream -> aguiToUIMessageStream), the page is
+ * a plain-fetch client that renders the streamed UIMessageChunks token by token.
+ *
+ *   ZAQ_AGUI_URL=http://localhost:4100 ZAQ_AGUI_TOKEN=dev-agui-token \
+ *     bun run example/server.ts
+ *   # open http://localhost:3333
+ *
+ * ponytail: client parses the UIMessage SSE stream by hand (text-delta only) so
+ * the demo needs no bundler/React. A real app uses `useChat` from @ai-sdk/react
+ * against this exact route — see README.
+ */
+import { createUIMessageStreamResponse, generateId } from "ai";
+import {
+	aguiHttpAgentEventStream,
+	aguiToUIMessageStream,
+	toAGUIMessages,
+} from "../src/index";
+
+const ZAQ_URL = process.env.ZAQ_AGUI_URL ?? "http://localhost:4100";
+const ZAQ_TOKEN = process.env.ZAQ_AGUI_TOKEN ?? "dev-agui-token";
+const PORT = Number(process.env.PORT ?? 3333);
+
+// Advertised so ZAQ takes its streaming ReAct path (the plain path emits one delta).
+const RENDER_WIDGET_TOOL = {
+	name: "render_widget",
+	description: "Render a markdown/table/bar widget in the chat.",
+	parameters: {
+		type: "object",
+		properties: { type: { type: "string" }, title: { type: "string" }, data: {} },
+		required: ["type", "data"],
+	},
+};
+
+async function chat(req: Request): Promise<Response> {
+	const { messages, threadId } = await req.json();
+	const events = aguiHttpAgentEventStream({
+		url: `${ZAQ_URL}/ag-ui/runs`,
+		token: ZAQ_TOKEN, // held server-side; never sent to the browser
+		input: {
+			threadId: threadId ?? generateId(),
+			runId: generateId(),
+			state: {},
+			messages: toAGUIMessages(messages),
+			tools: [RENDER_WIDGET_TOOL],
+			context: [],
+			forwardedProps: {},
+		},
+		signal: req.signal,
+	});
+	return createUIMessageStreamResponse({ stream: aguiToUIMessageStream(events) });
+}
+
+Bun.serve({
+	port: PORT,
+	routes: {
+		"/api/chat": { POST: chat },
+		"/": () => new Response(PAGE, { headers: { "content-type": "text/html" } }),
+	},
+});
+console.log(`@zaq/ai-sdk demo on http://localhost:${PORT}  (ZAQ: ${ZAQ_URL})`);
+
+const PAGE = /* html */ `<!doctype html><meta charset=utf8>
+<title>@zaq/ai-sdk demo</title>
+<style>
+ body{font:15px system-ui;max-width:680px;margin:40px auto;padding:0 16px;background:#0d0a1f;color:#ece9ff}
+ #log{min-height:240px;display:flex;flex-direction:column;gap:10px;margin:16px 0}
+ .msg{padding:10px 14px;border-radius:12px;white-space:pre-wrap}
+ .user{background:#2a2156;align-self:flex-end} .bot{background:#171331;border:1px solid #2e2857}
+ form{display:flex;gap:8px} input{flex:1;padding:10px;border-radius:10px;border:1px solid #2e2857;background:#11102a;color:#fff}
+ button{padding:10px 16px;border-radius:10px;border:0;background:#6d5efc;color:#fff;font-weight:600}
+ .note{font-size:12px;color:#a39ccc}
+</style>
+<h2>@zaq/ai-sdk — live stream</h2>
+<div id=log></div>
+<form id=f><input id=i placeholder="Pose une question…" autocomplete=off autofocus><button>Envoyer</button></form>
+<script type=module>
+const log=document.getElementById('log'), f=document.getElementById('f'), i=document.getElementById('i');
+const threadId=crypto.randomUUID(); const messages=[];
+const bubble=(cls,txt='')=>{const d=document.createElement('div');d.className='msg '+cls;d.textContent=txt;log.appendChild(d);return d};
+f.onsubmit=async e=>{
+  e.preventDefault(); const text=i.value.trim(); if(!text)return; i.value='';
+  messages.push({id:crypto.randomUUID(),role:'user',parts:[{type:'text',text}]});
+  bubble('user',text); const bot=bubble('bot'); let answer='';
+  const res=await fetch('/api/chat',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({messages,threadId})});
+  const reader=res.body.getReader(), dec=new TextDecoder(); let buf='';
+  for(;;){const{done,value}=await reader.read(); if(done)break; buf+=dec.decode(value,{stream:true});
+    let n; while((n=buf.indexOf('\\n\\n'))>=0){const line=buf.slice(0,n).replace(/^data: /,'');buf=buf.slice(n+2);
+      if(line==='[DONE]')continue; let ev; try{ev=JSON.parse(line)}catch{continue}
+      if(ev.type==='text-delta'){answer+=ev.delta; bot.textContent=answer}
+      else if(ev.type==='tool-input-available'){const w=bubble('bot note');w.textContent='🧩 widget: '+JSON.stringify(ev.input).slice(0,200)}
+    }}
+  messages.push({id:crypto.randomUUID(),role:'assistant',parts:[{type:'text',text:answer}]});
+};
+</script>`;

--- a/sdks/typescript/ai-sdk/package.json
+++ b/sdks/typescript/ai-sdk/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@zaq/ai-sdk",
+  "version": "0.0.1",
+  "description": "Vercel AI SDK adapter for ZAQ's AG-UI transport — turns a ZAQ /ag-ui event stream into a useChat-compatible UIMessage stream.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ag-ui/client": "0.0.57",
+    "@ag-ui/core": "0.0.57",
+    "zod": "^3.24.0"
+  },
+  "peerDependencies": {
+    "ai": ">=6"
+  },
+  "devDependencies": {
+    "ai": "6.0.191",
+    "typescript": "^5.9.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/sdks/typescript/ai-sdk/package.json
+++ b/sdks/typescript/ai-sdk/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsc",
     "check-types": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "example": "bun run example/server.ts"
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",

--- a/sdks/typescript/ai-sdk/src/__tests__/adapter.test.ts
+++ b/sdks/typescript/ai-sdk/src/__tests__/adapter.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { aguiToUIMessageStream } from "../adapter";
+import type { AGUIEvent } from "../agui-events";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collect<T>(stream: ReadableStream<T>): Promise<T[]> {
+	const out: T[] = [];
+	const reader = stream.getReader();
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		out.push(value);
+	}
+	return out;
+}
+
+async function* scripted(events: AGUIEvent[]): AsyncIterable<AGUIEvent> {
+	for (const event of events) {
+		yield event;
+	}
+}
+
+function textDeltas(chunks: { type: string }[]): string[] {
+	return chunks
+		.filter(
+			(c): c is { type: "text-delta"; id: string; delta: string } =>
+				c.type === "text-delta",
+		)
+		.map((c) => c.delta);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("aguiToUIMessageStream", () => {
+	it("emits start first and finish last for a normal run", async () => {
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{ type: "TEXT_MESSAGE_START", messageId: "m1", role: "assistant" },
+			{ type: "TEXT_MESSAGE_CONTENT", messageId: "m1", delta: "Hello." },
+			{ type: "TEXT_MESSAGE_END", messageId: "m1" },
+			{
+				type: "RUN_FINISHED",
+				threadId: "t1",
+				runId: "run-1",
+				outcome: { type: "success" },
+			},
+		];
+
+		const chunks = await collect(aguiToUIMessageStream(scripted(events)));
+
+		expect(chunks.at(0)).toMatchObject({ type: "start", messageId: "run-1" });
+		expect(chunks.at(-1)).toMatchObject({ type: "finish" });
+	});
+
+	it("forwards each streamed TEXT_MESSAGE_CONTENT delta 1:1 as a text-delta", async () => {
+		const parts = ["The quick ", "brown fox ", "jumps."];
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{ type: "TEXT_MESSAGE_START", messageId: "m1", role: "assistant" },
+			...parts.map(
+				(delta): AGUIEvent => ({
+					type: "TEXT_MESSAGE_CONTENT",
+					messageId: "m1",
+					delta,
+				}),
+			),
+			{ type: "TEXT_MESSAGE_END", messageId: "m1" },
+			{
+				type: "RUN_FINISHED",
+				threadId: "t1",
+				runId: "run-1",
+				outcome: { type: "success" },
+			},
+		];
+
+		const deltas = textDeltas(await collect(aguiToUIMessageStream(scripted(events))));
+
+		// Each token is forwarded as its own frame; concatenation reconstructs
+		// the answer exactly (delta boundaries may shift around whitespace).
+		expect(deltas.length).toBeGreaterThan(1);
+		expect(deltas.join("")).toBe("The quick brown fox jumps.");
+	});
+
+	it("maps RUN_ERROR to an error chunk then finishes without throwing", async () => {
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{ type: "RUN_ERROR", message: "upstream rate limit exceeded" },
+		];
+
+		const chunks = await collect(aguiToUIMessageStream(scripted(events)));
+
+		expect(chunks).toContainEqual({
+			type: "error",
+			errorText: "upstream rate limit exceeded",
+		});
+		expect(chunks.at(-1)).toMatchObject({ type: "finish" });
+	});
+
+	it("strips ZAQ provenance markers from answer text", async () => {
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{ type: "TEXT_MESSAGE_START", messageId: "m1", role: "assistant" },
+			{
+				type: "TEXT_MESSAGE_CONTENT",
+				messageId: "m1",
+				delta: "Hello [[source:doc-42]] world [[memory:ctx-7]].",
+			},
+			{ type: "TEXT_MESSAGE_END", messageId: "m1" },
+			{
+				type: "RUN_FINISHED",
+				threadId: "t1",
+				runId: "run-1",
+				outcome: { type: "success" },
+			},
+		];
+
+		const deltas = textDeltas(await collect(aguiToUIMessageStream(scripted(events))));
+		expect(deltas.join("")).toBe("Hello world.");
+	});
+
+	it("strips a provenance marker split across streamed deltas", async () => {
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{ type: "TEXT_MESSAGE_START", messageId: "m1", role: "assistant" },
+			{ type: "TEXT_MESSAGE_CONTENT", messageId: "m1", delta: "Hello [[sou" },
+			{
+				type: "TEXT_MESSAGE_CONTENT",
+				messageId: "m1",
+				delta: "rce:doc-42]] world",
+			},
+			{ type: "TEXT_MESSAGE_END", messageId: "m1" },
+			{
+				type: "RUN_FINISHED",
+				threadId: "t1",
+				runId: "run-1",
+				outcome: { type: "success" },
+			},
+		];
+
+		const deltas = textDeltas(await collect(aguiToUIMessageStream(scripted(events))));
+		expect(deltas.join("")).toBe("Hello world");
+		expect(deltas.join("")).not.toContain("[[");
+	});
+
+	it("emits source-url for citation CUSTOM events", async () => {
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{
+				type: "CUSTOM",
+				name: "citation",
+				value: {
+					url: "https://example.com/doc",
+					title: "Example Doc",
+					sourceId: "src-1",
+				},
+			},
+			{
+				type: "RUN_FINISHED",
+				threadId: "t1",
+				runId: "run-1",
+				outcome: { type: "success" },
+			},
+		];
+
+		const chunks = await collect(aguiToUIMessageStream(scripted(events)));
+
+		expect(chunks).toContainEqual({
+			type: "source-url",
+			sourceId: "src-1",
+			url: "https://example.com/doc",
+			title: "Example Doc",
+		});
+	});
+
+	it("emits data-zaqEvent for STATE_SNAPSHOT events", async () => {
+		const snapshot = { phase: "retrieving", step: 1 };
+
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{ type: "STATE_SNAPSHOT", snapshot },
+			{
+				type: "RUN_FINISHED",
+				threadId: "t1",
+				runId: "run-1",
+				outcome: { type: "success" },
+			},
+		];
+
+		const chunks = await collect(aguiToUIMessageStream(scripted(events)));
+
+		const stateChunk = chunks.find(
+			(c) =>
+				c.type === "data-zaqEvent" &&
+				(c as { data: { kind: string } }).data?.kind === "state-snapshot",
+		);
+		expect(stateChunk).toBeDefined();
+		expect(
+			(stateChunk as { data: { kind: string; value: unknown } }).data.value,
+		).toEqual(snapshot);
+	});
+
+	it("gracefully finishes when the event stream ends without RUN_FINISHED", async () => {
+		const events: AGUIEvent[] = [
+			{ type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+			{ type: "TEXT_MESSAGE_START", messageId: "m1", role: "assistant" },
+			{ type: "TEXT_MESSAGE_END", messageId: "m1" },
+			// No RUN_FINISHED
+		];
+
+		const chunks = await collect(aguiToUIMessageStream(scripted(events)));
+
+		expect(chunks.at(0)).toMatchObject({ type: "start" });
+		expect(chunks.at(-1)).toMatchObject({ type: "finish", finishReason: "stop" });
+	});
+});

--- a/sdks/typescript/ai-sdk/src/adapter.ts
+++ b/sdks/typescript/ai-sdk/src/adapter.ts
@@ -1,0 +1,451 @@
+/**
+ * Core stream map: AG-UI events -> AI SDK `UIMessageChunk`s.
+ *
+ * Like `@ai-sdk/langchain` `toUIMessageStream`: emit a mandatory `start` chunk
+ * first, translate each AG-UI event (see the switch below for the full map),
+ * then emit a mandatory `finish` chunk last. Without `start` the UI never
+ * leaves status `submitted`; without `finish` it stays stuck in `streaming`.
+ *
+ * ZAQ token-streams its answer: each `TEXT_MESSAGE_CONTENT` carries an
+ * incremental delta, forwarded 1:1 as a `text-delta`. Inline provenance markers
+ * (`[[source:…]]`) are stripped by a stateful stripper that survives a marker
+ * split across delta boundaries.
+ */
+
+import {
+	createUIMessageStream,
+	type UIMessage,
+	type UIMessageChunk,
+	type UIMessageStreamWriter,
+} from "ai";
+import {
+	type AGUIEvent,
+	AGUIEventType,
+	type AGUIInterrupt,
+} from "./agui-events";
+
+// ---------------------------------------------------------------------------
+// Data-part types surfaced on the UIMessage data[] channel.
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed envelope for every ZAQ-specific data part emitted on the
+ * `data-zaqEvent` channel. Consumers narrow on `kind` to handle
+ * specific payloads (state snapshots, custom widget events, etc.).
+ */
+export interface ZaqEventDataPart {
+	kind: string;
+	value: unknown;
+}
+
+/**
+ * Data part emitted when ZAQ returns a HITL interrupt. Carries one or more
+ * pending interrupt descriptors; the client should surface an approval prompt
+ * for each before resuming the run.
+ */
+export interface ZaqInterruptDataPart {
+	kind: "interrupt";
+	interrupts: AGUIInterrupt[];
+}
+
+// ---------------------------------------------------------------------------
+// Public API.
+// ---------------------------------------------------------------------------
+
+export interface AguiToUIMessageStreamOptions {
+	/**
+	 * Called for any AG-UI event not handled by the mapping table. Useful for
+	 * debug logging or forwarding proprietary ZAQ events to analytics.
+	 */
+	onUnknownEvent?: (event: Extract<AGUIEvent, { type: "CUSTOM" }>) => void;
+	/**
+	 * Seed the message ID counter. Defaults to a `zaq-N` sequence. Override in
+	 * tests to get deterministic IDs.
+	 */
+	generateId?: () => string;
+}
+
+// ---------------------------------------------------------------------------
+// ZAQ provenance markers.
+//
+// ZAQ's answer text contains inline provenance annotations of the form
+// `[[source:...]]` / `[[memory:...]]` — retrieval-pipeline routing tags, not
+// answer text. They must be stripped before forwarding to the UI.
+//
+// Because ZAQ token-streams, a marker can arrive split across deltas
+// (`...[[so` + `urce:doc]]...`). A stateless per-delta `replace` would leak the
+// halves, so `createMarkerStripper` buffers a trailing run that could still grow
+// into a marker, emits everything proven safe, and flushes the remainder once
+// the text part closes.
+// ---------------------------------------------------------------------------
+
+const ZAQ_PROVENANCE_MARKER_RE = /\s*\[\[(?:source|memory):[^\]]*\]\]/g;
+
+interface MarkerStripper {
+	/** Push a streamed delta; returns the text safe to emit now. */
+	push(delta: string): string;
+	/** Drain whatever is still buffered once the stream ends. */
+	flush(): string;
+}
+
+function createMarkerStripper(): MarkerStripper {
+	let buffer = "";
+
+	const drainSafe = (atEnd: boolean): string => {
+		buffer = buffer.replace(ZAQ_PROVENANCE_MARKER_RE, "");
+		if (atEnd) {
+			const out = buffer;
+			buffer = "";
+			return out;
+		}
+		// Hold back from the last unclosed `[[` (or a lone trailing `[`): that
+		// tail could still grow into a complete marker on a later delta.
+		let hold = buffer.length;
+		const lastOpen = buffer.lastIndexOf("[[");
+		if (lastOpen !== -1 && !buffer.slice(lastOpen).includes("]]")) {
+			hold = lastOpen;
+		} else if (buffer.endsWith("[")) {
+			hold = buffer.length - 1;
+		}
+		// Always hold back a trailing whitespace run: it may precede a marker
+		// that opens in the next delta, and the marker regex eats one leading
+		// space. Concatenating all emitted deltas still reconstructs the answer
+		// exactly (minus complete markers); only the delta boundaries shift.
+		while (hold > 0 && /\s/.test(buffer.charAt(hold - 1))) {
+			hold -= 1;
+		}
+		const out = buffer.slice(0, hold);
+		buffer = buffer.slice(hold);
+		return out;
+	};
+
+	return {
+		push(delta: string): string {
+			buffer += delta;
+			return drainSafe(false);
+		},
+		flush(): string {
+			return drainSafe(true);
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse accumulated TOOL_CALL_ARGS JSON for a finished tool call. Returns
+ * `undefined` when no args were streamed, the parsed object on success, or
+ * `{ raw: args }` when the payload is malformed/partial — never throws, so a
+ * bad tool call degrades gracefully instead of tearing down the stream.
+ */
+function parseToolCallArgs(args: string | undefined): unknown {
+	if (!args) return undefined;
+	try {
+		return JSON.parse(args);
+	} catch {
+		return { raw: args };
+	}
+}
+
+/** CUSTOM event names that the adapter maps to `source-url` citation parts. */
+const CITATION_CUSTOM_NAMES = new Set([
+	"citation",
+	"source",
+	"cite",
+	"reference",
+]);
+
+// ---------------------------------------------------------------------------
+// Core transform.
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapt an `AsyncIterable<AGUIEvent>` from a ZAQ AG-UI endpoint into a
+ * `ReadableStream<UIMessageChunk>` that the Vercel AI SDK's `useChat` hook
+ * (and `createUIMessageStreamResponse`) can consume directly.
+ *
+ * @param events - The event stream from `aguiHttpAgentEventStream` or any
+ *   other source that yields `AGUIEvent` objects.
+ * @param options - Optional: unknown-event hook, ID generator.
+ * @returns A `ReadableStream<UIMessageChunk>` — pass it to
+ *   `createUIMessageStreamResponse` in your proxy route.
+ */
+export function aguiToUIMessageStream<UI_MESSAGE extends UIMessage = UIMessage>(
+	events: AsyncIterable<AGUIEvent>,
+	options: AguiToUIMessageStreamOptions = {},
+): ReadableStream<UIMessageChunk> {
+	const generateId = options.generateId ?? createCounterId();
+
+	return createUIMessageStream<UI_MESSAGE>({
+		execute: async ({ writer }: { writer: UIMessageStreamWriter<UI_MESSAGE> }) => {
+			const write = (chunk: UIMessageChunk): void =>
+				writer.write(chunk as Parameters<typeof writer.write>[0]);
+
+			let runId: string | undefined;
+			let started = false;
+			// One stripper per open text part, keyed by messageId. Flushed on
+			// TEXT_MESSAGE_END or when the run closes, so a marker still mid-buffer
+			// never leaks into the final answer.
+			const openText = new Map<string, MarkerStripper>();
+			const toolCalls = new Map<string, { name: string; args: string }>();
+
+			function ensureStarted(id?: string): void {
+				if (started) return;
+				started = true;
+				// messageId <- runId (mirrors how @ai-sdk/langchain uses run_id as id).
+				write({ type: "start", messageId: id ?? runId ?? generateId() });
+			}
+
+			const closeOpenText = (): void => {
+				for (const [id, stripper] of openText) {
+					const tail = stripper.flush();
+					if (tail) {
+						write({ type: "text-delta", id, delta: tail });
+					}
+					write({ type: "text-end", id });
+				}
+				openText.clear();
+			};
+
+			try {
+				for await (const event of events) {
+					switch (event.type) {
+						case AGUIEventType.RUN_STARTED: {
+							runId = event.runId;
+							ensureStarted(event.runId);
+							break;
+						}
+
+						case AGUIEventType.STEP_STARTED: {
+							write({ type: "start-step" });
+							break;
+						}
+
+						case AGUIEventType.STEP_FINISHED: {
+							write({ type: "finish-step" });
+							break;
+						}
+
+						case AGUIEventType.TEXT_MESSAGE_START: {
+							ensureStarted();
+							openText.set(event.messageId, createMarkerStripper());
+							write({ type: "text-start", id: event.messageId });
+							break;
+						}
+
+						case AGUIEventType.TEXT_MESSAGE_CONTENT: {
+							ensureStarted();
+							// Forward each streamed delta 1:1 as a text-delta, stripping
+							// any inline provenance markers (handles markers split across
+							// deltas). Tolerate a missing TEXT_MESSAGE_START.
+							let stripper = openText.get(event.messageId);
+							if (!stripper) {
+								stripper = createMarkerStripper();
+								openText.set(event.messageId, stripper);
+							}
+							const clean = stripper.push(event.delta);
+							if (clean) {
+								write({
+									type: "text-delta",
+									id: event.messageId,
+									delta: clean,
+								});
+							}
+							break;
+						}
+
+						case AGUIEventType.TEXT_MESSAGE_END: {
+							const stripper = openText.get(event.messageId);
+							const tail = stripper?.flush() ?? "";
+							if (tail) {
+								write({ type: "text-delta", id: event.messageId, delta: tail });
+							}
+							openText.delete(event.messageId);
+							write({ type: "text-end", id: event.messageId });
+							break;
+						}
+
+						case AGUIEventType.TOOL_CALL_START: {
+							ensureStarted();
+							toolCalls.set(event.toolCallId, {
+								name: event.toolCallName,
+								args: "",
+							});
+							// REQUIRED for remote-agent dynamic tools (dynamic: true).
+							write({
+								type: "tool-input-start",
+								toolCallId: event.toolCallId,
+								toolName: event.toolCallName,
+								dynamic: true,
+							});
+							break;
+						}
+
+						case AGUIEventType.TOOL_CALL_ARGS: {
+							const acc = toolCalls.get(event.toolCallId);
+							if (acc) {
+								acc.args += event.delta;
+							}
+							write({
+								type: "tool-input-delta",
+								toolCallId: event.toolCallId,
+								inputTextDelta: event.delta,
+							});
+							break;
+						}
+
+						case AGUIEventType.TOOL_CALL_END: {
+							const acc = toolCalls.get(event.toolCallId);
+							write({
+								type: "tool-input-available",
+								toolCallId: event.toolCallId,
+								toolName: acc?.name ?? "",
+								input: parseToolCallArgs(acc?.args),
+								dynamic: true,
+							});
+							toolCalls.delete(event.toolCallId);
+							break;
+						}
+
+						case AGUIEventType.TOOL_CALL_RESULT: {
+							// Server-side (MCP capability) tool result: the tool ran
+							// inside ZAQ and the result returned over SSE — no browser
+							// round-trip.
+							write({
+								type: "tool-output-available",
+								toolCallId: event.toolCallId,
+								output: event.content,
+							});
+							break;
+						}
+
+						case AGUIEventType.STATE_SNAPSHOT: {
+							// Emit as a data-zaqEvent data part.
+							write({
+								type: "data-zaqEvent",
+								id: generateId(),
+								data: {
+									kind: "state-snapshot",
+									value: event.snapshot,
+								} satisfies ZaqEventDataPart,
+								transient: false,
+							});
+							break;
+						}
+
+						case AGUIEventType.CUSTOM: {
+							emitCustom(write, generateId, event, options);
+							break;
+						}
+
+						case AGUIEventType.RUN_ERROR: {
+							closeOpenText();
+							write({ type: "error", errorText: event.message });
+							write({ type: "finish", finishReason: "error" });
+							return;
+						}
+
+						case AGUIEventType.RUN_FINISHED: {
+							if (event.outcome?.type === "interrupt") {
+								// HITL path: surface the interrupt descriptors so the
+								// client can render an approval prompt.
+								write({
+									type: "data-zaqEvent",
+									id: generateId(),
+									data: {
+										kind: "interrupt",
+										interrupts: event.outcome.interrupts,
+									} satisfies ZaqInterruptDataPart,
+									transient: false,
+								});
+							}
+							// LAST CHUNK.
+							closeOpenText();
+							write({ type: "finish", finishReason: "stop" });
+							return;
+						}
+
+						default: {
+							// Unknown event type — pass to the caller's hook if provided.
+							options.onUnknownEvent?.(
+								event as Extract<AGUIEvent, { type: "CUSTOM" }>,
+							);
+							break;
+						}
+					}
+				}
+
+				// Stream exhausted without a RUN_FINISHED event — still close out
+				// gracefully so the UI doesn't get stuck in `streaming`.
+				if (!started) {
+					write({ type: "start", messageId: generateId() });
+				}
+				closeOpenText();
+				write({ type: "finish", finishReason: "stop" });
+			} catch (error) {
+				closeOpenText();
+				write({
+					type: "error",
+					errorText: error instanceof Error ? error.message : String(error),
+				});
+				write({ type: "finish", finishReason: "error" });
+			}
+		},
+
+		onError: (error) =>
+			error instanceof Error ? error.message : String(error),
+	}) as ReadableStream<UIMessageChunk>;
+}
+
+// ---------------------------------------------------------------------------
+// CUSTOM event routing.
+// ---------------------------------------------------------------------------
+
+/**
+ * Route a CUSTOM event to either a `source-url` citation part or a generic
+ * `data-zaqEvent` data part, based on the event `name`.
+ */
+function emitCustom(
+	write: (chunk: UIMessageChunk) => void,
+	generateId: () => string,
+	event: Extract<AGUIEvent, { type: "CUSTOM" }>,
+	options: AguiToUIMessageStreamOptions,
+): void {
+	if (CITATION_CUSTOM_NAMES.has(event.name.toLowerCase())) {
+		const citation = event.value as {
+			url?: string;
+			title?: string;
+			sourceId?: string;
+		} | null;
+		if (citation?.url) {
+			write({
+				type: "source-url",
+				sourceId: citation.sourceId ?? generateId(),
+				url: citation.url,
+				title: citation.title,
+			});
+			return;
+		}
+	}
+
+	// Unknown custom event — pass to caller, then emit as a data part so
+	// the stream stays in sync.
+	options.onUnknownEvent?.(event);
+	write({
+		type: "data-zaqEvent",
+		id: generateId(),
+		data: { kind: event.name, value: event.value } satisfies ZaqEventDataPart,
+		transient: false,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// ID generator.
+// ---------------------------------------------------------------------------
+
+function createCounterId(): () => string {
+	let n = 0;
+	return () => `zaq-${++n}`;
+}

--- a/sdks/typescript/ai-sdk/src/agui-events.ts
+++ b/sdks/typescript/ai-sdk/src/agui-events.ts
@@ -1,0 +1,361 @@
+/**
+ * AG-UI wire shapes — single source of truth for everything that crosses the
+ * ZAQ <-> client seam over HTTP+SSE.
+ *
+ * Mirrors `@ag-ui/core` `core/src/events.ts` + `core/src/types.ts` @ 0.0.57.
+ * We intentionally model only the EVENT SUBSET ZAQ emits, plus the
+ * `RunAgentInput` request body the client POSTs to the ZAQ AG-UI endpoint.
+ *
+ * Zod schemas are colocated with the TS types so consumers can validate-then-
+ * narrow each SSE frame instead of trusting the socket. Keep this file
+ * framework-free: no `ai`, no Next.js imports.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// EventType — the discriminant on every AG-UI frame.
+// We list the subset ZAQ's bridge actually broadcasts (RUN_*, TEXT_MESSAGE_*, TOOL_CALL_*,
+// STATE_SNAPSHOT, STEP_*, CUSTOM). Other members are accepted-but-ignored so
+// an upstream addition never hard-fails the stream.
+// ---------------------------------------------------------------------------
+
+export const AGUIEventType = {
+	RUN_STARTED: "RUN_STARTED",
+	RUN_FINISHED: "RUN_FINISHED",
+	RUN_ERROR: "RUN_ERROR",
+	STEP_STARTED: "STEP_STARTED",
+	STEP_FINISHED: "STEP_FINISHED",
+	TEXT_MESSAGE_START: "TEXT_MESSAGE_START",
+	TEXT_MESSAGE_CONTENT: "TEXT_MESSAGE_CONTENT",
+	TEXT_MESSAGE_END: "TEXT_MESSAGE_END",
+	TOOL_CALL_START: "TOOL_CALL_START",
+	TOOL_CALL_ARGS: "TOOL_CALL_ARGS",
+	TOOL_CALL_END: "TOOL_CALL_END",
+	TOOL_CALL_RESULT: "TOOL_CALL_RESULT",
+	STATE_SNAPSHOT: "STATE_SNAPSHOT",
+	CUSTOM: "CUSTOM",
+} as const;
+
+export type AGUIEventType = (typeof AGUIEventType)[keyof typeof AGUIEventType];
+
+// ---------------------------------------------------------------------------
+// Shared message-role vocabulary (ag-ui core/src/types.ts).
+// ---------------------------------------------------------------------------
+
+export const aguiTextMessageRoleSchema = z.enum([
+	"developer",
+	"system",
+	"assistant",
+	"user",
+]);
+export type AGUITextMessageRole = z.infer<typeof aguiTextMessageRoleSchema>;
+
+export const aguiMessageRoleSchema = z.enum([
+	"developer",
+	"system",
+	"assistant",
+	"user",
+	"tool",
+]);
+export type AGUIMessageRole = z.infer<typeof aguiMessageRoleSchema>;
+
+/**
+ * ToolCall as it appears inside an AssistantMessage (ag-ui core/src/types.ts).
+ * `function.arguments` is a JSON-encoded string (NOT a parsed object) — matches
+ * the OpenAI tool-call wire shape.
+ */
+export const aguiToolCallSchema = z.object({
+	id: z.string(),
+	type: z.literal("function"),
+	function: z.object({
+		name: z.string(),
+		arguments: z.string(),
+	}),
+});
+export type AGUIToolCall = z.infer<typeof aguiToolCallSchema>;
+
+/**
+ * Conversation message in `RunAgentInput.messages`. Discriminated on `role`.
+ * Kept loose (`content: string`) on purpose — ZAQ only needs role + text +
+ * tool linkage; rich multi-part content is flattened by `message-mapping.ts`
+ * before it reaches the wire.
+ */
+export const aguiMessageSchema = z.object({
+	id: z.string(),
+	role: aguiMessageRoleSchema,
+	content: z.string().optional(),
+	name: z.string().optional(),
+	// assistant-only
+	toolCalls: z.array(aguiToolCallSchema).optional(),
+	// tool-only — links a ToolMessage back to the assistant tool call
+	toolCallId: z.string().optional(),
+});
+export type AGUIMessage = z.infer<typeof aguiMessageSchema>;
+
+// ---------------------------------------------------------------------------
+// BaseEvent — fields common to every frame (ag-ui core/src/events.ts).
+// `.passthrough()` keeps unknown fields rather than stripping them, so a newer
+// ZAQ build that adds a field never trips Zod.
+// ---------------------------------------------------------------------------
+
+const baseEventShape = {
+	type: z.string(),
+	timestamp: z.number().optional(),
+	rawEvent: z.unknown().optional(),
+};
+
+// --- Lifecycle -------------------------------------------------------------
+
+export const runStartedSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.RUN_STARTED),
+		threadId: z.string(),
+		runId: z.string(),
+		parentRunId: z.string().optional(),
+	})
+	.passthrough();
+export type RunStartedEvent = z.infer<typeof runStartedSchema>;
+
+/**
+ * RUN_FINISHED carries an optional outcome. `interrupt` is the HITL path:
+ * ZAQ maps a workflow "waiting" state to `outcome.type === 'interrupt'` so the
+ * adapter can surface an approval prompt.
+ */
+export const aguiInterruptSchema = z.object({
+	id: z.string(),
+	reason: z.string(),
+	message: z.string().optional(),
+	toolCallId: z.string().optional(),
+	responseSchema: z.record(z.string(), z.unknown()).optional(),
+	expiresAt: z.string().optional(),
+	metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type AGUIInterrupt = z.infer<typeof aguiInterruptSchema>;
+
+export const runFinishedSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.RUN_FINISHED),
+		threadId: z.string(),
+		runId: z.string(),
+		result: z.unknown().optional(),
+		outcome: z
+			.union([
+				z.object({ type: z.literal("success") }),
+				z.object({
+					type: z.literal("interrupt"),
+					interrupts: z.array(aguiInterruptSchema).min(1),
+				}),
+			])
+			.optional(),
+	})
+	.passthrough();
+export type RunFinishedEvent = z.infer<typeof runFinishedSchema>;
+
+export const runErrorSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.RUN_ERROR),
+		message: z.string(),
+		code: z.string().optional(),
+	})
+	.passthrough();
+export type RunErrorEvent = z.infer<typeof runErrorSchema>;
+
+export const stepStartedSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.STEP_STARTED),
+		stepName: z.string(),
+	})
+	.passthrough();
+export type StepStartedEvent = z.infer<typeof stepStartedSchema>;
+
+export const stepFinishedSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.STEP_FINISHED),
+		stepName: z.string(),
+	})
+	.passthrough();
+export type StepFinishedEvent = z.infer<typeof stepFinishedSchema>;
+
+// --- Text streaming --------------------------------------------------------
+
+export const textMessageStartSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.TEXT_MESSAGE_START),
+		messageId: z.string(),
+		role: aguiTextMessageRoleSchema.default("assistant"),
+	})
+	.passthrough();
+export type TextMessageStartEvent = z.infer<typeof textMessageStartSchema>;
+
+/**
+ * ZAQ token-streams: each `TEXT_MESSAGE_CONTENT` carries one incremental
+ * `delta`, which the adapter forwards 1:1 as a `text-delta`.
+ */
+export const textMessageContentSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.TEXT_MESSAGE_CONTENT),
+		messageId: z.string(),
+		delta: z.string(),
+	})
+	.passthrough();
+export type TextMessageContentEvent = z.infer<typeof textMessageContentSchema>;
+
+export const textMessageEndSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.TEXT_MESSAGE_END),
+		messageId: z.string(),
+	})
+	.passthrough();
+export type TextMessageEndEvent = z.infer<typeof textMessageEndSchema>;
+
+// --- Tool calls ------------------------------------------------------------
+
+export const toolCallStartSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.TOOL_CALL_START),
+		toolCallId: z.string(),
+		toolCallName: z.string(),
+		parentMessageId: z.string().optional(),
+	})
+	.passthrough();
+export type ToolCallStartEvent = z.infer<typeof toolCallStartSchema>;
+
+export const toolCallArgsSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.TOOL_CALL_ARGS),
+		toolCallId: z.string(),
+		delta: z.string(),
+	})
+	.passthrough();
+export type ToolCallArgsEvent = z.infer<typeof toolCallArgsSchema>;
+
+export const toolCallEndSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.TOOL_CALL_END),
+		toolCallId: z.string(),
+	})
+	.passthrough();
+export type ToolCallEndEvent = z.infer<typeof toolCallEndSchema>;
+
+/**
+ * TOOL_CALL_RESULT is the server-side (MCP capability tool) path: the tool ran
+ * inside ZAQ and the result returns over SSE — no browser round-trip.
+ */
+export const toolCallResultSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.TOOL_CALL_RESULT),
+		messageId: z.string(),
+		toolCallId: z.string(),
+		content: z.string(),
+		role: z.literal("tool").optional(),
+	})
+	.passthrough();
+export type ToolCallResultEvent = z.infer<typeof toolCallResultSchema>;
+
+// --- State / custom side-data ---------------------------------------------
+
+export const stateSnapshotSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.STATE_SNAPSHOT),
+		snapshot: z.unknown(),
+	})
+	.passthrough();
+export type StateSnapshotEvent = z.infer<typeof stateSnapshotSchema>;
+
+/**
+ * CUSTOM carries ZAQ-specific side-data: citations, KG entities, widget
+ * payloads. `name` discriminates the payload kind so the adapter can route to
+ * `source-url` (citations) vs `data-zaqEvent` (everything else).
+ */
+export const customEventSchema = z
+	.object({
+		...baseEventShape,
+		type: z.literal(AGUIEventType.CUSTOM),
+		name: z.string(),
+		value: z.unknown(),
+	})
+	.passthrough();
+export type CustomEvent = z.infer<typeof customEventSchema>;
+
+// ---------------------------------------------------------------------------
+// Discriminated union over the whole subset.
+// ---------------------------------------------------------------------------
+
+export const aguiEventSchema = z.discriminatedUnion("type", [
+	runStartedSchema,
+	runFinishedSchema,
+	runErrorSchema,
+	stepStartedSchema,
+	stepFinishedSchema,
+	textMessageStartSchema,
+	textMessageContentSchema,
+	textMessageEndSchema,
+	toolCallStartSchema,
+	toolCallArgsSchema,
+	toolCallEndSchema,
+	toolCallResultSchema,
+	stateSnapshotSchema,
+	customEventSchema,
+]);
+export type AGUIEvent = z.infer<typeof aguiEventSchema>;
+
+// ---------------------------------------------------------------------------
+// Request body — RunAgentInput + Tool + Context (ag-ui core/src/types.ts).
+// This is what the client POSTs to the ZAQ AG-UI endpoint.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frontend (page) tool advertised per-turn. `parameters` is a JSON-Schema
+ * object; `metadata.a2ui` carries the A2UI rendering schema for render_widget.
+ */
+export const aguiToolSchema = z.object({
+	name: z.string(),
+	description: z.string(),
+	parameters: z.record(z.string(), z.unknown()),
+	metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type AGUITool = z.infer<typeof aguiToolSchema>;
+
+export const aguiContextSchema = z.object({
+	description: z.string(),
+	value: z.string(),
+});
+export type AGUIContext = z.infer<typeof aguiContextSchema>;
+
+/**
+ * HITL resume entry — one per pending interrupt, sent on the next run to
+ * unblock a waiting ZAQ workflow (POST /ag-ui/runs/:runId/resume).
+ */
+export const aguiResumeEntrySchema = z.object({
+	interruptId: z.string(),
+	status: z.enum(["resolved", "cancelled"]),
+	payload: z.unknown().optional(),
+});
+export type AGUIResumeEntry = z.infer<typeof aguiResumeEntrySchema>;
+
+export const runAgentInputSchema = z.object({
+	threadId: z.string(),
+	runId: z.string(),
+	parentRunId: z.string().optional(),
+	state: z.unknown(),
+	messages: z.array(aguiMessageSchema),
+	tools: z.array(aguiToolSchema),
+	context: z.array(aguiContextSchema),
+	forwardedProps: z.unknown(),
+	resume: z.array(aguiResumeEntrySchema).optional(),
+});
+export type RunAgentInput = z.infer<typeof runAgentInputSchema>;

--- a/sdks/typescript/ai-sdk/src/agui-http-agent.ts
+++ b/sdks/typescript/ai-sdk/src/agui-http-agent.ts
@@ -1,0 +1,126 @@
+/**
+ * Official AG-UI client transport.
+ *
+ * Wraps `@ag-ui/client`'s `HttpAgent`, which POSTs the `RunAgentInput`,
+ * decodes the `text/event-stream` response, and validates each frame against
+ * the official `@ag-ui/core` `EventSchemas` — yielding a typed
+ * `Observable<BaseEvent>`.
+ *
+ * We bridge that rxjs Observable into an `AsyncIterable<BaseEvent>` so the
+ * existing `aguiToUIMessageStream` mapper (provenance-marker handling +
+ * event translation) consumes it unchanged. The official `BaseEvent` shapes
+ * are field-compatible with the event types the mapper already reads
+ * (`toolCallId`, `toolCallName`, `messageId`, `delta`, `snapshot`, `name`,
+ * `value`), so the mapper needs no change.
+ *
+ * Note: `EventSchemas.parse` strips fields not in the official spec — notably
+ * ZAQ's non-standard `RUN_FINISHED.outcome` (HITL). That path is dormant in
+ * the current release; if HITL ships it must use the official interrupt
+ * mechanism rather than a custom field.
+ */
+
+import { HttpAgent } from "@ag-ui/client";
+import type {
+	RunAgentInput as AgUiRunAgentInput,
+	BaseEvent,
+} from "@ag-ui/core";
+import type { RunAgentInput } from "./agui-events";
+
+export interface AguiHttpAgentOptions {
+	/** The `RunAgentInput` the client POSTs (built by the proxy route). */
+	input: RunAgentInput;
+	/** Request abort signal — wired to the agent so a client disconnect tears
+	 * down the upstream ZAQ request. */
+	signal?: AbortSignal;
+	/** Bearer token held server-side; never reaches the browser. */
+	token: string;
+	/** Full AG-UI runs endpoint, e.g. `http://localhost:4100/ag-ui/runs`. */
+	url: string;
+}
+
+/**
+ * Bridge an rxjs `Observable` into a pull-based `AsyncIterable`. Buffers
+ * events that arrive faster than the consumer drains them; surfaces errors and
+ * completion. Unsubscribes when the consumer stops (return/throw) so the
+ * upstream HTTP request is cancelled.
+ */
+async function* observableToAsyncIterable<T>(observable: {
+	subscribe(observer: {
+		next: (value: T) => void;
+		error: (err: unknown) => void;
+		complete: () => void;
+	}): { unsubscribe: () => void };
+}): AsyncIterable<T> {
+	const queue: T[] = [];
+	let wake: (() => void) | null = null;
+	let done = false;
+	let failure: { error: unknown } | null = null;
+
+	const subscription = observable.subscribe({
+		next: (value) => {
+			queue.push(value);
+			wake?.();
+			wake = null;
+		},
+		error: (error) => {
+			failure = { error };
+			wake?.();
+			wake = null;
+		},
+		complete: () => {
+			done = true;
+			wake?.();
+			wake = null;
+		},
+	});
+
+	try {
+		while (true) {
+			if (queue.length > 0) {
+				yield queue.shift() as T;
+				continue;
+			}
+			if (failure) {
+				// Cast: TS's control-flow analysis narrows `failure` to `never`
+				// here because the assignment lives inside the subscribe closure.
+				throw (failure as { error: unknown }).error;
+			}
+			if (done) {
+				return;
+			}
+			await new Promise<void>((resolve) => {
+				wake = resolve;
+			});
+		}
+	} finally {
+		subscription.unsubscribe();
+	}
+}
+
+/**
+ * Run a ZAQ AG-UI agent over HTTP via the official `@ag-ui/client` and yield
+ * the decoded, validated `BaseEvent` stream.
+ */
+export function aguiHttpAgentEventStream(
+	options: AguiHttpAgentOptions,
+): AsyncIterable<BaseEvent> {
+	const agent = new HttpAgent({
+		url: options.url,
+		headers: { Authorization: `Bearer ${options.token}` },
+	});
+
+	if (options.signal) {
+		if (options.signal.aborted) {
+			agent.abortRun();
+		} else {
+			options.signal.addEventListener("abort", () => agent.abortRun(), {
+				once: true,
+			});
+		}
+	}
+
+	// `run` is the low-level method: POST + SSE decode + per-frame validation.
+	// Our `RunAgentInput` is field-compatible with the official type.
+	const events$ = agent.run(options.input as unknown as AgUiRunAgentInput);
+	return observableToAsyncIterable<BaseEvent>(events$);
+}

--- a/sdks/typescript/ai-sdk/src/index.ts
+++ b/sdks/typescript/ai-sdk/src/index.ts
@@ -1,0 +1,11 @@
+// biome-ignore lint/performance/noBarrelFile: intentional package barrel — single public entry point for @zaq/ai-sdk
+export type {
+	AguiToUIMessageStreamOptions,
+	ZaqEventDataPart,
+	ZaqInterruptDataPart,
+} from "./adapter";
+export { aguiToUIMessageStream } from "./adapter";
+export * from "./agui-events";
+export type { AguiHttpAgentOptions } from "./agui-http-agent";
+export { aguiHttpAgentEventStream } from "./agui-http-agent";
+export { toAGUIMessages } from "./message-mapping";

--- a/sdks/typescript/ai-sdk/src/message-mapping.ts
+++ b/sdks/typescript/ai-sdk/src/message-mapping.ts
@@ -1,0 +1,39 @@
+/**
+ * UIMessage -> AG-UI Message conversion.
+ *
+ * The AI SDK's `UIMessage` carries a `parts[]` array (text, reasoning, tool,
+ * source, file, data, step-start). ZAQ only needs role + flat text, so
+ * `toAGUIMessages` flattens the text parts and drops the client-only parts the
+ * backend never round-trips — mirroring ag-ui's `prepareRunAgentInput`.
+ *
+ * Types only from `ai` (`verbatimModuleSyntax` is on), so no runtime `ai`
+ * dependency is pulled into this path.
+ */
+
+import type { UIMessage } from "ai";
+import type { AGUIMessage } from "./agui-events";
+
+type AnyUIMessagePart = UIMessage["parts"][number];
+
+/** Concatenate a UIMessage's text parts; ignore everything else. */
+function flattenTextContent(message: UIMessage): string {
+	let content = "";
+	for (const part of message.parts as AnyUIMessagePart[]) {
+		if (part.type === "text") {
+			content += part.text;
+		}
+	}
+	return content;
+}
+
+/**
+ * Convert the AI SDK conversation history into AG-UI messages for
+ * `RunAgentInput.messages`.
+ */
+export function toAGUIMessages(uiMessages: UIMessage[]): AGUIMessage[] {
+	return uiMessages.map((message) => ({
+		id: message.id,
+		role: message.role,
+		content: flattenTextContent(message),
+	}));
+}

--- a/sdks/typescript/ai-sdk/tsconfig.json
+++ b/sdks/typescript/ai-sdk/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "strictNullChecks": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

`@zaq/ai-sdk` — a standalone TypeScript package that turns ZAQ's [AG-UI](https://github.com/ag-ui-protocol/ag-ui) HTTP/SSE event stream into a [Vercel AI SDK](https://sdk.vercel.ai) `UIMessage` stream. Any `useChat` frontend can drive a ZAQ agent with no bespoke wire code.

It builds on the official `@ag-ui/client` (SSE decode + per-frame `@ag-ui/core` validation) and adds the one missing piece: the mapping from AG-UI events to the AI SDK's `UIMessageChunk` shape. This is the **client side**; it pairs with the AG-UI HTTP transport PR (server side).

Adds `sdks/typescript/ai-sdk/` only — no changes to existing code.

## API

| Export | Role |
|---|---|
| `aguiToUIMessageStream(events, options?)` | Maps `AsyncIterable<AGUIEvent>` → `ReadableStream<UIMessageChunk>`. `RUN_STARTED`→`start`, `TEXT_MESSAGE_CONTENT`→re-chunked `text-delta`, `TOOL_CALL_*`→dynamic `tool-*` parts, `STATE_SNAPSHOT`/`CUSTOM`→`data-*` parts, citations→`source-url`, `RUN_FINISHED`→`finish`. |
| `aguiHttpAgentEventStream({ url, token, input, signal })` | Wraps `@ag-ui/client` `HttpAgent`: POSTs a `RunAgentInput`, decodes `text/event-stream`, validates each frame against `@ag-ui/core`, and yields `AsyncIterable<BaseEvent>`. Bearer held server-side. |
| `toAGUIMessages(messages)` | Flattens AI SDK `UIMessage[]` → AG-UI `Message[]` for the request body. |
| `agui-events.ts` | Colocated Zod schemas for the AG-UI event subset ZAQ emits + the `RunAgentInput` request body. |

## Usage (server proxy + `useChat`)

Hold the bearer server-side; the browser uses the stock `DefaultChatTransport` pointed at your route.

```ts
// app/api/chat/route.ts
import { aguiHttpAgentEventStream, aguiToUIMessageStream, toAGUIMessages } from "@zaq/ai-sdk";
import { createUIMessageStreamResponse, generateId } from "ai";

export async function POST(req: Request) {
  const { messages, threadId } = await req.json();
  const events = aguiHttpAgentEventStream({
    url: `${process.env.ZAQ_AGUI_URL}/ag-ui/runs`,
    token: process.env.ZAQ_AGUI_TOKEN!,   // never sent to the browser
    input: {
      threadId: threadId ?? generateId(),
      runId: generateId(),
      state: {},
      messages: toAGUIMessages(messages),
      tools: [], context: [], forwardedProps: {},
    },
    signal: req.signal,
  });
  return createUIMessageStreamResponse({ stream: aguiToUIMessageStream(events) });
}
```

## Notes

- **Token streaming:** ZAQ token-streams its answer — each `TEXT_MESSAGE_CONTENT` delta is forwarded 1:1 as a `text-delta`, so the UI streams in real time with no client-side synthesis.
- **Citations:** ZAQ emits `[[source:…]]` / `[[memory:…]]` provenance markers inline; the adapter strips them from the text and surfaces them as `source-url` parts. The stripper is stateful, so a marker split across two streamed deltas (`…[[so` + `urce:doc]]…`) is still removed cleanly. `CUSTOM` citation events also map to `source-url`.
- **Frontend tools:** when the agent advertises a tool in `RunAgentInput.tools`, its `TOOL_CALL_*` frames become dynamic `tool-*` parts the UI can render.

## Quality

- Deps: `@ag-ui/client@0.0.57`, `@ag-ui/core@0.0.57`, `zod`; peer `ai >= 6`.
- 8 unit tests over the adapter (start/finish framing, 1:1 delta forwarding, `RUN_ERROR`, marker stripping incl. split-across-deltas, citations, state snapshots, missing-`RUN_FINISHED` graceful close); `tsc --noEmit` clean.

> Draft: opened for review alongside the server-side AG-UI transport PR.
