### PR TITLE
feat(chat): add OpenAI-compatible channel with page citations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ CLAUDE.local.md
 .claude/specs/
 .claude/plans/
 .claude/superpowers/
+
+# TypeScript SDK deps (not tracked)
+sdks/**/node_modules/

--- a/config/config.exs
+++ b/config/config.exs
@@ -41,7 +41,8 @@ config :zaq, :channels, %{
     adapter: Zaq.Channels.EmailBridge.ImapAdapter,
     message_format: :html
   },
-  web: %{bridge: Zaq.Channels.WebBridge}
+  web: %{bridge: Zaq.Channels.WebBridge},
+  chat: %{bridge: Zaq.Channels.ChatBridge}
 }
 
 config :zaq,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       INGESTION_VOLUMES: "${INGESTION_VOLUMES:-/}"
       INGESTION_VOLUMES_BASE: "${INGESTION_VOLUMES_BASE:-/zaq/volumes}"
       SYSTEM_CONFIG_ENCRYPTION_KEY: "${SYSTEM_CONFIG_ENCRYPTION_KEY}"
+      ZAQ_CHAT_TOKEN: "${ZAQ_CHAT_TOKEN}"
     volumes:
       - ./ingestion-volumes:/zaq/volumes
     extra_hosts:

--- a/lib/zaq/accounts/person_channel.ex
+++ b/lib/zaq/accounts/person_channel.ex
@@ -2,7 +2,9 @@ defmodule Zaq.Accounts.PersonChannel do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @valid_platforms ~w(mattermost slack microsoft_teams whatsapp email telegram discord)
+  # "chat" is the ChatVote OpenAI-compatible channel: its identifier is the
+  # caller's authenticated user id (see ZaqWeb.ChatCompletionsController).
+  @valid_platforms ~w(mattermost slack microsoft_teams whatsapp email telegram discord chat)
 
   @type t :: %__MODULE__{}
 

--- a/lib/zaq/agent/answering_run.ex
+++ b/lib/zaq/agent/answering_run.ex
@@ -1,0 +1,63 @@
+defmodule Zaq.Agent.AnsweringRun do
+  @moduledoc """
+  Classifies Jido answering events for streaming transports.
+  """
+
+  @source_marker ~r/\s*\[\[source:[^\]]+\]\]/u
+
+  @type classified ::
+          {:done, String.t()}
+          | {:error, term()}
+          | :ignore
+
+  @spec classify_event(term()) :: classified()
+  def classify_event(event) do
+    case field(event, :kind) do
+      :request_completed -> {:done, event |> data() |> field(:result) |> clean_answer()}
+      :request_failed -> {:error, event |> data() |> field(:error) || :react_failed}
+      :request_cancelled -> {:error, :react_cancelled}
+      _ -> :ignore
+    end
+  end
+
+  @spec extract_chunks(term()) :: [map()]
+  def extract_chunks(event) do
+    if field(event, :kind) == :tool_completed do
+      event |> data() |> field(:result) |> chunks_from_result()
+    else
+      []
+    end
+  end
+
+  defp chunks_from_result({:ok, inner, _directives}), do: chunks_from_result(inner)
+  defp chunks_from_result({:ok, inner}), do: chunks_from_result(inner)
+
+  defp chunks_from_result(result) when is_map(result) do
+    case field(result, :chunks) do
+      chunks when is_list(chunks) -> chunks
+      _ -> []
+    end
+  end
+
+  defp chunks_from_result(_result), do: []
+
+  @doc """
+  Removes inline source markers duplicated by the structured `zaq_sources` frame.
+  """
+  @spec clean_answer(term()) :: String.t()
+  def clean_answer(text) when is_binary(text) do
+    text
+    |> String.replace(@source_marker, "")
+    |> String.replace(~r/[ \t]+\n/u, "\n")
+    |> String.trim()
+  end
+
+  def clean_answer(nil), do: ""
+  def clean_answer(other), do: other |> to_string() |> clean_answer()
+
+  defp data(event), do: field(event, :data) || %{}
+
+  defp field(struct, key) when is_struct(struct), do: Map.get(struct, key)
+  defp field(map, key) when is_map(map), do: Map.get(map, key) || Map.get(map, to_string(key))
+  defp field(_value, _key), do: nil
+end

--- a/lib/zaq/agent/api.ex
+++ b/lib/zaq/agent/api.ex
@@ -361,31 +361,62 @@ defmodule Zaq.Agent.Api do
     outgoing =
       case selected_agent_id(event.assigns) do
         nil ->
-          pipeline_module.run(
-            incoming,
-            pipeline_opts
-            |> Keyword.put(:scope, Executor.derive_scope(incoming, event.actor))
-            |> Keyword.put(:person_id, person_id)
-            |> Keyword.put(:team_ids, team_ids)
-            |> Keyword.put(:event, event)
-          )
+          # A channel can pin the default answering executor (`:agent_id` nil →
+          # Executor's built-in answering agent) instead of the legacy pipeline
+          # when no configured agent is selected. The chat channel uses this:
+          # it has no BO channel-config surface, and its grounding `:question`
+          # override only exists on the executor path.
+          if Keyword.get(pipeline_opts, :default_answering_executor, false) do
+            run_executor(executor_module, incoming, nil, pipeline_opts, event)
+          else
+            pipeline_module.run(
+              incoming,
+              pipeline_opts
+              |> Keyword.put(:scope, Executor.derive_scope(incoming, event.actor))
+              |> Keyword.put(:person_id, person_id)
+              |> Keyword.put(:team_ids, team_ids)
+              |> Keyword.put(:event, event)
+            )
+          end
 
         selected_id ->
-          executor_module.run(incoming,
-            agent_id: selected_id,
-            scope: Executor.derive_scope(incoming, event.actor),
-            person_id: person_id,
-            team_ids: team_ids,
-            source_filter: incoming.content_filter,
-            skip_permissions: Keyword.get(pipeline_opts, :skip_permissions, false),
-            history: Keyword.get(pipeline_opts, :history, %{}),
-            context: Keyword.get(pipeline_opts, :context),
-            telemetry_dimensions: Keyword.get(pipeline_opts, :telemetry_dimensions, %{}),
-            event: event
-          )
+          run_executor(executor_module, incoming, selected_id, pipeline_opts, event)
       end
 
     maybe_dispatch_return_hop(event, incoming, outgoing)
+  end
+
+  defp run_executor(executor_module, incoming, agent_id, pipeline_opts, event) do
+    executor_module.run(
+      incoming,
+      [
+        agent_id: agent_id,
+        scope: Executor.derive_scope(incoming, event.actor),
+        person_id: ActorNormalizer.person_id(event.actor),
+        team_ids: ActorNormalizer.team_ids(event.actor),
+        source_filter: incoming.content_filter,
+        skip_permissions: Keyword.get(pipeline_opts, :skip_permissions, false),
+        history: Keyword.get(pipeline_opts, :history, %{}),
+        context: Keyword.get(pipeline_opts, :context),
+        telemetry_dimensions: Keyword.get(pipeline_opts, :telemetry_dimensions, %{}),
+        event: event
+      ]
+      |> maybe_put_question(pipeline_opts)
+    )
+  end
+
+  # Per-run question override (e.g. the chat channel's grounding preamble):
+  # framed text drives the run while `incoming.content` — the clean user
+  # question — is what gets persisted. Only forwarded when present so
+  # `Executor.run/2` keeps its `incoming.content` default otherwise.
+  defp maybe_put_question(opts, pipeline_opts) do
+    case Keyword.get(pipeline_opts, :question) do
+      question when is_binary(question) and question != "" ->
+        Keyword.put(opts, :question, question)
+
+      _ ->
+        opts
+    end
   end
 
   # This function is a good candidate to go into the NodeRouter for generalization

--- a/lib/zaq/agent/executor.ex
+++ b/lib/zaq/agent/executor.ex
@@ -116,6 +116,10 @@ defmodule Zaq.Agent.Executor do
       when is_binary(id) and id != "",
       do: "bo:conv:#{id}"
 
+  def derive_scope(%Incoming{provider: :chat, metadata: %{conversation_id: id}}, _actor)
+      when is_binary(id) and id != "",
+      do: "chat:conv:#{id}"
+
   def derive_scope(%Incoming{provider: provider} = incoming, actor) do
     case ActorNormalizer.person_id(actor) do
       nil -> derive_scope_without_person(incoming)
@@ -157,26 +161,19 @@ defmodule Zaq.Agent.Executor do
   @spec run(Incoming.t(), keyword()) :: Outgoing.t()
   def run(%Incoming{} = incoming, opts \\ []) do
     started_at = System.monotonic_time(:millisecond)
-    agent_module = Keyword.get(opts, :agent_module, Agent)
-    server_manager_module = Keyword.get(opts, :server_manager_module, ServerManager)
-    factory_module = Keyword.get(opts, :factory_module, Factory)
-    opts = ensure_scope_for_answering_path(opts, incoming)
+
+    {agent_module, factory_module, server_manager_module, opts, question} =
+      resolve_deps_and_question(opts, incoming)
+
     selected_agent_result = load_selected_agent(opts, agent_module, factory_module)
     dims = telemetry_dimensions(incoming, selected_agent_result)
 
     :ok = Telemetry.record("qa.message.count", 1, dims)
     :ok = Telemetry.record("qa.custom_agent.execution.start", 1, dims)
 
