### PR TITLE
refactor: design migration v1.5

### DIFF
--- a/assets/css/form.css
+++ b/assets/css/form.css
@@ -46,6 +46,14 @@
   letter-spacing: var(--zaq-letter-spacing-relaxed);
 }
 
+/* Form field validation error row — DesignSystem.Checkbox, Input, SecretInput */
+.zaq-field-error {
+  display: flex;
+  align-items: center;
+  gap: var(--zaq-scale-8);
+  margin-top: var(--zaq-scale-8);
+}
+
 /* ── Shared painted shell: native <select>, text inputs, combobox triggers ─── */
 
 .zaq-control-select,

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -174,14 +174,6 @@ textarea.zaq-control-text {
   align-items: center;
 }
 
-/* Form field validation error row — DesignSystem.Checkbox, Input, SecretInput */
-.zaq-field-error {
-  display: flex;
-  align-items: center;
-  gap: var(--zaq-scale-8);
-  margin-top: var(--zaq-scale-8);
-}
-
 /* ── Dropdown / menu item ─────────────────────────────────────────────────── */
 
 .zaq-dropdown-menu-item {
@@ -425,14 +417,46 @@ pre.zaq-file-preview-body {
   color: inherit;
   text-decoration: underline;
   text-decoration-color: currentColor;
-  text-underline-offset: var(--zaq-scale-8);
+  text-underline-offset: var(--zaq-scale-4);
   text-decoration-thickness: 1px;
   text-decoration-skip-ink: auto;
 }
 
 .zaq-link-underline:hover,
-.zaq-link-underline:focus-visible {
+.zaq-link-underline:focus-visible,
+a.zaq-link:hover .zaq-link-underline,
+a.zaq-link:focus-visible .zaq-link-underline {
   text-decoration-thickness: 2px;
+}
+
+/* BO link shell — flex row; apply `.zaq-link-underline` on `.zaq-link__label` (not the icon) */
+.zaq-link {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--zaq-scale-8);
+  text-decoration: none;
+  color: inherit;
+  overflow: visible;
+}
+
+.zaq-link__icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  line-height: 0;
+}
+
+.zaq-link__label {
+  display: inline;
+  overflow: visible;
+}
+
+/* Accent tone — label + icon (not only the shell; beats `.zaq-link-underline { color: inherit }`) */
+.zaq-link--accent,
+.zaq-link--accent .zaq-link__label,
+.zaq-link--accent .zaq-link__icon {
+  color: var(--zaq-text-color-body-accent);
 }
 
 /* ── Icon — small inline (shared: breadcrumbs, segment toggles, toolbars) ─ */

--- a/lib/zaq_web/components/bo_telemetry_components.ex
+++ b/lib/zaq_web/components/bo_telemetry_components.ex
@@ -6,7 +6,8 @@ defmodule ZaqWeb.Components.BOTelemetryComponents do
   use Phoenix.Component
 
   alias Zaq.Engine.Telemetry.Contracts.DashboardChart