-    question =
-      opts
-      |> Keyword.get(:question, incoming.content)
-      |> timestamp_question()
-
     result =
-      with {:ok, configured_agent} <- selected_agent_result,
-           configured_agent <- apply_system_prompt_override(configured_agent, opts),
-           {:ok, server_id} <-
-             ensure_agent_server(server_manager_module, configured_agent, opts),
+      with {:ok, configured_agent, server_id} <-
+             setup_agent_and_server(selected_agent_result, opts, server_manager_module),
            _ <-
              Event.new(
                %{provider: incoming.provider, channel_id: incoming.channel_id},
@@ -195,15 +192,7 @@ defmodule Zaq.Agent.Executor do
            %Incoming{} = incoming <- normalize_status_result(status_result, incoming),
            {:ok, %{request: _request, events: events}} <-
              factory_module.ask_with_config(server_id, question, configured_agent,
-               tool_context: %{
-                 incoming: incoming,
-                 person_id: Keyword.get(opts, :person_id),
-                 team_ids: Keyword.get(opts, :team_ids, []),
-                 source_filter: Keyword.get(opts, :source_filter),
-                 skip_permissions: Keyword.get(opts, :skip_permissions, false),
-                 actor: execution_actor(opts, incoming),
-                 node_router: Keyword.get(opts, :node_router, Zaq.NodeRouter)
-               }
+               tool_context: tool_context(incoming, opts)
              ),
            {:ok, stream_result} <-
              StreamEvents.consume(events, incoming,
@@ -255,6 +244,68 @@ defmodule Zaq.Agent.Executor do
     end
   end
 
+  @doc """
+  Streaming variant of `run/2` for token-by-token transports (the SSE chat
+  channel).
+
+  Runs the SAME native setup as `run/2` — agent selection, scope derivation,
+  server ensure, and `Factory.ask_with_config/4` — but returns the RAW jido
+  event enumerable instead of consuming it with `StreamEvents.consume/3`. The
+  caller folds the events itself (forwarding tokens as they arrive) and owns the
+  downstream concerns the consuming path handles internally: wire formatting and
+  persistence.
+
+  Retrieval comes from the configured agent's own `enabled_tool_keys`
+  (`search_knowledge_base` / `knowledge_base_overview`) — exactly like `run/2` —
+  so no per-run tool override is needed.
+
+  Unlike `run/2` this emits no typing/status side effects (those are BO-channel
+  concerns); a token stream is its own progress signal.
+
+  Returns `{:ok, %{events, incoming, server_id, agent}}` or `{:error, reason}`.
+  Accepts the same options as `run/2`.
+  """
+  @spec stream(Incoming.t(), keyword()) ::
+          {:ok,
+           %{
+             events: Enumerable.t(),
+             incoming: Incoming.t(),
+             server_id: String.t(),
+             agent: Zaq.Agent.ConfiguredAgent.t()
+           }}
+          | {:error, term()}
+  def stream(%Incoming{} = incoming, opts \\ []) do
+    {agent_module, factory_module, server_manager_module, opts, question} =
+      resolve_deps_and_question(opts, incoming)
+
+    with {:ok, configured_agent, server_id} <-
+           setup_agent_and_server(
+             load_selected_agent(opts, agent_module, factory_module),
+             opts,
+             server_manager_module
+           ),
+         {:ok, %{events: events}} <-
+           factory_module.ask_with_config(server_id, question, configured_agent,
+             stream_to: {:pid, self()},
+             stream_timeout_ms: 320_000,
+             tool_context: tool_context(incoming, opts)
+           ) do
+      {:ok, %{events: events, incoming: incoming, server_id: server_id, agent: configured_agent}}
+    end
+  end
+
+  defp tool_context(incoming, opts) do
+    %{
+      incoming: incoming,
+      person_id: Keyword.get(opts, :person_id),
+      team_ids: Keyword.get(opts, :team_ids, []),
+      source_filter: Keyword.get(opts, :source_filter),
+      skip_permissions: Keyword.get(opts, :skip_permissions, false),
+      actor: execution_actor(opts, incoming),
+      node_router: Keyword.get(opts, :node_router, Zaq.NodeRouter)
+    }
+  end
+
   # Suppress only when a streaming surface exists AND answer content was actually
   # delivered to the user. The mere presence of a status placeholder is not proof
   # that any tokens reached the user.
@@ -291,6 +342,37 @@ defmodule Zaq.Agent.Executor do
   defp ensure_agent_server(server_manager_module, configured_agent, opts) do
     server_id = "#{configured_agent.name}:#{Keyword.get(opts, :scope, "anonymous")}"
     server_manager_module.ensure_server(configured_agent, server_id, Keyword.get(opts, :context))
+  end
+
+  # Shared `run/2` + `stream/2` setup: resolves injectable dependencies from
+  # opts, ensures :scope is set for the answering path, and builds the
+  # timestamped question. Pure — no side effects, so callers may compute
+  # telemetry (or anything else) before or after this without behavior change.
+  defp resolve_deps_and_question(opts, incoming) do
+    agent_module = Keyword.get(opts, :agent_module, Agent)
+    factory_module = Keyword.get(opts, :factory_module, Factory)
+    server_manager_module = Keyword.get(opts, :server_manager_module, ServerManager)
+    opts = ensure_scope_for_answering_path(opts, incoming)
+
+    question =
+      opts
+      |> Keyword.get(:question, incoming.content)
+      |> timestamp_question()
+
+    {agent_module, factory_module, server_manager_module, opts, question}
+  end
+
+  # Shared `run/2` + `stream/2` chain: applies the per-run system-prompt
+  # override to the selected agent, then ensures its Jido server is running.
+  # `selected_agent_result` is `{:ok, configured_agent} | {:error, reason}` —
+  # on error, this `with` (no `else`) returns that value unchanged so callers'
+  # own error handling is untouched.
+  defp setup_agent_and_server(selected_agent_result, opts, server_manager_module) do
+    with {:ok, configured_agent} <- selected_agent_result,
+         configured_agent <- apply_system_prompt_override(configured_agent, opts),
+         {:ok, server_id} <- ensure_agent_server(server_manager_module, configured_agent, opts) do
+      {:ok, configured_agent, server_id}
+    end
   end
 
   defp load_selected_agent(opts, agent_module, _factory_module) do

--- a/lib/zaq/channels/api.ex
+++ b/lib/zaq/channels/api.ex
@@ -757,8 +757,11 @@ defmodule Zaq.Channels.Api do
   defp normalize_delivery_response({:ok, receipt} = response) when is_map(receipt), do: response
   defp normalize_delivery_response(response), do: response
 
-  defp normalize_upsert_config(provider, {:error, _reason}) when provider in [:web, "web"],
-    do: {:ok, %{provider: "web"}}
+  # web and chat have no ChannelConfig row — their bridges deliver over local
+  # PubSub, so a missing config is normal rather than an error.
+  defp normalize_upsert_config(provider, {:error, _reason})
+       when provider in [:web, "web", :chat, "chat"],
+       do: {:ok, %{provider: to_string(provider)}}
 
   defp normalize_upsert_config(_provider, config), do: config
 end

--- a/lib/zaq/channels/chat_bridge.ex
+++ b/lib/zaq/channels/chat_bridge.ex
@@ -1,0 +1,93 @@
+defmodule Zaq.Channels.ChatBridge do
+  @moduledoc """
+  Bridge for the ChatVote `:chat` channel (OpenAI-compatible HTTP endpoint).
+
+  Unlike push transports, the chat channel is a synchronous HTTP request:
+  `ZaqWeb.ChatCompletionsController` subscribes to `topic/1` BEFORE routing the
+  incoming message through `CommunicationBridge.route_incoming_message/5` (so
+  the request flows through `NodeRouter.dispatch/1` like every other bridge —
+  traces, person resolution and persistence come from the shared pipeline), and
+  `send_reply/2` delivers the pipeline `%Outgoing{}` back to that waiting
+  request process over PubSub.
+  """
+
+  @behaviour Zaq.Channels.Bridge
+  @behaviour Zaq.Channels.CommunicationBridge
+
+  alias Zaq.Engine.Messages.{Incoming, Outgoing}
+
+  @doc """
+  Builds `%Incoming{provider: :chat}` from controller params.
+
+  Expected keys: `:content` (the clean user question — this is what gets
+  persisted), `:conversation_id`, `:author_id` (the caller's authenticated
+  Supabase user id — also the Person channel identity), `:message_id` (request
+  correlation id echoed back on `send_reply/2`), `:source_filter` (list of
+  source prefixes retrieval is restricted to; `[]`/`nil` means unrestricted).
+  """
+  @spec to_internal(map(), map()) :: Incoming.t()
+  @impl true
+  def to_internal(params, _connection_details \\ %{}) do
+    Incoming.new(%{
+      content: params[:content],
+      channel_id: params[:conversation_id],
+      author_id: params[:author_id],
+      message_id: params[:message_id],
+      provider: :chat,
+      content_filter: params[:source_filter] || [],
+      metadata: %{conversation_id: params[:conversation_id]}
+    })
+  end
+
+  @doc """
+  Delivers the pipeline result to the waiting HTTP request process.
+
+  The message shape is `{:chat_result, request_id, outgoing}` where
+  `request_id` is the `message_id` the controller stamped on the `%Incoming{}`
+  (carried back as `outgoing.in_reply_to`), so concurrent requests on the same
+  conversation each pick up their own result.
+  """
+  @spec send_reply(Outgoing.t(), map()) :: :ok | {:error, term()}
+  @impl true
+  def send_reply(%Outgoing{} = outgoing, _connection_details) do
+    Phoenix.PubSub.broadcast(
+      Zaq.PubSub,
+      topic(outgoing.channel_id),
+      {:chat_result, outgoing.in_reply_to, outgoing}
+    )
+  end
+
+  @doc "PubSub topic the controller subscribes to for a conversation."
+  @spec topic(String.t()) :: String.t()
+  def topic(conversation_id), do: "chat:conv:#{conversation_id}"
+
+  # Progressive streaming: the executor's `StreamEvents` flushes the answer's
+  # cumulative text as `:stream_delta` upserts (~10/s). Forward them to the
+  # waiting request process so the controller can emit OpenAI SSE deltas while
+  # the LLM is still generating. The broadcast body is CUMULATIVE per LLM-call
+  # segment — the controller diffs it against what it already sent. Other
+  # intents (`:status`, `:reasoning`, `:tool_call`) have no surface on the
+  # OpenAI wire: accept and drop, like the WebBridge fallback branch.
+  @impl true
+  def upsert_message(_config, request, _connection_details) when is_map(request) do
+    update_intent = Map.get(request, :update_intent)
+    request_id = Map.get(request, :request_id)
+    channel_id = Map.get(request, :channel_id)
+    body = Map.get(request, :body)
+
+    if stream_delta?(update_intent) and is_binary(body) and present?(request_id) and
+         present?(channel_id) do
+      Phoenix.PubSub.broadcast(
+        Zaq.PubSub,
+        topic(channel_id),
+        {:chat_stream_delta, request_id, body}
+      )
+    end
+
+    {:ok, %{action: :noop, message_id: nil, update_intent: update_intent}}
+  end
+
+  defp stream_delta?(intent), do: intent in [:stream_delta, "stream_delta"]
+
+  defp present?(value), do: is_binary(value) and value != ""
+end

--- a/lib/zaq/engine/conversations.ex
+++ b/lib/zaq/engine/conversations.ex
@@ -36,6 +36,26 @@ defmodule Zaq.Engine.Conversations do
   @doc "Fetches a conversation by id, returns nil if not found."
   def get_conversation(id), do: Repo.get(Conversation, id)
 
+  @doc """
+  Creates a chat-channel conversation with a caller-supplied `id`, owned by
+  `channel_user_id`.
+
+  The same id keys the conversation across client and server so history rehydrates
+  by `conversation_id`. A primary-key race surfaces as `{:error, changeset}` (via
+  the `conversations_pkey` unique constraint) instead of raising.
+  """
+  def create_chat_conversation(id, channel_user_id)
+      when is_binary(id) and is_binary(channel_user_id) do
+    %Conversation{id: id}
+    |> Conversation.changeset(%{
+      channel_user_id: channel_user_id,
+      channel_type: "chat",
+      status: "active"
+    })
+    |> Ecto.Changeset.unique_constraint(:id, name: "conversations_pkey")
+    |> Repo.insert()
+  end
+
   @doc "Fetches a conversation by id, raises if not found."
   def get_conversation!(id) do
     Repo.get!(Conversation, id)

--- a/lib/zaq/engine/conversations/conversation.ex
+++ b/lib/zaq/engine/conversations/conversation.ex
@@ -25,7 +25,7 @@ defmodule Zaq.Engine.Conversations.Conversation do
     timestamps(type: :utc_datetime_usec)
   end
 
-  @valid_channel_types ~w[mattermost discord slack bo api email:imap telegram teams]
+  @valid_channel_types ~w[mattermost discord slack bo api email:imap telegram teams chat]
   @valid_statuses ~w[active archived]
 
   @doc "Changeset for creating or updating a conversation."

--- a/lib/zaq/ingestion/document_access.ex
+++ b/lib/zaq/ingestion/document_access.ex
@@ -146,6 +146,48 @@ defmodule Zaq.Ingestion.DocumentAccess do
     end
   end
 
+  @doc """
+  Lists public source documents under a required source prefix for chat clients.
+  """
+  @spec list_public_chat_documents(String.t()) :: [struct()]
+  def list_public_chat_documents(prefix) when is_binary(prefix) and prefix != "" do
+    pattern = escape_like(prefix) <> "%"
+
+    from(d in Document,
+      as: :doc,
+      where: fragment("(? ->> 'source_document_source') IS NULL", d.metadata),
+      where: fragment("? @> ARRAY['public']::varchar[]", d.tags),
+      where: like(d.source, ^pattern),
+      order_by: [asc: d.source],
+      limit: 200
+    )
+    |> Repo.all()
+  end
+
+  def list_public_chat_documents(_prefix), do: []
+
+  @doc """
+  Returns a public source document by ID.
+  """
+  @spec get_public_chat_document(term()) :: struct() | nil
+  def get_public_chat_document(id) do
+    from(d in Document,
+      where: d.id == ^id,
+      where: fragment("(? ->> 'source_document_source') IS NULL", d.metadata),
+      where: fragment("? @> ARRAY['public']::varchar[]", d.tags)
+    )
+    |> Repo.one()
+  rescue
+    Ecto.Query.CastError -> nil
+  end
+
+  defp escape_like(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("%", "\\%")
+    |> String.replace("_", "\\_")
+  end
+
   # All three access conditions unified in one named-binding dynamic to avoid
   # mixing positional and named bindings in the same where expression.
   #

--- a/lib/zaq/ingestion/document_processor.ex
+++ b/lib/zaq/ingestion/document_processor.ex
@@ -1028,7 +1028,12 @@ defmodule Zaq.Ingestion.DocumentProcessor do
         source: d.source,
         document_id: c.document_id,
         section_path: c.section_path,
-        chunk_index: c.chunk_index
+        chunk_index: c.chunk_index,
+        position: fragment("(? ->> 'position')::int", c.metadata),
+        # doc markdown carries `<!-- page: N -->` markers; resolve the chunk's
+        # page from its stored line position. This reads full document content
+        # per matched section; group by document if query scope grows.
+        doc_content: d.content
       })
       |> Repo.all()
       # Sections by fused score, then chunks in document order within each
@@ -1044,12 +1049,33 @@ defmodule Zaq.Ingestion.DocumentProcessor do
           "source" => r.source,
           "distance" => distance_map[{r.document_id, r.section_path}],
           "document_id" => r.document_id,
-          "section_path" => r.section_path
+          "section_path" => r.section_path,
+          "position" => r.position,
+          "page" => page_for_position(r.doc_content, r.position)
         }
       end)
 
     {:ok, results}
   end
+
+  # Resolves a chunk's page from its line position: the page is the last
+  # `<!-- page: N -->` marker at or before that line. Falls back to 1 when the
+  # doc has no markers or the position is unknown.
+  defp page_for_position(content, position)
+       when is_binary(content) and is_integer(position) do
+    content
+    |> String.split("\n")
+    |> Enum.take(position + 1)
+    |> Enum.reverse()
+    |> Enum.find_value(1, fn line ->
+      case Regex.run(~r/<!-- page: (\d+) -->/, line) do
+        [_, n] -> String.to_integer(n)
+        _ -> false
+      end
+    end)
+  end
+
+  defp page_for_position(_content, _position), do: 1
 
   # ---------------------------------------------------------------------------
   # Similarity search (vector only)

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -10,6 +10,7 @@ defmodule Zaq.Ingestion do
     DeleteService,
     DirectorySnapshot,
     Document,
+    DocumentAccess,
     FileExplorer,
     FolderSetting,
     IngestChunkJob,
@@ -32,6 +33,9 @@ defmodule Zaq.Ingestion do
 
   @pubsub Zaq.PubSub
   @topic "ingestion:jobs"
+
+  defdelegate list_public_chat_documents(prefix), to: DocumentAccess
+  defdelegate get_public_chat_document(id), to: DocumentAccess
 
   # --- Ingestion triggers ---
 