-  alias Zaq.Engine.Telemetry.Contracts.DisplayMeta
+  alias ZaqWeb.Components.DesignSystem.MetricCard
+  alias ZaqWeb.Helpers.TelemetryFormat
 
   alias Zaq.Engine.Telemetry.Contracts.Payloads.{
     CategoryVectorPayload,
@@ -30,114 +31,7 @@ defmodule ZaqWeb.Components.BOTelemetryComponents do
   attr :range, :string, default: nil
   attr :hint, :string, default: nil
 
-  def metric_card(assigns) do
-    assigns = assign_from_card(assigns)
-
-    ~H"""
-    <article id={@id} class="zaq-card-default zaq-border-default zaq-card-hover">
-      <p
-        class="zaq-text-caption uppercase tracking-[0.18em]"
-        style="color: var(--zaq-text-color-body-secondary);"
-      >
-        {@label}
-      </p>
-      <div class="mt-3 flex items-end justify-between gap-3">
-        <p class="zaq-text-h1" style="color: var(--zaq-text-color-body-default);">
-          {format_value(@value)}<span
-            :if={@unit}
-            class="zaq-text-body-sm ml-1"
-            style="color: var(--zaq-text-color-body-secondary);"
-          >{@unit}</span>
-        </p>
-        <p
-          :if={is_number(@trend)}
-          class={[
-            "rounded-full px-2 py-1 font-mono text-[0.68rem] transition-colors",
-            if(@trend >= 0,
-              do: "bg-cyan-50 text-cyan-700",
-              else: "bg-slate-100 text-slate-600"
-            )
-          ]}
-        >
-          {trend_label(@trend)}
-        </p>
-      </div>
-      <p
-        :if={metadata_line(@display, @range, @hint)}
-        class="zaq-text-body-sm mt-3"
-        style="color: var(--zaq-text-color-body-tertiary);"
-      >
-        {metadata_line(@display, @range, @hint)}
-      </p>
-    </article>
-    """
-  end
-
-  defp assign_from_card(%{card: %ScalarPayload{} = card} = assigns) do
-    assigns
-    |> assign(:label, card.label)
-    |> assign(:value, card.value)
-    |> assign(:unit, card.unit)
-    |> assign(:trend, card.trend)
-    |> assign(:display, card.display)
-  end
-
-  defp assign_from_card(assigns) do
-    display =
-      case Map.get(assigns, :meta) do
-        %DisplayMeta{} = value -> value
-        meta when is_map(meta) -> DisplayMeta.from_map(meta)
-        _ -> %DisplayMeta{}
-      end
-
-    assign(assigns, :display, display)
-  end
-
-  defp metadata_line(display, range, hint) do
-    range_value = display_range(display) || range
-    hint_value = display_hint(display) || hint
-
-    extra_meta =
-      display_extra(display)
-      |> Enum.reject(fn {_key, value} -> blank_meta_value?(value) end)
-      |> Enum.map(fn {key, value} -> "#{format_meta_key(key)}: #{format_meta_value(value)}" end)
-
-    ([metadata_part("range", range_value), hint_value] ++ extra_meta)
-    |> Enum.reject(&blank_meta_value?/1)
-    |> case do
-      [] -> nil
-      parts -> Enum.join(parts, " · ")
-    end
-  end
-
-  defp metadata_part(_name, value) when value in [nil, ""], do: nil
-  defp metadata_part(name, value), do: "#{name}: #{value}"
-
-  defp display_range(%DisplayMeta{range: value}), do: value
-  defp display_range(_), do: nil
-
-  defp display_hint(%DisplayMeta{hint: value}), do: value
-  defp display_hint(_), do: nil
-
-  defp display_extra(%DisplayMeta{extra: value}) when is_map(value), do: value
-  defp display_extra(_), do: %{}
-
-  defp format_meta_key(key) do
-    key
-    |> key_string()
-    |> String.replace("_", " ")
-  end
-
-  defp key_string(key) when is_atom(key), do: Atom.to_string(key)
-  defp key_string(key) when is_binary(key), do: key
-  defp key_string(key), do: to_string(key)
-
-  defp format_meta_value(value) when is_binary(value), do: value
-  defp format_meta_value(value) when is_number(value), do: format_value(value)
-  defp format_meta_value(value), do: to_string(value)
-
-  defp blank_meta_value?(value) when value in [nil, ""], do: true
-  defp blank_meta_value?(_value), do: false
+  def metric_card(assigns), do: MetricCard.metric_card(assigns)
 
   defp assign_time_series_from_chart(%{chart: %DashboardChart{} = chart} = assigns) do
     payload = time_series_payload(chart)
@@ -1401,32 +1295,7 @@ defmodule ZaqWeb.Components.BOTelemetryComponents do
   defp status_dot_class(:down), do: "bg-slate-700"
   defp status_dot_class(:unknown), do: "bg-slate-300"
 
-  defp trend_label(value) when value >= 0, do: "+#{round2(value)}%"
-  defp trend_label(value), do: "#{round2(value)}%"
-
-  defp format_value(nil), do: "--"
-
-  defp format_value(value) when is_integer(value) do
-    value
-    |> Integer.to_string()
-    |> String.reverse()
-    |> String.replace(~r/(.{3})(?=.)/, "\\1,")
-    |> String.reverse()
-  end
-
-  defp format_value(value) when is_float(value) do
-    rounded = Float.round(value, 2)
-
-    if rounded == trunc(rounded) do
-      Integer.to_string(trunc(rounded))
-    else
-      :erlang.float_to_binary(rounded, decimals: 2)
-      |> String.trim_trailing("0")
-      |> String.trim_trailing(".")
-    end
-  end
-
-  defp format_value(value), do: to_string(value)
+  defp format_value(value), do: TelemetryFormat.format_value(value)
 
   defp to_number(value) when is_integer(value), do: value * 1.0
   defp to_number(value) when is_float(value), do: value
@@ -1471,5 +1340,5 @@ defmodule ZaqWeb.Components.BOTelemetryComponents do
   defp clamp(value, _min, max) when value > max, do: max
   defp clamp(value, _min, _max), do: value
 
-  defp round2(value), do: Float.round(value * 1.0, 2)
+  defp round2(value), do: TelemetryFormat.round2(value)
 end

--- a/lib/zaq_web/components/design_system/link.ex
+++ b/lib/zaq_web/components/design_system/link.ex
@@ -1,0 +1,98 @@
+defmodule ZaqWeb.Components.DesignSystem.Link do
+  @moduledoc """
+  BO underline navigation link — decoration on the label only (icon excluded).
+
+  Set `destination` to the target path. Use `external: true` for plain `href` links.
+  Sizes: `:default` (`.zaq-text-body`) and `:sm` (`.zaq-text-body-sm`).
+  Optional `icon` with `icon_position` (`:left` default, `:right`).
+
+  Color: `tone` — `:default` (inherit from parent) or `:accent` (`--zaq-text-color-body-accent`).
+  No other color modes; do not pass color utilities via `class`.
+
+  **Styles:** `.zaq-link`, `.zaq-link-underline` in `styles.css`.
+  """
+
+  use Phoenix.Component
+
+  import ZaqWeb.CoreComponents, only: [icon: 1]
+
+  attr :destination, :string, required: true, doc: "Target path or URL."
+
+  attr :external, :boolean,
+    default: false,
+    doc: "When true, renders `href` instead of LiveView `navigate`."
+
+  attr :size, :atom, default: :default, values: [:default, :sm]
+
+  attr :tone, :atom,
+    default: :default,
+    values: [:default, :accent],
+    doc: "`:default` inherits color from parent; `:accent` uses `--zaq-text-color-body-accent`."
+
+  attr :icon, :string, default: nil, doc: "Optional Heroicon name (e.g. `hero-arrow-right`)."
+
+  attr :icon_position, :atom,
+    default: :left,
+    values: [:left, :right],
+    doc: "Icon placement when `icon` is set. Underline stays on the label only."
+
+  attr :id, :string, default: nil
+  attr :class, :any, default: nil
+
+  attr :rest, :global, include: ~w(data-testid aria-label patch)
+
+  slot :inner_block, required: true
+
+  def nav_link(assigns) do
+    tone = normalize_tone(assigns.tone)
+
+    assigns =
+      assigns
+      |> assign(:tone, tone)
+      |> assign(:icon_position, normalize_icon_position(assigns.icon_position))
+      |> assign(:shell_class, shell_class(tone))
+      |> assign(:label_class, label_class(assigns.size))
+      |> assign(:destination_attrs, destination_attrs(assigns.external, assigns.destination))
+
+    ~H"""
+    <.link id={@id} class={[Enum.join(@shell_class, " "), @class]} {@destination_attrs} {@rest}>
+      <.link_icon :if={@icon && @icon_position == :left} name={@icon} />
+      <span class={@label_class}>
+        {render_slot(@inner_block)}
+      </span>
+      <.link_icon :if={@icon && @icon_position == :right} name={@icon} />
+    </.link>
+    """
+  end
+
+  attr :name, :string, required: true
+
+  defp link_icon(assigns) do
+    ~H"""
+    <span class="zaq-link__icon">
+      <.icon name={@name} class="zaq-icon-sm" />
+    </span>
+    """
+  end
+
+  defp shell_class(:default), do: ["zaq-link", "zaq-focus-visible"]
+  defp shell_class(:accent), do: ["zaq-link", "zaq-link--accent", "zaq-focus-visible"]
+
+  defp label_class(size) do
+    [text_size_class(size), "zaq-link__label", "zaq-link-underline"]
+  end
+
+  defp text_size_class(:default), do: "zaq-text-body"
+  defp text_size_class(:sm), do: "zaq-text-body-sm"
+
+  defp destination_attrs(true, destination), do: %{href: destination}
+  defp destination_attrs(false, destination), do: %{navigate: destination}
+
+  defp normalize_icon_position(position) when position in [:left, :right], do: position
+  defp normalize_icon_position("left"), do: :left
+  defp normalize_icon_position("right"), do: :right
+
+  defp normalize_tone(tone) when tone in [:default, :accent], do: tone
+  defp normalize_tone("default"), do: :default
+  defp normalize_tone("accent"), do: :accent
+end

--- a/lib/zaq_web/components/design_system/metric_card.ex
+++ b/lib/zaq_web/components/design_system/metric_card.ex
@@ -1,0 +1,326 @@
+defmodule ZaqWeb.Components.DesignSystem.MetricCard do
+  @moduledoc """
+  BO KPI metric card — label, value, optional unit/trend, and metadata footer.
+
+  Optional navigation:
+
+  * **`primary_link`** — map `%{destination:, id:, external:}` wrapping the card in a
+    block link (`group block`). When omitted and `card` is a `%ScalarPayload{}` with
+    `runtime.href`, the primary link is derived from the payload.
+  * **`secondary_link`** — map `%{destination:, label:, id:, tone:, size:, icon:,
+    icon_position:, external:}` rendering `DesignSystem.Link.nav_link/1` below the card.
+
+  Display metadata comes from `display` / flat attrs; `runtime` metadata is never rendered
+  on the card surface (only used for primary-link auto-fill).
+  """
+
+  use Phoenix.Component
+
+  import ZaqWeb.Components.DesignSystem.Link, only: [nav_link: 1]
+
+  alias Zaq.Engine.Telemetry.Contracts.DisplayMeta
+  alias Zaq.Engine.Telemetry.Contracts.Payloads.ScalarPayload
+  alias ZaqWeb.Helpers.TelemetryFormat
+
+  attr :id, :string, required: true, doc: "Id on the card `<article>` element."
+
+  attr :card, :map, default: nil, doc: "Optional `%ScalarPayload{}` envelope."
+
+  attr :label, :string, default: nil
+  attr :value, :any, default: nil
+  attr :unit, :string, default: nil
+  attr :trend, :float, default: nil
+  attr :meta, :map, default: %{}
+  attr :range, :string, default: nil
+  attr :hint, :string, default: nil
+
+  attr :primary_link, :map,
+    default: nil,
+    doc:
+      "Optional `%{destination:, id:, external:}`. Auto-filled from `card.runtime.href` when omitted."
+
+  attr :secondary_link, :map,
+    default: nil,
+    doc:
+      "Optional `%{destination:, label:, id:, tone:, size:, icon:, icon_position:, external:}`."
+
+  def metric_card(assigns) do
+    assigns = assign_from_card(assigns)
+
+    assigns =
+      assigns
+      |> assign(:resolved_primary, resolved_primary_link(assigns))
+      |> assign(:resolved_secondary, resolved_secondary_link(assigns))
+
+    ~H"""
+    <div :if={@resolved_secondary} class="space-y-2">
+      <.linked_metric_card_article
+        id={@id}
+        primary={@resolved_primary}
+        label={@label}
+        value={@value}
+        unit={@unit}
+        trend={@trend}
+        display={@display}
+        range={@range}
+        hint={@hint}
+      />
+      <.metric_card_secondary_link link={@resolved_secondary} />
+    </div>
+    <.linked_metric_card_article
+      :if={!@resolved_secondary}
+      id={@id}
+      primary={@resolved_primary}
+      label={@label}
+      value={@value}
+      unit={@unit}
+      trend={@trend}
+      display={@display}
+      range={@range}
+      hint={@hint}
+    />
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :primary, :map, default: nil
+  attr :label, :string, default: nil
+  attr :value, :any, default: nil
+  attr :unit, :string, default: nil
+  attr :trend, :float, default: nil
+  attr :display, :map, default: nil
+  attr :range, :string, default: nil
+  attr :hint, :string, default: nil
+
+  defp linked_metric_card_article(assigns) do
+    ~H"""
+    <.link
+      :if={@primary}
+      id={@primary.id}
+      class="group block"
+      {primary_destination_attrs(@primary)}
+    >
+      <.metric_card_article
+        id={@id}
+        label={@label}
+        value={@value}
+        unit={@unit}
+        trend={@trend}
+        display={@display}
+        range={@range}
+        hint={@hint}
+      />
+    </.link>
+    <.metric_card_article
+      :if={!@primary}
+      id={@id}
+      label={@label}
+      value={@value}
+      unit={@unit}
+      trend={@trend}
+      display={@display}
+      range={@range}
+      hint={@hint}
+    />
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :label, :string, default: nil
+  attr :value, :any, default: nil
+  attr :unit, :string, default: nil
+  attr :trend, :float, default: nil
+  attr :display, :map, default: nil
+  attr :range, :string, default: nil
+  attr :hint, :string, default: nil
+
+  defp metric_card_article(assigns) do
+    ~H"""
+    <article id={@id} class="zaq-card-default zaq-border-default zaq-card-hover">
+      <p
+        class="zaq-text-caption uppercase tracking-[0.18em]"
+        style="color: var(--zaq-text-color-body-secondary);"
+      >
+        {@label}
+      </p>
+      <div class="mt-3 flex items-end justify-between gap-3">
+        <p class="zaq-text-h1" style="color: var(--zaq-text-color-body-default);">
+          {TelemetryFormat.format_value(@value)}<span
+            :if={@unit}
+            class="zaq-text-body-sm ml-1"
+            style="color: var(--zaq-text-color-body-secondary);"
+          >{@unit}</span>
+        </p>
+        <p
+          :if={is_number(@trend)}
+          class={[
+            "rounded-full px-2 py-1 font-mono text-[0.68rem] transition-colors",
+            if(@trend >= 0,
+              do: "bg-cyan-50 text-cyan-700",
+              else: "bg-slate-100 text-slate-600"
+            )
+          ]}
+        >
+          {TelemetryFormat.format_trend_percent(@trend)}
+        </p>
+      </div>
+      <p
+        :if={metadata_line(@display, @range, @hint)}
+        class="zaq-text-body-sm mt-3"
+        style="color: var(--zaq-text-color-body-tertiary);"
+      >
+        {metadata_line(@display, @range, @hint)}
+      </p>
+    </article>
+    """
+  end
+
+  attr :link, :map, required: true
+
+  defp metric_card_secondary_link(assigns) do
+    ~H"""
+    <.nav_link
+      id={@link.id}
+      destination={@link.destination}
+      external={@link.external}
+      tone={@link.tone}
+      size={@link.size}
+      icon={@link.icon}
+      icon_position={@link.icon_position}
+    >
+      {@link.label}
+    </.nav_link>
+    """
+  end
+
+  defp resolved_primary_link(%{primary_link: link}) when is_map(link) do
+    normalize_primary_link(link)
+  end
+
+  defp resolved_primary_link(%{
+         primary_link: nil,
+         card: %ScalarPayload{runtime: %{href: href}} = card
+       })
+       when is_binary(href) and href != "" do
+    %{destination: href, id: card.id, external: false}
+  end
+
+  defp resolved_primary_link(%{primary_link: nil}), do: nil
+
+  defp resolved_primary_link(_assigns), do: nil
+
+  defp resolved_secondary_link(%{secondary_link: link}) when is_map(link) do
+    normalize_secondary_link(link)
+  end
+
+  defp resolved_secondary_link(_assigns), do: nil
+
+  defp normalize_primary_link(link) do
+    destination = map_get(link, :destination)
+
+    if blank_meta_value?(destination) do
+      nil
+    else
+      %{
+        destination: destination,
+        id: map_get(link, :id),
+        external: map_get(link, :external) || false
+      }
+    end
+  end
+
+  defp normalize_secondary_link(link) do
+    destination = map_get(link, :destination)
+    label = map_get(link, :label)
+
+    if blank_meta_value?(destination) or blank_meta_value?(label) do
+      nil
+    else
+      %{
+        destination: destination,
+        label: label,
+        id: map_get(link, :id),
+        external: map_get(link, :external) || false,
+        tone: map_get(link, :tone) || :accent,
+        size: map_get(link, :size) || :sm,
+        icon: map_get(link, :icon) || "hero-arrow-right",
+        icon_position: map_get(link, :icon_position) || :right
+      }
+    end
+  end
+
+  defp primary_destination_attrs(%{external: true, destination: destination}),
+    do: %{href: destination}
+
+  defp primary_destination_attrs(%{destination: destination}), do: %{navigate: destination}
+
+  defp assign_from_card(%{card: %ScalarPayload{} = card} = assigns) do
+    assigns
+    |> assign(:label, card.label)
+    |> assign(:value, card.value)
+    |> assign(:unit, card.unit)
+    |> assign(:trend, card.trend)
+    |> assign(:display, card.display)
+  end
+
+  defp assign_from_card(assigns) do
+    display =
+      case Map.get(assigns, :meta) do
+        %DisplayMeta{} = value -> value
+        meta when is_map(meta) -> DisplayMeta.from_map(meta)
+        _ -> %DisplayMeta{}
+      end
+
+    assign(assigns, :display, display)
+  end
+
+  defp metadata_line(display, range, hint) do
+    range_value = display_range(display) || range
+    hint_value = display_hint(display) || hint
+
+    extra_meta =
+      display_extra(display)
+      |> Enum.reject(fn {_key, value} -> blank_meta_value?(value) end)
+      |> Enum.map(fn {key, value} -> "#{format_meta_key(key)}: #{format_meta_value(value)}" end)
+
+    ([metadata_part("range", range_value), hint_value] ++ extra_meta)
+    |> Enum.reject(&blank_meta_value?/1)
+    |> case do
+      [] -> nil
+      parts -> Enum.join(parts, " · ")
+    end
+  end
+
+  defp metadata_part(_name, value) when value in [nil, ""], do: nil
+  defp metadata_part(name, value), do: "#{name}: #{value}"
+
+  defp display_range(%DisplayMeta{range: value}), do: value
+  defp display_range(_), do: nil
+
+  defp display_hint(%DisplayMeta{hint: value}), do: value
+  defp display_hint(_), do: nil
+
+  defp display_extra(%DisplayMeta{extra: value}) when is_map(value), do: value
+  defp display_extra(_), do: %{}
+
+  defp format_meta_key(key) do
+    key
+    |> key_string()
+    |> String.replace("_", " ")
+  end
+
+  defp key_string(key) when is_atom(key), do: Atom.to_string(key)
+  defp key_string(key) when is_binary(key), do: key
+  defp key_string(key), do: to_string(key)
+
+  defp format_meta_value(value) when is_binary(value), do: value
+  defp format_meta_value(value) when is_number(value), do: TelemetryFormat.format_value(value)
+  defp format_meta_value(value), do: to_string(value)
+
+  defp blank_meta_value?(value) when value in [nil, ""], do: true
+  defp blank_meta_value?(_value), do: false
+
+  defp map_get(map, key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+end

--- a/lib/zaq_web/dashboard/metric_overview.ex
+++ b/lib/zaq_web/dashboard/metric_overview.ex
@@ -5,60 +5,64 @@ defmodule ZaqWeb.Dashboard.MetricOverview do
 
   use Phoenix.Component
 
-  import ZaqWeb.Components.BOTelemetryComponents, only: [metric_card: 1]
-  import ZaqWeb.Components.DesignSystem.Link, only: [nav_link: 1]
+  import ZaqWeb.Components.DesignSystem.MetricCard, only: [metric_card: 1]
 
   attr :metric_cards, :list, required: true
 
   def metric_overview(assigns) do
     ~H"""
     <div class="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-      <div :for={metric <- @metric_cards} class="space-y-2">
-        <.link
-          id={metric.id}
-          navigate={metric.runtime.href || "/bo/dashboard"}
-          class="group block"
-        >
-          <.metric_card id={metric.id <> "-card"} card={metric} />
-        </.link>
-
-        <.nav_link
-          :if={metric.id == "dashboard-metric-documents-ingested"}
-          id="dashboard-knowledge-base-metrics-link"
-          destination="/bo/dashboard/knowledge-base-metrics"
-          tone={:accent}
-          size={:sm}
-          icon="hero-arrow-right"
-          icon_position={:right}
-        >
-          View Knowledge base metrics
-        </.nav_link>
-
-        <.nav_link
-          :if={metric.id == "dashboard-metric-llm-api-calls"}
-          id="dashboard-llm-performance-link"
-          destination="/bo/dashboard/llm-performance"
-          tone={:accent}
-          size={:sm}
-          icon="hero-arrow-right"
-          icon_position={:right}
-        >
-          View LLM performance
-        </.nav_link>
-
-        <.nav_link
-          :if={metric.id == "dashboard-metric-qa-response-time"}
-          id="dashboard-conversations-metrics-link"
-          destination="/bo/dashboard/conversations-metrics"
-          tone={:accent}
-          size={:sm}
-          icon="hero-arrow-right"
-          icon_position={:right}
-        >
-          View Conversations metrics
-        </.nav_link>
-      </div>
+      <.metric_card
+        :for={metric <- @metric_cards}
+        id={metric.id <> "-card"}
+        card={metric}
+        primary_link={
+          %{
+            id: metric.id,
+            destination: metric.runtime.href || "/bo/dashboard"
+          }
+        }
+        secondary_link={secondary_link_for(metric.id)}
+      />
     </div>
     """
   end
+
+  defp secondary_link_for("dashboard-metric-documents-ingested") do
+    %{
+      id: "dashboard-knowledge-base-metrics-link",
+      destination: "/bo/dashboard/knowledge-base-metrics",
+      label: "View Knowledge base metrics",
+      tone: :accent,
+      size: :sm,
+      icon: "hero-arrow-right",
+      icon_position: :right
+    }
+  end
+
+  defp secondary_link_for("dashboard-metric-llm-api-calls") do
+    %{
+      id: "dashboard-llm-performance-link",
+      destination: "/bo/dashboard/llm-performance",
+      label: "View LLM performance",
+      tone: :accent,
+      size: :sm,
+      icon: "hero-arrow-right",
+      icon_position: :right
+    }
+  end
+
+  defp secondary_link_for("dashboard-metric-qa-response-time") do
+    %{
+      id: "dashboard-conversations-metrics-link",
+      destination: "/bo/dashboard/conversations-metrics",
+      label: "View Conversations metrics",
+      tone: :accent,
+      size: :sm,
+      icon: "hero-arrow-right",
+      icon_position: :right
+    }
+  end
+
+  defp secondary_link_for(_), do: nil
 end

--- a/lib/zaq_web/dashboard/metric_overview.ex
+++ b/lib/zaq_web/dashboard/metric_overview.ex
@@ -6,6 +6,7 @@ defmodule ZaqWeb.Dashboard.MetricOverview do
   use Phoenix.Component
 
   import ZaqWeb.Components.BOTelemetryComponents, only: [metric_card: 1]
+  import ZaqWeb.Components.DesignSystem.Link, only: [nav_link: 1]
 
   attr :metric_cards, :list, required: true
 
@@ -21,32 +22,41 @@ defmodule ZaqWeb.Dashboard.MetricOverview do
           <.metric_card id={metric.id <> "-card"} card={metric} />
         </.link>
 
-        <.link
+        <.nav_link
           :if={metric.id == "dashboard-metric-documents-ingested"}
           id="dashboard-knowledge-base-metrics-link"
-          navigate="/bo/dashboard/knowledge-base-metrics"
-          class="inline-flex items-center gap-2 rounded-lg border border-[#03b6d4]/25 bg-white px-3 py-1.5 font-mono text-[0.68rem] font-semibold text-[#03b6d4] transition-colors hover:bg-[#03b6d4]/10"
+          destination="/bo/dashboard/knowledge-base-metrics"
+          tone={:accent}
+          size={:sm}
+          icon="hero-arrow-right"
+          icon_position={:right}
         >
-          View Knowledge base metrics <span class="text-[0.8rem]">-&gt;</span>
-        </.link>
+          View Knowledge base metrics
+        </.nav_link>
 
-        <.link
+        <.nav_link
           :if={metric.id == "dashboard-metric-llm-api-calls"}
           id="dashboard-llm-performance-link"
-          navigate="/bo/dashboard/llm-performance"
-          class="inline-flex items-center gap-2 rounded-lg border border-[#03b6d4]/25 bg-white px-3 py-1.5 font-mono text-[0.68rem] font-semibold text-[#03b6d4] transition-colors hover:bg-[#03b6d4]/10"
+          destination="/bo/dashboard/llm-performance"
+          tone={:accent}
+          size={:sm}
+          icon="hero-arrow-right"
+          icon_position={:right}
         >
-          View LLM performance <span class="text-[0.8rem]">-&gt;</span>
-        </.link>
+          View LLM performance
+        </.nav_link>
 
-        <.link
+        <.nav_link
           :if={metric.id == "dashboard-metric-qa-response-time"}
           id="dashboard-conversations-metrics-link"
-          navigate="/bo/dashboard/conversations-metrics"
-          class="inline-flex items-center gap-2 rounded-lg border border-[#03b6d4]/25 bg-white px-3 py-1.5 font-mono text-[0.68rem] font-semibold text-[#03b6d4] transition-colors hover:bg-[#03b6d4]/10"
+          destination="/bo/dashboard/conversations-metrics"
+          tone={:accent}
+          size={:sm}
+          icon="hero-arrow-right"
+          icon_position={:right}
         >
-          View Conversations metrics <span class="text-[0.8rem]">-&gt;</span>
-        </.link>
+          View Conversations metrics
+        </.nav_link>
       </div>
     </div>
     """

--- a/lib/zaq_web/helpers/telemetry_format.ex
+++ b/lib/zaq_web/helpers/telemetry_format.ex
@@ -1,0 +1,37 @@
+defmodule ZaqWeb.Helpers.TelemetryFormat do
+  @moduledoc """
+  Shared number formatting for BO telemetry KPIs and charts.
+  """
+
+  @spec format_value(term()) :: String.t()
+  def format_value(nil), do: "--"
+
+  def format_value(value) when is_integer(value) do
+    value
+    |> Integer.to_string()
+    |> String.reverse()
+    |> String.replace(~r/(.{3})(?=.)/, "\\1,")
+    |> String.reverse()
+  end
+
+  def format_value(value) when is_float(value) do
+    rounded = Float.round(value, 2)
+
+    if rounded == trunc(rounded) do
+      Integer.to_string(trunc(rounded))
+    else
+      :erlang.float_to_binary(rounded, decimals: 2)
+      |> String.trim_trailing("0")
+      |> String.trim_trailing(".")
+    end
+  end
+
+  def format_value(value), do: to_string(value)
+
+  @spec format_trend_percent(number()) :: String.t()
+  def format_trend_percent(value) when value >= 0, do: "+#{round2(value)}%"
+  def format_trend_percent(value), do: "#{round2(value)}%"
+
+  @spec round2(number()) :: float()
+  def round2(value), do: Float.round(value * 1.0, 2)
+end

--- a/storybook/components/cards/metric_card.story.exs
+++ b/storybook/components/cards/metric_card.story.exs
@@ -1,42 +1,162 @@
 defmodule Storybook.Components.Cards.MetricCard do
   use PhoenixStorybook.Story, :page
+  use Phoenix.Component
 
-  def description, do: "KPI tile with value, unit, trend indicator, and optional hint tooltip."
+  import ZaqWeb.Components.DesignSystem.MetricCard, only: [metric_card: 1]
+
+  alias Zaq.Engine.Telemetry.Contracts.{DisplayMeta, RuntimeMeta}
+  alias Zaq.Engine.Telemetry.Contracts.Payloads.ScalarPayload
+
+  def description do
+    "KPI tile (`DesignSystem.MetricCard`) with optional **`primary_link`** (card wrapper) and " <>
+      "**`secondary_link`** (`DesignSystem.Link` below the card). " <>
+      "**Navigation sections** (primary only, auto primary, both links) are distinct API modes. " <>
+      "**No links** shows one mode — display-only cards — with several sample data shapes side by side."
+  end
 
   def render(assigns) do
     ~H"""
-    <div style="display: flex; flex-wrap: wrap; gap: 1rem; padding: 1.5rem;">
-      <ZaqWeb.Components.BOTelemetryComponents.metric_card
-        id="card-queries"
-        label="Queries today"
-        value={1_284}
-        unit="queries"
-        trend={0.12}
-        range="vs yesterday"
-      />
-      <ZaqWeb.Components.BOTelemetryComponents.metric_card
-        id="card-errors"
-        label="Error rate"
-        value={3.4}
-        unit="%"
-        trend={-0.08}
-        range="vs last week"
-      />
-      <ZaqWeb.Components.BOTelemetryComponents.metric_card
-        id="card-agents"
-        label="Active agents"
-        value={7}
-        unit="agents"
-      />
-      <ZaqWeb.Components.BOTelemetryComponents.metric_card
-        id="card-confidence"
-        label="Avg confidence"
-        value={0.83}
-        unit="score"
-        trend={0.04}
-        range="vs last month"
-        hint="Average confidence score across all answered queries."
-      />
+    <div
+      class="zaq-text-body"
+      style="display: flex; flex-direction: column; gap: var(--zaq-scale-32); padding: var(--zaq-scale-24);"
+    >
+      <section>
+        <p class="zaq-text-body-sm" style="color: var(--zaq-text-color-body-secondary); margin: 0;">
+          No links — display-only cards
+        </p>
+        <p
+          class="zaq-text-caption"
+          style="color: var(--zaq-text-color-body-tertiary); margin: var(--zaq-scale-8) 0 var(--zaq-scale-16); max-width: 42rem;"
+        >
+          Same API mode: omit `primary_link` and `secondary_link`. Each example below is a single
+          card instance with different optional fields (unit, trend, range, hint) — not a composite
+          “default group”. On live pages you typically render one card per slot.
+        </p>
+        <div style="display: flex; flex-wrap: wrap; gap: var(--zaq-scale-24); align-items: flex-start;">
+          <.example label="Full — unit, positive trend, range">
+            <.metric_card
+              id="card-queries"
+              label="Queries today"
+              value={1_284}
+              unit="queries"
+              trend={0.12}
+              range="vs yesterday"
+            />
+          </.example>
+          <.example label="Negative trend">
+            <.metric_card
+              id="card-errors"
+              label="Error rate"
+              value={3.4}
+              unit="%"
+              trend={-0.08}
+              range="vs last week"
+            />
+          </.example>
+          <.example label="Minimal — value and unit only">
+            <.metric_card id="card-agents" label="Active agents" value={7} unit="agents" />
+          </.example>
+          <.example label="With hint in metadata footer">
+            <.metric_card
+              id="card-confidence"
+              label="Avg confidence"
+              value={0.83}
+              unit="score"
+              trend={0.04}
+              range="vs last month"
+              hint="Average confidence score across all answered queries."
+            />
+          </.example>
+        </div>
+      </section>
+
+      <section>
+        <p class="zaq-text-body-sm" style="color: var(--zaq-text-color-body-secondary); margin: 0;">
+          Primary link only — explicit `primary_link` map
+        </p>
+        <p
+          class="zaq-text-caption"
+          style="color: var(--zaq-text-color-body-tertiary); margin: var(--zaq-scale-8) 0 var(--zaq-scale-16); max-width: 42rem;"
+        >
+          Card is wrapped in a block link. Pass a `primary_link` map with `destination` and optional `id`.
+        </p>
+        <.metric_card
+          id="card-primary-only"
+          label="Documents ingested"
+          value={128}
+          range="30d"
+          primary_link={%{id: "story-metric-primary", destination: "/bo/ingestion"}}
+        />
+      </section>
+
+      <section>
+        <p class="zaq-text-body-sm" style="color: var(--zaq-text-color-body-secondary); margin: 0;">
+          Primary link only — auto-filled from `card.runtime.href`
+        </p>
+        <p
+          class="zaq-text-caption"
+          style="color: var(--zaq-text-color-body-tertiary); margin: var(--zaq-scale-8) 0 var(--zaq-scale-16); max-width: 42rem;"
+        >
+          When `primary_link` is omitted and `card` is a `%ScalarPayload{}` with `runtime.href`, the
+          component wraps the card automatically (link `id` uses `card.id`).
+        </p>
+        <.metric_card
+          id="story-metric-auto-primary-card"
+          card={
+            %ScalarPayload{
+              id: "story-metric-auto-primary",
+              label: "LLM API calls",
+              value: 4_200,
+              display: %DisplayMeta{range: "30d", hint: "answering throughput"},
+              runtime: %RuntimeMeta{href: "/bo/ai-diagnostics"}
+            }
+          }
+        />
+      </section>
+
+      <section>
+        <p class="zaq-text-body-sm" style="color: var(--zaq-text-color-body-secondary); margin: 0;">
+          Primary + secondary — dashboard KPI pattern
+        </p>
+        <p
+          class="zaq-text-caption"
+          style="color: var(--zaq-text-color-body-tertiary); margin: var(--zaq-scale-8) 0 var(--zaq-scale-16); max-width: 42rem;"
+        >
+          Clickable card plus a `DesignSystem.Link` CTA below. Destinations are independent;
+          `secondary_link` always requires an explicit `label` and `destination`.
+        </p>
+        <.metric_card
+          id="story-metric-both-links-card"
+          label="Documents ingested"
+          value={128}
+          range="30d"
+          primary_link={%{id: "story-metric-both", destination: "/bo/ingestion"}}
+          secondary_link={
+            %{
+              id: "story-metric-secondary",
+              destination: "/bo/dashboard/knowledge-base-metrics",
+              label: "View Knowledge base metrics"
+            }
+          }
+        />
+      </section>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  slot :inner_block, required: true
+
+  defp example(assigns) do
+    ~H"""
+    <div style="display: flex; flex-direction: column; gap: var(--zaq-scale-8); max-width: 16rem;">
+      <span
+        class="zaq-text-caption"
+        style="color: var(--zaq-text-color-body-tertiary); font-family: ui-monospace, monospace;"
+      >
+        {@label}
+      </span>
+      {render_slot(@inner_block)}
     </div>
     """
   end

--- a/storybook/components/design_system/link.story.exs
+++ b/storybook/components/design_system/link.story.exs
@@ -1,0 +1,102 @@
+defmodule Storybook.Components.DesignSystem.Link do
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &ZaqWeb.Components.DesignSystem.Link.nav_link/1
+
+  # Demo-only placeholder — callers pass their own `destination` at use site.
+  @demo_destination "/bo/example-destination"
+
+  def description do
+    "BO underline navigation link. Pass **`destination`** (required) where the component is used — " <>
+      "Storybook examples below only show a demo path (`#{@demo_destination}`). " <>
+      "**Color:** `tone={:default}` (inherit from parent) or `tone={:accent}` — no other color modes. " <>
+      "Optional `icon` with `icon_position` (`:left` default, `:right`). " <>
+      "Sizes: `:default` (`.zaq-text-body`) or `:sm` (`.zaq-text-body-sm`)."
+  end
+
+  def container do
+    {:div,
+     style:
+       "padding: var(--zaq-scale-24); background: var(--zaq-surface-color-base); color: var(--zaq-text-color-body-default); display: flex; flex-direction: column; gap: var(--zaq-scale-16); align-items: flex-start;"}
+  end
+
+  def variations do
+    demo = @demo_destination
+    base = %{destination: demo, external: true}
+
+    [
+      %VariationGroup{
+        id: :default_tone,
+        description: "tone={:default} — inherits parent color",
+        variations: [
+          %Variation{
+            id: :text_only,
+            description: "Default size, no icon",
+            attributes: Map.merge(base, %{size: :default, tone: :default}),
+            slots: ["Example link label"]
+          },
+          %Variation{
+            id: :with_icon_right,
+            description: "Default size, icon right",
+            attributes:
+              Map.merge(base, %{
+                size: :default,
+                tone: :default,
+                icon: "hero-arrow-right",
+                icon_position: :right
+              }),
+            slots: ["Example link label"]
+          },
+          %Variation{
+            id: :small,
+            description: "Small size, icon left",
+            attributes:
+              Map.merge(base, %{
+                size: :sm,
+                tone: :default,
+                icon: "hero-arrow-right",
+                icon_position: :left
+              }),
+            slots: ["Example link label"]
+          }
+        ]
+      },
+      %VariationGroup{
+        id: :accent_tone,
+        description: "tone={:accent} — semantic accent color",
+        variations: [
+          %Variation{
+            id: :text_only,
+            description: "Default size, no icon",
+            attributes: Map.merge(base, %{size: :default, tone: :accent}),
+            slots: ["Example link label"]
+          },
+          %Variation{
+            id: :with_icon_right,
+            description: "Default size, icon right",
+            attributes:
+              Map.merge(base, %{
+                size: :default,
+                tone: :accent,
+                icon: "hero-arrow-right",
+                icon_position: :right
+              }),
+            slots: ["Example link label"]
+          },
+          %Variation{
+            id: :small,
+            description: "Small size, icon left",
+            attributes:
+              Map.merge(base, %{
+                size: :sm,
+                tone: :accent,
+                icon: "hero-arrow-right",
+                icon_position: :left
+              }),
+            slots: ["Example link label"]
+          }
+        ]
+      }
+    ]
+  end
+end

--- a/storybook/dashboard/metric_overview.story.exs
+++ b/storybook/dashboard/metric_overview.story.exs
@@ -8,7 +8,7 @@ defmodule Storybook.Dashboard.MetricOverview do
   alias Zaq.Engine.Telemetry.Contracts.Payloads.ScalarPayload
 
   def description,
-    do: "BO Dashboard — KPI grid with `BOTelemetryComponents.metric_card` and sub-metric links."
+    do: "BO Dashboard — KPI grid with `DesignSystem.MetricCard` and sub-metric links."
 
   def render(assigns) do
     metrics = sample_metrics()

--- a/test/e2e/support/story-urls.json
+++ b/test/e2e/support/story-urls.json
@@ -20,6 +20,7 @@
   "/storybook/components/design_system/ingestion_file_list_view",
   "/storybook/components/design_system/ingestion_jobs_panel",
   "/storybook/components/design_system/ingestion_volume_selector",
+  "/storybook/components/design_system/link",
   "/storybook/components/design_system/modal_add_raw",
   "/storybook/components/design_system/modal_delete",
   "/storybook/components/design_system/modal_delete_selected",

--- a/test/zaq_web/components/bo_telemetry_components_test.exs
+++ b/test/zaq_web/components/bo_telemetry_components_test.exs
@@ -25,10 +25,10 @@ defmodule ZaqWeb.Components.BOTelemetryComponentsTest do
     assert html =~ "Last 24h"
   end
 
-  test "metric_card/1 renders display metadata but not runtime metadata" do
+  test "metric_card/1 renders display metadata and primary link from runtime href" do
     html =
       render_component(&BOTelemetryComponents.metric_card/1,
-        id: "metric-runtime-separation",
+        id: "metric-runtime-separation-card",
         card: %ScalarPayload{
           id: "metric-runtime-separation",
           label: "API calls",
@@ -40,7 +40,9 @@ defmodule ZaqWeb.Components.BOTelemetryComponentsTest do
 
     assert html =~ "range: 30d"
     assert html =~ "scope: critical"
-    refute html =~ "/bo/hidden-runtime"
+    assert html =~ ~s(href="/bo/hidden-runtime")
+    assert html =~ ~s(id="metric-runtime-separation")
+    refute html =~ ~s(id="metric-runtime-separation-card" href=)
   end
 
   test "time_series_chart/1 renders representative data and id" do

--- a/test/zaq_web/components/design_system/link_test.exs
+++ b/test/zaq_web/components/design_system/link_test.exs
@@ -1,0 +1,115 @@
+defmodule ZaqWeb.Components.DesignSystem.LinkTest do
+  use ZaqWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias ZaqWeb.Components.DesignSystem.Link
+
+  test "nav_link/1 uses destination as navigate by default" do
+    html =
+      render_component(&Link.nav_link/1,
+        destination: "/bo/ingestion",
+        inner_block: [%{inner_block: fn _, _ -> "Browse" end}]
+      )
+
+    assert html =~ "zaq-link"
+    assert html =~ "zaq-link-underline"
+    assert html =~ "zaq-text-body"
+    assert html =~ ~s(data-phx-link="redirect")
+    assert html =~ "/bo/ingestion"
+    assert html =~ "Browse"
+  end
+
+  test "nav_link/1 external uses destination as href" do
+    html =
+      render_component(&Link.nav_link/1,
+        external: true,
+        destination: "/bo/system-config?tab=embedding",
+        inner_block: [%{inner_block: fn _, _ -> "Go to Settings →" end}]
+      )
+
+    assert html =~ ~s(href="/bo/system-config?tab=embedding")
+    assert html =~ "Go to Settings →"
+  end
+
+  test "nav_link/1 tone default does not add accent shell class" do
+    html =
+      render_component(&Link.nav_link/1,
+        destination: "/bo/ingestion",
+        inner_block: [%{inner_block: fn _, _ -> "Browse" end}]
+      )
+
+    refute html =~ "zaq-link--accent"
+  end
+
+  test "nav_link/1 tone accent adds accent shell class" do
+    html =
+      render_component(&Link.nav_link/1,
+        tone: :accent,
+        destination: "/bo/ingestion",
+        inner_block: [%{inner_block: fn _, _ -> "root" end}]
+      )
+
+    assert html =~ "zaq-link--accent"
+    refute html =~ "zaq-link__label--accent"
+    assert html =~ "root"
+  end
+
+  test "nav_link/1 with icon keeps underline on label only" do
+    html =
+      render_component(&Link.nav_link/1,
+        destination: "/bo/dashboard",
+        icon: "hero-arrow-right",
+        icon_position: :left,
+        inner_block: [%{inner_block: fn _, _ -> "Dashboard" end}]
+      )
+
+    assert html =~ "zaq-link__icon"
+    assert html =~ "hero-arrow-right"
+    assert html =~ "zaq-link-underline"
+    refute html =~ ~s(class="zaq-link__icon zaq-link-underline")
+    assert icon_before_label?(html)
+  end
+
+  test "nav_link/1 icon_position right renders icon after label" do
+    html =
+      render_component(&Link.nav_link/1,
+        destination: "/bo/dashboard",
+        icon: "hero-arrow-right",
+        icon_position: :right,
+        inner_block: [%{inner_block: fn _, _ -> "Dashboard" end}]
+      )
+
+    assert html =~ "zaq-link__icon"
+    refute icon_before_label?(html)
+  end
+
+  test "nav_link/1 :sm applies body-sm typography" do
+    html =
+      render_component(&Link.nav_link/1,
+        size: :sm,
+        destination: "/bo/dashboard",
+        inner_block: [%{inner_block: fn _, _ -> "Small link" end}]
+      )
+
+    assert html =~ "zaq-text-body-sm"
+  end
+
+  test "nav_link/1 merges optional class attribute" do
+    html =
+      render_component(&Link.nav_link/1,
+        class: "mt-2",
+        destination: "/bo/dashboard",
+        inner_block: [%{inner_block: fn _, _ -> "Dashboard" end}]
+      )
+
+    assert html =~ "zaq-link"
+    assert html =~ "mt-2"
+  end
+
+  defp icon_before_label?(html) do
+    {icon_pos, _} = :binary.match(html, "zaq-link__icon")
+    {label_pos, _} = :binary.match(html, "zaq-link__label")
+    icon_pos < label_pos
+  end
+end

--- a/test/zaq_web/components/design_system/metric_card_test.exs
+++ b/test/zaq_web/components/design_system/metric_card_test.exs
@@ -1,0 +1,122 @@
+defmodule ZaqWeb.Components.DesignSystem.MetricCardTest do
+  use ZaqWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Zaq.Engine.Telemetry.Contracts.{DisplayMeta, RuntimeMeta}
+  alias Zaq.Engine.Telemetry.Contracts.Payloads.ScalarPayload
+  alias ZaqWeb.Components.DesignSystem.MetricCard
+
+  test "metric_card/1 renders label, value, and id" do
+    html =
+      render_component(&MetricCard.metric_card/1,
+        id: "metric-users",
+        label: "Active users",
+        value: 12_450,
+        trend: 4.2,
+        hint: "Last 24h"
+      )
+
+    assert html =~ "id=\"metric-users\""
+    assert html =~ "Active users"
+    assert html =~ "12,450"
+    assert html =~ "+4.2%"
+    assert html =~ "Last 24h"
+  end
+
+  test "metric_card/1 renders display metadata but not runtime metadata on the article" do
+    html =
+      render_component(&MetricCard.metric_card/1,
+        id: "metric-runtime-separation-card",
+        card: %ScalarPayload{
+          id: "metric-runtime-separation",
+          label: "API calls",
+          value: 120,
+          display: %DisplayMeta{range: "30d", hint: "scope: critical"},
+          runtime: %RuntimeMeta{href: "/bo/hidden-runtime"}
+        }
+      )
+
+    assert html =~ "range: 30d"
+    assert html =~ "scope: critical"
+    refute html =~ ~s(id="metric-runtime-separation-card" href=)
+  end
+
+  test "metric_card/1 auto-wraps with primary link from card.runtime.href" do
+    html =
+      render_component(&MetricCard.metric_card/1,
+        id: "dashboard-metric-documents-ingested-card",
+        card: %ScalarPayload{
+          id: "dashboard-metric-documents-ingested",
+          label: "Documents ingested",
+          value: 128,
+          display: %DisplayMeta{range: "30d"},
+          runtime: %RuntimeMeta{href: "/bo/ingestion"}
+        }
+      )
+
+    assert html =~ ~s(id="dashboard-metric-documents-ingested")
+    assert html =~ ~s(href="/bo/ingestion")
+    assert html =~ "id=\"dashboard-metric-documents-ingested-card\""
+  end
+
+  test "metric_card/1 explicit primary_link overrides card.runtime.href" do
+    html =
+      render_component(&MetricCard.metric_card/1,
+        id: "metric-card",
+        card: %ScalarPayload{
+          id: "metric-id",
+          label: "API calls",
+          value: 10,
+          runtime: %RuntimeMeta{href: "/bo/from-runtime"}
+        },
+        primary_link: %{destination: "/bo/explicit", id: "metric-id"}
+      )
+
+    assert html =~ ~s(href="/bo/explicit")
+    refute html =~ "/bo/from-runtime"
+  end
+
+  test "metric_card/1 renders secondary_link with nav_link styling" do
+    html =
+      render_component(&MetricCard.metric_card/1,
+        id: "metric-card",
+        label: "Documents ingested",
+        value: 42,
+        secondary_link: %{
+          id: "dashboard-knowledge-base-metrics-link",
+          destination: "/bo/dashboard/knowledge-base-metrics",
+          label: "View Knowledge base metrics"
+        }
+      )
+
+    assert html =~ "id=\"dashboard-knowledge-base-metrics-link\""
+    assert html =~ ~s(href="/bo/dashboard/knowledge-base-metrics")
+    assert html =~ "View Knowledge base metrics"
+    assert html =~ "zaq-link--accent"
+    assert html =~ "hero-arrow-right"
+  end
+
+  test "metric_card/1 renders primary and secondary links together" do
+    html =
+      render_component(&MetricCard.metric_card/1,
+        id: "dashboard-metric-documents-ingested-card",
+        label: "Documents ingested",
+        value: 128,
+        primary_link: %{
+          id: "dashboard-metric-documents-ingested",
+          destination: "/bo/ingestion"
+        },
+        secondary_link: %{
+          id: "dashboard-knowledge-base-metrics-link",
+          destination: "/bo/dashboard/knowledge-base-metrics",
+          label: "View Knowledge base metrics"
+        }
+      )
+
+    assert html =~ "space-y-2"
+    assert html =~ ~s(id="dashboard-metric-documents-ingested")
+    assert html =~ "id=\"dashboard-metric-documents-ingested-card\""
+    assert html =~ "id=\"dashboard-knowledge-base-metrics-link\""
+  end
+end


### PR DESCRIPTION
Design migration v1.5 adds two BO design-system components and wires them into the main dashboard KPI grid. No backend or telemetry logic changes.

- DesignSystem.Link — reusable underline nav link (:accent tone, optional icon, navigate / external href)
- DesignSystem.MetricCard — KPI tile with optional primary_link (card wrapper) and secondary_link (sub-page CTA)
- MetricOverview now uses MetricCard end-to-end; BOTelemetryComponents.metric_card/1 delegates to it
- TelemetryFormat helper extracted for shared KPI number formatting
- CSS: link tokens in styles.css; .zaq-field-error moved to form.css
- Storybook + ExUnit for both components; dashboard test ids unchanged