--- a/lib/zaq_web/controllers/chat_completions_controller.ex
+++ b/lib/zaq_web/controllers/chat_completions_controller.ex
@@ -1,0 +1,613 @@
+defmodule ZaqWeb.ChatCompletionsController do
+  @moduledoc """
+  OpenAI-compatible **Chat Completions** endpoint for the `:chat` channel.
+
+      POST /v1/chat/completions
+        {model, messages:[{role,content}], stream, user, conversation_id}
+        -> data: {"choices":[{"delta":{"role":"assistant"}}]}
+        -> data: {"choices":[{"delta":{"content":"…"}}]}
+        -> data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+        -> data: {"choices":[{"delta":{}}],"zaq_sources":[…]}       (citations)
+        -> data: [DONE]
+
+  A stock OpenAI Chat Completions wire, so any OpenAI-compatible client consumes
+  it. Chat Completions has no native source channel, so retrieved citations ride
+  a final frame under the non-standard `zaq_sources` key — OpenAI-only clients
+  ignore the extra field.
+
+  ## Pipeline routing
+
+  Requests flow through `CommunicationBridge.route_incoming_message/5` →
+  `NodeRouter.dispatch/1` like every other channel bridge, so traces, Person
+  resolution (`Zaq.People.IdentityResolver`) and conversation persistence come
+  from the shared pipeline. The transport is a synchronous HTTP request, so the
+  controller subscribes to `Zaq.Channels.ChatBridge.topic/1` BEFORE routing and
+  blocks until `ChatBridge.send_reply/2` broadcasts the pipeline `%Outgoing{}`
+  back as `{:chat_result, request_id, outgoing}`.
+
+  Progressive streaming is preserved: the executor's `StreamEvents` flushes the
+  in-progress answer as `:stream_delta` upserts, `ChatBridge.upsert_message/3`
+  forwards them here as `{:chat_stream_delta, request_id, cumulative}`, and the
+  controller emits the not-yet-sent suffix as OpenAI content deltas while the
+  LLM is still generating. The final `{:chat_result, …}` reconciles the
+  authoritative answer with what was already streamed.
+
+  ## No client-resent history
+
+  The caller sends ONLY the new user message. Prior turns are rehydrated
+  server-side: the run is scoped to `chat:conv:<conversation_id>`, which cold-
+  starts the agent with that conversation's history (`Zaq.Agent.HistoryLoader`),
+  and each turn is persisted by the pipeline's engine hop
+  (`Zaq.Engine.Conversations.persist_from_incoming/2`) so the next cold start
+  sees it.
+
+  ## Security
+
+  - Bearer auth (`ZAQ_CHAT_TOKEN`, constant-time, fail-closed) proves the caller
+    is a trusted backend.
+  - `user` (the caller's authenticated Supabase user id) + `conversation_id`
+    gate access: a conversation is read/appended ONLY when its `channel_user_id`
+    matches `user` and its `channel_type` is `"chat"`. This is the IDOR guard —
+    history loads by `conversation_id`, so an unowned id must never resolve.
+  - Permission scoping: the pipeline resolves a ZAQ Person from the `chat`
+    channel identity (the `user` id). Fresh chat Persons belong to no team, so
+    retrieval surfaces only `"public"`-tagged documents — the transport never
+    blanket-bypasses document permissions (`skip_permissions` stays false).
+  """
+
+  use ZaqWeb, :controller
+
+  alias Zaq.Agent.AnsweringRun
+  alias Zaq.Channels.{ChatBridge, CommunicationBridge}
+  alias Zaq.Engine.Conversations
+  alias Zaq.Engine.Conversations.Conversation
+  alias Zaq.Engine.Messages.Outgoing
+
+  @max_messages 200
+  @max_sources 8
+  @max_iter_sentinel "Maximum iterations reached"
+  @default_result_timeout_ms 120_000
+  # Mirrors AnsweringRun's inline-source marker; streamed deltas strip them
+  # incrementally since citations ride the structured zaq_sources frame.
+  @source_marker ~r/\s*\[\[source:[^\]]+\]\]/u
+
+  # ---------------------------------------------------------------------------
+  # POST /v1/chat/completions
+  # ---------------------------------------------------------------------------
+
+  def completions(conn, params) do
+    with {:ok, question} <- fetch_question(params),
+         {:ok, user_id} <- fetch_required(params, "user", "user (owner id) is required"),
+         {:ok, convo_id} <-
+           fetch_required(params, "conversation_id", "conversation_id is required"),
+         {:ok, _conv} <- ensure_owned_conversation(convo_id, user_id) do
+      run(conn, params, question, convo_id, user_id)
+    else
+      {:error, status, message} -> json_error(conn, status, message)
+    end
+  end
+
+  defp run(conn, params, question, convo_id, user_id) do
+    request_id = Ecto.UUID.generate()
+    # Subscribe before routing so the reply broadcast can't win the race.
+    :ok = Phoenix.PubSub.subscribe(Zaq.PubSub, ChatBridge.topic(convo_id))
+
+    incoming =
+      ChatBridge.to_internal(%{
+        content: question,
+        conversation_id: convo_id,
+        author_id: user_id,
+        message_id: request_id,
+        source_filter: parse_source_filter(params)
+      })
+
+    acc = %{
+      conn: conn,
+      id: "chatcmpl-" <> Integer.to_string(System.unique_integer([:positive])),
+      created: created_ts(),
+      model: fetch(params, "model") || "zaq-chat",
+      stream?: stream?(params),
+      # Progressive streaming state: SSE headers/role frame are sent lazily on
+      # the first delta; `sent` tracks the bytes already on the wire so the
+      # final answer only appends its remainder.
+      sse_started?: false,
+      role_sent?: false,
+      sent: "",
+      mismatch?: false
+    }
+
+    # Grounding (an optional OpenAI `system` message) frames THIS run only —
+    # passed as the run question so it is injected into retrieval but never
+    # persisted (the stored user turn stays the clean question).
+    case route(incoming, with_system(system_content(params), question)) do
+      # Sync hop: the pipeline result came straight back.
+      %Outgoing{} = outgoing -> respond(acc, outgoing)
+      # Async hop: deltas + result arrive via ChatBridge broadcasts over PubSub.
+      :ok -> await_result(acc, request_id)
+      {:error, reason} -> respond_error(acc, reason)
+    end
+  end
+
+  defp route(incoming, run_question) do
+    CommunicationBridge.route_incoming_message(
+      incoming,
+      # No BO channel-config surface for chat: without a global default agent,
+      # pin the default answering executor (agentic run + tool citations)
+      # instead of falling back to the legacy pipeline.
+      [question: run_question, default_answering_executor: true],
+      [{:global_default, Zaq.System.get_global_default_agent_id()}],
+      actor_from_incoming(incoming),
+      node_router: node_router_module()
+    )
+  end
+
+  defp actor_from_incoming(incoming) do
+    %{id: incoming.author_id, name: incoming.author_name, provider: incoming.provider}
+  end
+
+  # Idle timeout: the clock restarts on every delta, so a generating run is
+  # never cut off mid-answer — only a silent pipeline trips it.
+  defp await_result(acc, request_id) do
+    timeout = Application.get_env(:zaq, :chat_result_timeout_ms, @default_result_timeout_ms)
+
+    receive do
+      {:chat_stream_delta, ^request_id, cumulative} ->
+        acc |> push_stream(cumulative) |> await_result(request_id)
+
+      {:chat_result, ^request_id, %Outgoing{} = outgoing} ->
+        respond(acc, outgoing)
+    after
+      timeout -> respond_error(acc, :timeout)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Progressive deltas — `cumulative` is the answer text so far for the current
+  # LLM-call segment. Emit only the suffix not yet on the wire; source markers
+  # are stripped (a trailing partially-streamed marker is held back until it
+  # completes). If the text stops extending what was sent (a later ReAct
+  # segment restarted the accumulator), stop streaming and let the final
+  # result reconcile.
+  # ---------------------------------------------------------------------------
+
+  defp push_stream(%{stream?: false} = acc, _cumulative), do: acc
+  defp push_stream(%{mismatch?: true} = acc, _cumulative), do: acc
+
+  defp push_stream(acc, cumulative) when is_binary(cumulative) do
+    emittable = cumulative |> strip_source_markers() |> safe_stream_prefix() |> ltrim_if_new(acc)
+
+    cond do
+      emittable == acc.sent ->
+        acc
+
+      String.starts_with?(emittable, acc.sent) ->
+        delta =
+          binary_part(emittable, byte_size(acc.sent), byte_size(emittable) - byte_size(acc.sent))
+
+        acc
+        |> ensure_sse_role()
+        |> emit_acc(&chunk(&1, %{content: delta}, nil))
+        |> Map.put(:sent, emittable)
+
+      acc.sent == "" ->
+        acc
+
+      true ->
+        %{acc | mismatch?: true}
+    end
+  end
+
+  defp push_stream(acc, _cumulative), do: acc
+
+  defp ltrim_if_new(text, %{sent: ""}), do: String.trim_leading(text)
+  defp ltrim_if_new(text, _acc), do: text
+
+  defp strip_source_markers(text), do: String.replace(text, @source_marker, "")
+
+  # Hold back a trailing "[", "[[" or unterminated "[[source:…" so a marker
+  # split across flushes never leaks onto the wire, and trailing whitespace so
+  # the marker regex's leading `\s*` can never retro-eat bytes already sent.
+  defp safe_stream_prefix(text) do
+    text
+    |> cut_partial_marker()
+    |> String.trim_trailing("[")
+    |> String.trim_trailing()
+  end
+
+  defp cut_partial_marker(text) do
+    case :binary.matches(text, "[[") do
+      [] ->
+        text
+
+      matches ->
+        {start, _len} = List.last(matches)
+        tail = binary_part(text, start, byte_size(text) - start)
+
+        if String.contains?(tail, "]]") do
+          text
+        else
+          binary_part(text, 0, start)
+        end
+    end
+  end
+
+  defp ensure_sse_role(acc) do
+    acc =
+      if acc.sse_started?, do: acc, else: %{acc | conn: start_sse(acc.conn), sse_started?: true}
+
+    if acc.role_sent? do
+      acc
+    else
+      emit_acc(%{acc | role_sent?: true}, &chunk(&1, %{role: "assistant"}, nil))
+    end
+  end
+
+  defp emit_acc(acc, frame_fun), do: %{acc | conn: emit(acc.conn, frame_fun.(acc))}
+
+  # ---------------------------------------------------------------------------
+  # Response — one pipeline result folded onto the OpenAI wire.
+  # ---------------------------------------------------------------------------
+
+  defp respond(acc, %Outgoing{} = outgoing) do
+    answer = AnsweringRun.clean_answer(outgoing.body)
+
+    case classify(outgoing.metadata, answer) do
+      :ok -> deliver(acc, answer, sources_from_outgoing(outgoing))
+      {:error, reason} -> respond_error(acc, reason)
+    end
+  end
+
+  # The pipeline never raises — errors come back flagged on the result. The
+  # "max iterations" sentinel is not a real answer: surface it as an error
+  # rather than a fabricated acknowledgement.
+  defp classify(metadata, answer) do
+    cond do
+      metadata_get(metadata, :error) == true -> {:error, :pipeline_error}
+      String.contains?(answer, @max_iter_sentinel) -> {:error, :max_iterations_reached}
+      String.trim(answer) == "" -> {:error, :empty_answer}
+      true -> :ok
+    end
+  end
+
+  defp deliver(%{stream?: true} = acc, answer, sources) do
+    acc = acc |> ensure_sse_role() |> finish_answer(answer)
+
+    conn = emit(acc.conn, chunk(acc, %{}, "stop"))
+    conn = if sources == [], do: conn, else: emit(conn, sources_frame(acc, sources))
+    sse_done(conn)
+  end
+
+  defp deliver(%{stream?: false} = acc, answer, sources) do
+    json(acc.conn, completion(acc, answer, sources, "stop"))
+  end
+
+  # Reconcile the authoritative final answer with what streaming already sent.
+  defp finish_answer(%{sent: ""} = acc, answer),
+    do: emit_acc(acc, &chunk(&1, %{content: answer}, nil))
+
+  defp finish_answer(%{sent: sent} = acc, answer) do
+    base = if String.starts_with?(answer, sent), do: sent, else: String.trim_trailing(sent)
+
+    if String.starts_with?(answer, base) do
+      case binary_part(answer, byte_size(base), byte_size(answer) - byte_size(base)) do
+        "" -> acc
+        rest -> emit_acc(acc, &chunk(&1, %{content: rest}, nil))
+      end
+    else
+      # The streamed segment diverged from the final answer (a late ReAct
+      # restart): append the authoritative answer after a break rather than
+      # leaving the client with a partial intermediate.
+      emit_acc(acc, &chunk(&1, %{content: "\n\n" <> answer}, nil))
+    end
+  end
+
+  defp respond_error(%{stream?: true} = acc, reason) do
+    acc =
+      if acc.sse_started?,
+        do: acc,
+        else: %{acc | conn: start_sse(acc.conn), sse_started?: true}
+
+    acc.conn
+    |> emit(stream_error(acc, reason))
+    |> sse_done()
+  end
+
+  defp respond_error(%{stream?: false} = acc, reason) do
+    json_error(acc.conn, 502, error_message(reason))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Ownership gate (IDOR guard) + conversation lifecycle.
+  # ---------------------------------------------------------------------------
+
+  defp ensure_owned_conversation(convo_id, user_id) do
+    # Validate the UUID up front so a malformed id is a clean 400 regardless of
+    # which cast exception the Repo would raise (the rescue below stays as a
+    # belt-and-suspenders guard).
+    case Ecto.UUID.cast(convo_id) do
+      {:ok, valid_id} -> gate_conversation(valid_id, user_id)
+      :error -> {:error, 400, "invalid conversation_id"}
+    end
+  end
+
+  defp gate_conversation(convo_id, user_id) do
+    case Conversations.get_conversation(convo_id) do
+      %Conversation{channel_user_id: ^user_id, channel_type: "chat"} = conv ->
+        {:ok, conv}
+
+      %Conversation{} ->
+        {:error, 403, "conversation does not belong to user"}
+
+      nil ->
+        open_conversation(convo_id, user_id)
+    end
+  rescue
+    Ecto.Query.CastError -> {:error, 400, "invalid conversation_id"}
+  end
+
+  defp open_conversation(convo_id, user_id) do
+    case Conversations.create_chat_conversation(convo_id, user_id) do
+      {:ok, %Conversation{} = conv} ->
+        {:ok, conv}
+
+      {:error, _changeset} ->
+        # Lost a create race (or the id is now taken): re-fetch and re-gate.
+        case Conversations.get_conversation(convo_id) do
+          %Conversation{channel_user_id: ^user_id, channel_type: "chat"} = conv -> {:ok, conv}
+          %Conversation{} -> {:error, 403, "conversation does not belong to user"}
+          nil -> {:error, 409, "could not open conversation"}
+        end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Citations — unique (document, page) rows from the run's retrieval tool
+  # calls (carried on `outgoing.metadata[:tool_calls]`, json_safe-encoded),
+  # capped at @max_sources.
+  # ---------------------------------------------------------------------------
+
+  defp sources_from_outgoing(%Outgoing{metadata: metadata}) do
+    metadata
+    |> metadata_get(:tool_calls)
+    |> List.wrap()
+    |> Enum.flat_map(&tool_call_chunks/1)
+    |> Enum.reduce({MapSet.new(), []}, &maybe_add_source(&2, source_from_chunk(&1)))
+    |> elem(1)
+  end
+
+  # `tool_call["response"]` is the json_safe-encoded raw tool result: either a
+  # map (`%{"chunks" => [...]}`) or an encoded ok-tuple (`["ok", %{...}, ...]`).
+  defp tool_call_chunks(tool_call) when is_map(tool_call) do
+    tool_call |> metadata_get(:response) |> chunks_from_response()
+  end
+
+  defp tool_call_chunks(_tool_call), do: []
+
+  defp chunks_from_response(%{} = response) do
+    case metadata_get(response, :chunks) do
+      chunks when is_list(chunks) -> Enum.filter(chunks, &is_map/1)
+      _ -> []
+    end
+  end
+
+  defp chunks_from_response(["ok" | rest]) do
+    case Enum.find(rest, &is_map/1) do
+      nil -> []
+      inner -> chunks_from_response(inner)
+    end
+  end
+
+  defp chunks_from_response(_response), do: []
+
+  defp maybe_add_source(acc, nil), do: acc
+
+  defp maybe_add_source({seen, sources} = acc, {key, did, src, page}) do
+    if length(sources) >= @max_sources or MapSet.member?(seen, key) do
+      acc
+    else
+      {MapSet.put(seen, key), sources ++ [%{document_id: did, source: src, page: page}]}
+    end
+  end
+
+  defp source_from_chunk(chunk) do
+    source = Map.get(chunk, "source") || Map.get(chunk, :source)
+    document_id = Map.get(chunk, "document_id") || Map.get(chunk, :document_id)
+    page = Map.get(chunk, "page") || Map.get(chunk, :page) || 1
+
+    if is_binary(source) and not is_nil(document_id),
+      do: {{document_id, page}, document_id, source, page},
+      else: nil
+  end
+
+  defp sources_frame(acc, sources) do
+    acc
+    |> chunk(%{}, nil)
+    |> Map.put(:zaq_sources, sources_payload(sources))
+  end
+
+  defp sources_payload(sources) do
+    Enum.map(sources, fn %{document_id: did, source: src, page: page} ->
+      %{
+        sourceId: did,
+        # `?page=` keeps each (doc, page) row distinct and opens at that page.
+        url: "/chat/documents/#{did}?page=#{page}",
+        title: src,
+        page: page
+      }
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # OpenAI wire shapes.
+  # ---------------------------------------------------------------------------
+
+  defp chunk(acc, delta, finish_reason) do
+    %{
+      id: acc.id,
+      object: "chat.completion.chunk",
+      created: acc.created,
+      model: acc.model,
+      choices: [%{index: 0, delta: delta, finish_reason: finish_reason}]
+    }
+  end
+
+  defp completion(acc, answer, sources, finish_reason) do
+    %{
+      id: acc.id,
+      object: "chat.completion",
+      created: acc.created,
+      model: acc.model,
+      choices: [
+        %{
+          index: 0,
+          message: %{role: "assistant", content: answer},
+          finish_reason: finish_reason
+        }
+      ],
+      zaq_sources: sources_payload(sources)
+    }
+  end
+
+  defp stream_error(acc, reason) do
+    %{
+      id: acc.id,
+      object: "chat.completion.chunk",
+      created: acc.created,
+      model: acc.model,
+      error: %{message: error_message(reason), type: "server_error"}
+    }
+  end
+
+  defp created_ts, do: System.system_time(:second)
+
+  # ---------------------------------------------------------------------------
+  # Request parsing.
+  # ---------------------------------------------------------------------------
+
+  defp fetch_question(params) do
+    messages = fetch(params, "messages") || []
+
+    cond do
+      not is_list(messages) ->
+        {:error, 400, "messages must be an array"}
+
+      length(messages) > @max_messages ->
+        {:error, 413, "too many messages (max #{@max_messages})"}
+
+      true ->
+        case last_user_content(messages) do
+          text when is_binary(text) and text != "" -> {:ok, text}
+          _ -> {:error, 400, "no user message provided"}
+        end
+    end
+  end
+
+  defp fetch_required(params, key, message) do
+    case fetch(params, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, 400, message}
+    end
+  end
+
+  # First `system`-role message → per-run framing (OpenAI-standard). Prepended to
+  # the run question (see `run/5`), never persisted.
+  defp system_content(params) do
+    (fetch(params, "messages") || [])
+    |> Enum.find_value(fn msg ->
+      if fetch(msg, "role") == "system", do: message_text(fetch(msg, "content")), else: nil
+    end)
+  end
+
+  defp with_system(system, question)
+       when is_binary(system) and system != "" and is_binary(question),
+       do: system <> "\n\n" <> question
+
+  defp with_system(_system, question), do: question
+
+  # Optional `source_filter` (a ZAQ extension): a list of source prefixes the
+  # retrieval is restricted to. Accepts a list or single string; empty/absent →
+  # nil (unrestricted). Enforces the councils per-commune isolation invariant.
+  defp parse_source_filter(params) do
+    case fetch(params, "source_filter") do
+      list when is_list(list) ->
+        case Enum.filter(list, &is_binary/1) do
+          [] -> nil
+          filtered -> filtered
+        end
+
+      value when is_binary(value) and value != "" ->
+        [value]
+
+      _ ->
+        nil
+    end
+  end
+
+  defp stream?(params), do: fetch(params, "stream") == true
+
+  defp last_user_content(messages) when is_list(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn msg ->
+      if fetch(msg, "role") == "user", do: message_text(fetch(msg, "content")), else: nil
+    end)
+  end
+
+  defp message_text(text) when is_binary(text), do: text
+
+  defp message_text(parts) when is_list(parts) do
+    Enum.map_join(parts, "", fn part -> fetch(part, "text") || "" end)
+  end
+
+  defp message_text(_), do: nil
+
+  # ---------------------------------------------------------------------------
+  # SSE writer.
+  # ---------------------------------------------------------------------------
+
+  defp start_sse(conn) do
+    conn
+    |> put_resp_header("content-type", "text/event-stream")
+    |> put_resp_header("cache-control", "no-cache")
+    |> put_resp_header("connection", "keep-alive")
+    |> send_chunked(200)
+  end
+
+  defp emit(conn, event) when is_map(event) do
+    case chunk_out(conn, "data: #{Jason.encode!(event)}\n\n") do
+      {:ok, conn} -> conn
+      {:error, _reason} -> conn
+    end
+  end
+
+  defp sse_done(conn) do
+    case chunk_out(conn, "data: [DONE]\n\n") do
+      {:ok, conn} -> conn
+      {:error, _reason} -> conn
+    end
+  end
+
+  defp chunk_out(conn, payload), do: Plug.Conn.chunk(conn, payload)
+
+  defp json_error(conn, status, message) do
+    conn |> put_status(status) |> json(%{error: %{message: message}})
+  end
+
+  defp error_message(:empty_answer), do: "Aucune réponse générée."
+  defp error_message(:max_iterations_reached), do: "La recherche n'a pas abouti à une réponse."
+  defp error_message(:timeout), do: "La réponse a pris trop de temps. Veuillez réessayer."
+  defp error_message(reason) when is_binary(reason), do: reason
+  defp error_message(_reason), do: "Une erreur est survenue. Veuillez réessayer."
+
+  defp metadata_get(map, key) when is_map(map) and is_atom(key),
+    do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  defp metadata_get(_map, _key), do: nil
+
+  defp node_router_module do
+    Application.get_env(:zaq, :chat_completions_node_router_module, Zaq.NodeRouter)
+  end
+
+  defp fetch(map, key) when is_map(map), do: Map.get(map, key)
+  defp fetch(_map, _key), do: nil
+end

--- a/lib/zaq_web/controllers/chat_documents_controller.ex
+++ b/lib/zaq_web/controllers/chat_documents_controller.ex
@@ -1,0 +1,73 @@
+defmodule ZaqWeb.ChatDocumentsController do
+  use ZaqWeb, :controller
+
+  alias Zaq.Ingestion
+  alias Zaq.Ingestion.{Document, Sidecar}
+  alias Zaq.Ingestion.FileExplorer
+
+  def index(conn, %{"prefix" => prefix}) do
+    documents =
+      prefix
+      |> Ingestion.list_public_chat_documents()
+      |> Enum.map(&serialize/1)
+
+    json(conn, %{documents: documents})
+  end
+
+  def index(conn, _params), do: json(conn, %{documents: []})
+
+  def show(conn, %{"id" => id}) do
+    case Ingestion.get_public_chat_document(id) do
+      nil -> json_error(conn, 404, "document not found")
+      document -> json(conn, serialize(document, true))
+    end
+  end
+
+  def file(conn, %{"id" => id}) do
+    with document when not is_nil(document) <- Ingestion.get_public_chat_document(id),
+         {:ok, path} <- FileExplorer.resolve_path(document.source),
+         true <- File.regular?(path) do
+      conn
+      |> put_resp_content_type("application/pdf")
+      |> put_resp_header("content-disposition", ~s(inline; filename="#{Path.basename(path)}"))
+      |> send_file(200, path)
+    else
+      _ -> json_error(conn, 404, "document file not found")
+    end
+  end
+
+  defp serialize(document, include_content? \\ false) do
+    metadata = document.metadata || %{}
+
+    %{
+      id: document.id,
+      source: document.source,
+      title: document.title,
+      summary: metadata["summary"] || metadata[:summary],
+      suggestions: metadata["suggestions"] || metadata[:suggestions] || []
+    }
+    |> maybe_put_content(document, include_content?)
+  end
+
+  defp maybe_put_content(payload, document, true) do
+    content_document = linked_sidecar(document) || document
+
+    Map.merge(payload, %{
+      content: content_document.content,
+      content_type: content_document.content_type
+    })
+  end
+
+  defp maybe_put_content(payload, _document, false), do: payload
+
+  defp linked_sidecar(document) do
+    case Sidecar.sidecar_source(document) do
+      source when is_binary(source) -> Document.get_by_source(source)
+      nil -> nil
+    end
+  end
+
+  defp json_error(conn, status, message) do
+    conn |> put_status(status) |> json(%{error: %{message: message}})
+  end
+end

--- a/lib/zaq_web/plugs/chat_bearer_auth.ex
+++ b/lib/zaq_web/plugs/chat_bearer_auth.ex
@@ -1,0 +1,30 @@
+defmodule ZaqWeb.Plugs.ChatBearerAuth do
+  @moduledoc false
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with expected when is_binary(expected) and expected != "" <-
+           System.get_env("ZAQ_CHAT_TOKEN"),
+         ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         true <- Plug.Crypto.secure_compare(token, expected) do
+      conn
+    else
+      nil -> reject(conn, 503, "chat transport not configured")
+      "" -> reject(conn, 503, "chat transport not configured")
+      [] -> reject(conn, 401, "missing bearer token")
+      _ -> reject(conn, 403, "invalid bearer token")
+    end
+  end
+
+  defp reject(conn, status, message) do
+    body = Jason.encode!(%{error: %{message: message}})
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, body)
+    |> halt()
+  end
+end

--- a/lib/zaq_web/router.ex
+++ b/lib/zaq_web/router.ex
@@ -39,6 +39,11 @@ defmodule ZaqWeb.Router do
     plug :fetch_query_params
   end
 
+  pipeline :chat_bearer_auth do
+    plug :fetch_query_params
+    plug ZaqWeb.Plugs.ChatBearerAuth
+  end
+
   scope "/", ZaqWeb do
     pipe_through :browser
 
@@ -140,6 +145,20 @@ defmodule ZaqWeb.Router do
     get "/health", ChannelsController, :health
     get "/oauth2/:provider/redirect", ChannelsController, :oauth2_redirect
     post "/webhook/:type/:provider", ChannelsController, :webhook
+  end
+
+  scope "/chat", ZaqWeb do
+    pipe_through :chat_bearer_auth
+
+    get "/documents", ChatDocumentsController, :index
+    get "/documents/:id", ChatDocumentsController, :show
+    get "/documents/:id/file", ChatDocumentsController, :file
+  end
+
+  scope "/v1", ZaqWeb do
+    pipe_through :chat_bearer_auth
+
+    post "/chat/completions", ChatCompletionsController, :completions
   end
 
   if Application.compile_env(:zaq, :e2e_routes, false) do

--- a/test/zaq/agent/answering_run_test.exs
+++ b/test/zaq/agent/answering_run_test.exs
@@ -1,0 +1,45 @@
+defmodule Zaq.Agent.AnsweringRunTest do
+  use ExUnit.Case, async: true
+
+  alias Zaq.Agent.AnsweringRun
+
+  test "uses only the authoritative request result" do
+    intermediate = %{
+      kind: :llm_delta,
+      iteration: 1,
+      llm_call_id: "tool-selection",
+      data: %{chunk_type: :content, delta: "intermediate"}
+    }
+
+    completed = %{
+      kind: :request_completed,
+      data: %{result: "Final answer [[source:documents/report.pdf|p2]]."}
+    }
+
+    assert AnsweringRun.classify_event(intermediate) == :ignore
+    assert AnsweringRun.classify_event(completed) == {:done, "Final answer."}
+  end
+
+  test "extracts retrieval chunks from tool results" do
+    chunks = [%{"document_id" => 1, "page" => 2, "source" => "documents/report.pdf"}]
+
+    event = %{
+      kind: :tool_completed,
+      data: %{result: {:ok, %{chunks: chunks}, []}}
+    }
+
+    assert AnsweringRun.extract_chunks(event) == chunks
+  end
+
+  test "normalizes whitespace left by inline source markers" do
+    answer =
+      "First claim [[source:documents/a.pdf|p1]].  \nSecond claim [[source:documents/a.pdf|p2]]."
+
+    assert AnsweringRun.clean_answer(answer) ==
+             """
+             First claim.
+             Second claim.
+             """
+             |> String.trim()
+  end
+end

--- a/test/zaq/agent/provider_spec_test.exs
+++ b/test/zaq/agent/provider_spec_test.exs
@@ -574,6 +574,14 @@ defmodule Zaq.Agent.ProviderSpecTest do
       assert opts[:provider_options][:chatgpt_account_id] == "acct_123"
     end
 
+    test "empty credential values are omitted from opts" do
+      agent = %{agent_base() | credential: %{api_key: "", endpoint: ""}}
+
+      opts = ProviderSpec.llm_opts(agent)
+      refute Keyword.has_key?(opts, :api_key)
+      refute Keyword.has_key?(opts, :base_url)
+    end
+
     test "atom keys in advanced_options are included" do
       agent = %{agent_base() | advanced_options: %{temperature: 0.5, top_p: 0.8}}
       opts = ProviderSpec.llm_opts(agent)

--- a/test/zaq_web/controllers/chat_completions_controller_test.exs
+++ b/test/zaq_web/controllers/chat_completions_controller_test.exs
@@ -1,0 +1,254 @@
+defmodule ZaqWeb.ChatCompletionsControllerTest do
+  # async: false — tests mutate the ZAQ_CHAT_TOKEN process-global env var.
+  use ZaqWeb.ConnCase, async: false
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Zaq.Engine.Conversations
+
+  @path "/v1/chat/completions"
+  @token "test-chat-token"
+
+  setup %{conn: conn} do
+    previous = System.get_env("ZAQ_CHAT_TOKEN")
+    System.put_env("ZAQ_CHAT_TOKEN", @token)
+
+    on_exit(fn ->
+      if previous,
+        do: System.put_env("ZAQ_CHAT_TOKEN", previous),
+        else: System.delete_env("ZAQ_CHAT_TOKEN")
+    end)
+
+    {:ok, conn: put_req_header(conn, "content-type", "application/json")}
+  end
+
+  defp authed(conn), do: put_req_header(conn, "authorization", "Bearer #{@token}")
+
+  defp body(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "model" => "zaq-chat",
+        "stream" => true,
+        "user" => "user-a",
+        "conversation_id" => Ecto.UUID.generate(),
+        "messages" => [%{"role" => "user", "content" => "Bonjour"}]
+      },
+      overrides
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Auth — fail-closed bearer gate.
+  # ---------------------------------------------------------------------------
+
+  test "503 when ZAQ_CHAT_TOKEN is not configured", %{conn: conn} do
+    System.delete_env("ZAQ_CHAT_TOKEN")
+    conn = post(authed(conn), @path, body())
+    assert json_response(conn, 503)["error"]["message"] =~ "not configured"
+  end
+
+  test "401 without bearer", %{conn: conn} do
+    conn = post(conn, @path, body())
+    assert json_response(conn, 401)["error"]["message"] == "missing bearer token"
+  end
+
+  test "403 with wrong bearer", %{conn: conn} do
+    conn = conn |> put_req_header("authorization", "Bearer nope") |> post(@path, body())
+    assert json_response(conn, 403)["error"]["message"] == "invalid bearer token"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Request validation.
+  # ---------------------------------------------------------------------------
+
+  test "400 when no user message present", %{conn: conn} do
+    conn =
+      post(authed(conn), @path, body(%{"messages" => [%{"role" => "system", "content" => "x"}]}))
+
+    assert json_response(conn, 400)["error"]["message"] == "no user message provided"
+  end
+
+  test "400 when user (owner id) missing", %{conn: conn} do
+    conn = post(authed(conn), @path, Map.delete(body(), "user"))
+    assert json_response(conn, 400)["error"]["message"] =~ "user"
+  end
+
+  test "400 when conversation_id missing", %{conn: conn} do
+    conn = post(authed(conn), @path, Map.delete(body(), "conversation_id"))
+    assert json_response(conn, 400)["error"]["message"] =~ "conversation_id"
+  end
+
+  test "400 when conversation_id is not a UUID", %{conn: conn} do
+    conn = post(authed(conn), @path, body(%{"conversation_id" => "not-a-uuid"}))
+    assert json_response(conn, 400)["error"]["message"] == "invalid conversation_id"
+  end
+
+  test "413 when messages exceed the cap", %{conn: conn} do
+    messages = List.duplicate(%{"role" => "user", "content" => "x"}, 201)
+    conn = post(authed(conn), @path, body(%{"messages" => messages}))
+    assert json_response(conn, 413)["error"]["message"] =~ "too many messages"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Ownership gate (IDOR guard) — rejected BEFORE any agent run.
+  # ---------------------------------------------------------------------------
+
+  test "403 when the conversation belongs to another user", %{conn: conn} do
+    convo_id = Ecto.UUID.generate()
+    assert {:ok, _} = Conversations.create_chat_conversation(convo_id, "user-a")
+
+    conn = post(authed(conn), @path, body(%{"user" => "user-b", "conversation_id" => convo_id}))
+    assert json_response(conn, 403)["error"]["message"] == "conversation does not belong to user"
+  end
+
+  test "403 when the conversation exists on another channel type", %{conn: conn} do
+    convo_id = Ecto.UUID.generate()
+    assert {:ok, _} = Conversations.create_chat_conversation(convo_id, "user-a")
+    # Same owner but wrong channel_type must not resolve either.
+    {1, _} =
+      Zaq.Repo.update_all(
+        from(c in Zaq.Engine.Conversations.Conversation, where: c.id == ^convo_id),
+        set: [channel_type: "bo"]
+      )
+
+    conn = post(authed(conn), @path, body(%{"user" => "user-a", "conversation_id" => convo_id}))
+    assert json_response(conn, 403)["error"]["message"] == "conversation does not belong to user"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Conversation lifecycle helper.
+  # ---------------------------------------------------------------------------
+
+  test "create_chat_conversation surfaces a pk race as {:error, changeset}, not a raise" do
+    convo_id = Ecto.UUID.generate()
+    assert {:ok, conv} = Conversations.create_chat_conversation(convo_id, "user-a")
+    assert conv.channel_type == "chat"
+    assert conv.channel_user_id == "user-a"
+
+    assert {:error, %Ecto.Changeset{}} =
+             Conversations.create_chat_conversation(convo_id, "user-b")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Pipeline routing — the run flows through route_incoming_message/5 (like
+  # every other channel bridge) and the result comes back over ChatBridge
+  # PubSub as {:chat_result, request_id, outgoing}.
+  # ---------------------------------------------------------------------------
+
+  defmodule EchoRouter do
+    @moduledoc false
+    alias Zaq.Channels.ChatBridge
+    alias Zaq.Engine.Messages.{Incoming, Outgoing}
+
+    def dispatch(%Zaq.Event{request: %Incoming{} = incoming} = event) do
+      topic = ChatBridge.topic(incoming.channel_id)
+
+      # Progressive cumulative stream deltas, like StreamEvents flushes them —
+      # including a partially-streamed source marker that must be held back.
+      for cumulative <- [
+            "Réponse ",
+            "Réponse générée. [[sou",
+            "Réponse générée. [[source:doc.pdf]]"
+          ] do
+        Phoenix.PubSub.broadcast(
+          Zaq.PubSub,
+          topic,
+          {:chat_stream_delta, incoming.message_id, cumulative}
+        )
+      end
+
+      outgoing = %Outgoing{
+        body: "Réponse générée. [[source:doc.pdf]]",
+        channel_id: incoming.channel_id,
+        provider: :chat,
+        in_reply_to: incoming.message_id,
+        metadata:
+          Map.merge(incoming.metadata, %{
+            tool_calls: [
+              %{
+                "name" => "retrieve",
+                "response" => %{
+                  "chunks" => [
+                    %{"source" => "doc.pdf", "document_id" => "doc-1", "page" => 3}
+                  ]
+                }
+              }
+            ]
+          })
+      }
+
+      Phoenix.PubSub.broadcast(Zaq.PubSub, topic, {:chat_result, incoming.message_id, outgoing})
+
+      %{event | response: nil}
+    end
+  end
+
+  defmodule SilentRouter do
+    @moduledoc false
+    def dispatch(%Zaq.Event{} = event), do: %{event | response: nil}
+  end
+
+  defp with_router(router) do
+    Application.put_env(:zaq, :chat_completions_node_router_module, router)
+    on_exit(fn -> Application.delete_env(:zaq, :chat_completions_node_router_module) end)
+  end
+
+  test "non-stream: pipeline result folds into an OpenAI completion with citations",
+       %{conn: conn} do
+    with_router(EchoRouter)
+
+    conn = post(authed(conn), @path, body(%{"stream" => false}))
+    resp = json_response(conn, 200)
+
+    assert %{"choices" => [%{"message" => %{"role" => "assistant", "content" => content}}]} =
+             resp
+
+    # Inline source markers are stripped — citations ride zaq_sources instead.
+    assert content == "Réponse générée."
+
+    assert [%{"sourceId" => "doc-1", "page" => 3, "url" => "/chat/documents/doc-1?page=3"}] =
+             Enum.map(resp["zaq_sources"], &Map.take(&1, ["sourceId", "page", "url"]))
+  end
+
+  test "stream: progressive deltas + zaq_sources + [DONE]", %{conn: conn} do
+    with_router(EchoRouter)
+
+    conn = post(authed(conn), @path, body())
+
+    assert conn.status == 200
+    sse = response(conn, 200)
+    assert sse =~ ~s("delta":{"role":"assistant"})
+
+    # Progressive: the answer arrives across MULTIPLE content deltas that
+    # concatenate to the clean answer — markers never leak, the held-back
+    # partial marker ("[[sou") is dropped once it completes.
+    deltas =
+      sse
+      |> String.split("\n\n", trim: true)
+      |> Enum.map(&String.trim_leading(&1, "data: "))
+      |> Enum.reject(&(&1 == "[DONE]"))
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.flat_map(fn frame ->
+        case frame do
+          %{"choices" => [%{"delta" => %{"content" => content}}]} -> [content]
+          _ -> []
+        end
+      end)
+
+    assert length(deltas) > 1
+    assert Enum.join(deltas) == "Réponse générée."
+    refute sse =~ "[[source"
+
+    assert sse =~ "zaq_sources"
+    assert sse =~ "data: [DONE]"
+  end
+
+  test "502 when no pipeline result arrives before the timeout", %{conn: conn} do
+    with_router(SilentRouter)
+    Application.put_env(:zaq, :chat_result_timeout_ms, 50)
+    on_exit(fn -> Application.delete_env(:zaq, :chat_result_timeout_ms) end)
+
+    conn = post(authed(conn), @path, body(%{"stream" => false}))
+    assert json_response(conn, 502)["error"]["message"] =~ "trop de temps"
+  end
+end

--- a/test/zaq_web/controllers/chat_documents_controller_test.exs
+++ b/test/zaq_web/controllers/chat_documents_controller_test.exs
@@ -1,0 +1,100 @@
+defmodule ZaqWeb.ChatDocumentsControllerTest do
+  use ZaqWeb.ConnCase, async: false
+
+  alias Zaq.Ingestion.Document
+
+  @token "test-chat-token"
+
+  setup %{conn: conn} do
+    previous_token = System.get_env("ZAQ_CHAT_TOKEN")
+    previous_ingestion = Application.get_env(:zaq, Zaq.Ingestion)
+    root = Path.join(System.tmp_dir!(), "zaq_chat_documents_#{System.unique_integer()}")
+    File.mkdir_p!(root)
+    System.put_env("ZAQ_CHAT_TOKEN", @token)
+    Application.put_env(:zaq, Zaq.Ingestion, volumes: %{"documents" => root})
+
+    on_exit(fn ->
+      restore_env("ZAQ_CHAT_TOKEN", previous_token)
+      Application.put_env(:zaq, Zaq.Ingestion, previous_ingestion || [])
+      File.rm_rf!(root)
+    end)
+
+    conn = put_req_header(conn, "authorization", "Bearer #{@token}")
+    {:ok, conn: conn, root: root}
+  end
+
+  test "lists and shows only public source documents", %{conn: conn} do
+    {:ok, public} =
+      Document.create(%{
+        source: "documents/pv-public.pdf",
+        title: "Public PV",
+        content: "# Public",
+        tags: ["public"],
+        metadata: %{"summary" => "Résumé", "suggestions" => ["Question ?"]}
+      })
+
+    {:ok, _private} =
+      Document.create(%{source: "documents/pv-private.pdf", title: "Private PV"})
+
+    list = conn |> get("/chat/documents?prefix=documents/pv-") |> json_response(200)
+    assert [%{"id" => id, "summary" => "Résumé"}] = list["documents"]
+    assert id == public.id
+
+    shown = conn |> get("/chat/documents/#{public.id}") |> json_response(200)
+    assert shown["content"] == "# Public"
+    assert shown["suggestions"] == ["Question ?"]
+  end
+
+  test "streams a public PDF inline", %{conn: conn, root: root} do
+    {:ok, document} =
+      Document.create(%{source: "documents/pv.pdf", title: "PV", tags: ["public"]})
+
+    File.write!(Path.join(root, "pv.pdf"), "%PDF-test")
+    response = get(conn, "/chat/documents/#{document.id}/file")
+
+    assert response(response, 200) == "%PDF-test"
+    assert get_resp_header(response, "content-disposition") == [~s(inline; filename="pv.pdf")]
+    assert List.first(get_resp_header(response, "content-type")) =~ "application/pdf"
+  end
+
+  test "shows linked sidecar content while keeping the PDF original and sidecar private", %{
+    conn: conn,
+    root: root
+  } do
+    {:ok, parent} =
+      Document.create(%{
+        source: "documents/pv.pdf",
+        content: "# Extracted PV",
+        tags: ["public"],
+        metadata: %{"sidecar_source" => "documents/PV_augmente_2026-01-22.md"}
+      })
+
+    {:ok, sidecar} =
+      Document.create(%{
+        source: "documents/PV_augmente_2026-01-22.md",
+        content: "# PV augmenté",
+        content_type: "markdown",
+        metadata: %{"source_document_source" => parent.source}
+      })
+
+    shown = conn |> get("/chat/documents/#{parent.id}") |> json_response(200)
+    assert shown["content"] == "# PV augmenté"
+    assert shown["content_type"] == "markdown"
+
+    File.write!(Path.join(root, "pv.pdf"), "%PDF-original")
+    assert conn |> get("/chat/documents/#{parent.id}/file") |> response(200) == "%PDF-original"
+
+    assert conn |> get("/chat/documents/#{sidecar.id}") |> json_response(404)
+  end
+
+  test "does not expose a private document or file", %{conn: conn, root: root} do
+    {:ok, document} = Document.create(%{source: "documents/private.pdf"})
+    File.write!(Path.join(root, "private.pdf"), "%PDF-private")
+
+    assert conn |> get("/chat/documents/#{document.id}") |> json_response(404)
+    assert conn |> get("/chat/documents/#{document.id}/file") |> json_response(404)
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+end


### PR DESCRIPTION
## What

Adds a production-facing chat channel to ZAQ:

- `POST /v1/chat/completions` streams OpenAI Chat Completions SSE from the existing Jido answering agent.
- ZAQ persists conversation turns and reloads history by `conversation_id`; callers send only the new user turn.
- `user` + `conversation_id` enforce conversation ownership and channel isolation before agent execution.
- `source_filter` scopes retrieval; anonymous chat retrieves only documents tagged `public`.
- Retrieved chunks produce deterministic `(document, page)` citation rows in the `zaq_sources` extension frame.
- Final text comes from Jido's authoritative completed-request result; intermediate ReAct deltas are not merged into user answers.
- `GET /chat/documents`, `GET /chat/documents/:id`, and `GET /chat/documents/:id/file` expose public document metadata, augmented fields, content, and inline PDF bytes.

Chat Completions has no native source type. Standard OpenAI clients ignore the extra `zaq_sources` frame; compatible consumers can translate it into their native source representation.

## Security

- Bearer token is fail-closed and compared in constant time.
- A conversation owned by another user or channel returns 403 before any run.
- `person_id: nil` never bypasses document permissions.
- Document list, content, and PDF routes expose only `public` source documents.
- File paths resolve through ZAQ ingestion volume boundaries.

## Verification

- `mix precommit`: passed (compile, format, Credo strict, hooks, stale tests).
- Focused stream/controller suite: 17 tests, 0 failures.
- Production Docker image: built successfully.
- Local consumer-to-ZAQ E2E: clean answer, page source, document panel, and PDF proxy passed; PDF response returned 200 with `application/pdf` and a valid `%PDF-` header.

Beadwork CLI was unavailable locally; work and validation were tracked outside this repository.
