### PR TITLE
feat(agent): make dispatch_event a usable tool with optional input, destination, and cascade forwarding

### DIFF
--- a/lib/zaq/agent/tools/registry.ex
+++ b/lib/zaq/agent/tools/registry.ex
@@ -265,6 +265,13 @@ defmodule Zaq.Agent.Tools.Registry do
       module: Zaq.Agent.Tools.Workflow.RunAgent
     },
     %{
+      key: "workflow.dispatch_event",
+      label: "Dispatch event",
+      description:
+        "Dispatch a workflow event to the Engine node, forwarding prior step outputs plus any extra input fields",
+      module: Zaq.Agent.Tools.Workflow.DispatchEvent
+    },
+    %{
       key: "advanced.lua_eval",
       label: "Lua eval",
       description: "Evaluate Lua code in a sandbox",

--- a/lib/zaq/agent/tools/workflow/dispatch_event.ex
+++ b/lib/zaq/agent/tools/workflow/dispatch_event.ex
@@ -1,6 +1,15 @@
 defmodule Zaq.Agent.Tools.Workflow.DispatchEvent do
   @moduledoc """
-  Workflow action: dispatches an allowlisted Engine event.
+  Workflow action: dispatches an event to a node role (the Engine by default).
+
+  `event_name` is free-form — any non-blank name may be dispatched. The target
+  node decides which events it consumes; this action does not gate names.
+
+  ## Destination
+
+  `destination` selects the target node role and is **optional** — it defaults to
+  `"engine"`. Allowed values: `engine`, `agent`, `channels`, `ingestion`, `bo`.
+  An unknown destination is rejected before dispatch.
 
   ## Machine runs
 
@@ -12,6 +21,23 @@ defmodule Zaq.Agent.Tools.Workflow.DispatchEvent do
   requiring a human actor. The bypass is opt-in — a missing marker never grants
   it (see `Zaq.Engine.TriggerNode`).
 
+  ## Request payload
+
+  By default the dispatched request is the **merged output of every previously
+  executed step** — the run's cascade (`%{step_name => result}`) flattened into a
+  single map. A `DispatchEvent` node can therefore sit anywhere in a workflow
+  (e.g. as the second node) with no incoming `input` mapping and still forward
+  the accumulated workflow state. Engine-internal plumbing keys (`__cascade__`,
+  `__map_index__`, …) are stripped; only real domain data is dispatched.
+
+  The optional `input` map is **layered on top** of those prior outputs and wins
+  on key conflicts — use it to add or override fields. With no prior steps and no
+  `input`, an empty request (`%{}`) is dispatched.
+
+  A **scalar `input`** (e.g. a string) is dispatched **verbatim** as the request,
+  bypassing the cascade merge and machine marker — handy for a plain message
+  payload, e.g. `input: "seeds ready"` with `destination: "channels"`.
+
   ## Example
 
       iex> Zaq.Agent.Tools.Workflow.DispatchEvent.run(
@@ -19,17 +45,39 @@ defmodule Zaq.Agent.Tools.Workflow.DispatchEvent do
       ...>   %{}
       ...> )
       {:ok, %{dispatched: %{"email" => "a@b.com"}}}
+
+      iex> Zaq.Agent.Tools.Workflow.DispatchEvent.run(
+      ...>   %{event_name: "lead_identified"},
+      ...>   %{}
+      ...> )
+      {:ok, %{dispatched: %{}}}
   """
 
   use Zaq.Engine.Workflows.Action,
     name: "dispatch_event",
-    description: "Dispatch an allowlisted workflow event to the Engine node.",
+    description: "Dispatch a workflow event to the Engine node.",
     schema: [
-      input: [type: :map, required: true, doc: "Request payload — passed as event request"],
+      input: [
+        # `:any` — a map is merged on top of prior step outputs (string keys, so an
+        # LLM tool call's string-keyed payload validates via `Jido.Exec.run`); a
+        # scalar (e.g. a channels message string) is dispatched verbatim.
+        type: :any,
+        required: false,
+        default: %{},
+        doc:
+          "Request payload. A map is layered on top of the merged outputs of prior steps (wins on conflicts); a scalar (e.g. a string) is dispatched as-is. Defaults to an empty map."
+      ],
       event_name: [
         type: :string,
         required: true,
-        doc: "Allowlisted Engine event name, e.g. \"lead_identified\""
+        doc: "Engine event name to dispatch, e.g. \"lead_identified\""
+      ],
+      destination: [
+        type: :string,
+        required: false,
+        default: "engine",
+        doc:
+          "Target node role: engine, agent, channels, ingestion, or bo. Defaults to \"engine\"."
       ],
       machine: [
         type: :boolean,
@@ -40,45 +88,56 @@ defmodule Zaq.Agent.Tools.Workflow.DispatchEvent do
       ]
     ],
     output_schema: [
-      dispatched: [type: :map, required: true, doc: "The request map that was dispatched"]
+      # `:any` — the dispatched request is a string-keyed map or a scalar (see
+      # run/2); the bare `:map` (atom-key-only) would reject either on validation.
+      dispatched: [
+        type: :any,
+        required: true,
+        doc: "The request that was dispatched (a map, or a scalar for verbatim payloads)"
+      ]
     ]
 
   require Logger
 
   alias Zaq.NodeRouter
 
-  @allowed_event_names ~w(lead_identified)
+  # Allowlisted node roles a workflow may dispatch to. String-keyed so a
+  # workflow/LLM-supplied name resolves without `String.to_atom` (atom-exhaustion
+  # safe); an atom destination is normalised back through the same table.
+  @destinations %{
+    "engine" => :engine,
+    "agent" => :agent,
+    "channels" => :channels,
+    "ingestion" => :ingestion,
+    "bo" => :bo
+  }
 
   @impl Jido.Action
-  def run(%{input: input, event_name: event_name} = params, ctx) do
+  def run(%{event_name: event_name} = params, ctx) do
+    input = Map.get(params, :input)
     machine? = Map.get(params, :machine, false) == true
+    destination = Map.get(params, :destination) || "engine"
 
     Logger.debug(
-      "[dispatch_event] run called event_name=#{inspect(event_name)} machine=#{machine?} input_keys=#{inspect(Map.keys(input))}"
+      "[dispatch_event] run called event_name=#{inspect(event_name)} destination=#{inspect(destination)} machine=#{machine?} input=#{inspect(input)}"
     )
 
-    case validate_event_name(event_name) do
-      :ok ->
-        dispatch_event(input, event_name, machine?, ctx)
-
+    with :ok <- validate_event_name(event_name),
+         {:ok, dest} <- resolve_destination(destination) do
+      dispatch_event(input, event_name, dest, machine?, ctx)
+    else
       {:error, reason} ->
         Logger.warning("[dispatch_event] aborted before dispatch reason=#{inspect(reason)}")
         {:error, reason}
     end
   end
 
-  defp dispatch_event(input, event_name, machine?, ctx) do
-    # Stringify all keys — iterate pipeline may atom-normalize keys via try_to_atom,
-    # leaving a mixed map that the engine rejects as {:invalid_request, ...}.
-    request =
-      input
-      |> Map.new(fn {k, v} -> {to_string(k), v} end)
-      |> maybe_mark_machine(machine?)
-
-    event = Zaq.Event.new(request, :engine, type: :async, name: event_name)
+  defp dispatch_event(input, event_name, destination, machine?, ctx) do
+    request = build_request(input, machine?, ctx)
+    event = Zaq.Event.new(request, destination, type: :async, name: event_name)
     node_router = Map.get(ctx, :node_router, NodeRouter)
 
-    Logger.debug("[dispatch_event] dispatching #{inspect(event.name)} to :engine")
+    Logger.debug("[dispatch_event] dispatching #{inspect(event.name)} to #{inspect(destination)}")
 
     case node_router.dispatch(event).response do
       {:ok, _} ->
@@ -96,18 +155,77 @@ defmodule Zaq.Agent.Tools.Workflow.DispatchEvent do
     end
   end
 
+  # A scalar `input` (string, number, …) is dispatched verbatim as the request —
+  # e.g. a plain channels message. Cascade merging and the machine marker only
+  # apply to map payloads, so a scalar bypasses both.
+  defp build_request(input, _machine?, _ctx) when not is_map(input) and not is_nil(input),
+    do: input
+
+  # Map (or absent) `input`: default to the merged outputs of every previously
+  # executed step (the run's `__cascade__`), so a DispatchEvent node forwards the
+  # accumulated workflow state without an explicit `input` mapping. Explicit
+  # `input` fields are layered on top and win on key conflicts.
+  #
+  # All keys are stringified — the iterate pipeline may atom-normalize keys via
+  # try_to_atom, leaving a mixed map that the engine rejects as
+  # {:invalid_request, ...}.
+  defp build_request(input, machine?, ctx) do
+    ctx
+    |> prior_step_outputs()
+    |> Map.merge(string_keyed(input || %{}))
+    |> maybe_mark_machine(machine?)
+  end
+
+  # Flattens the run's cascade (`%{step_name => result}`) into a single
+  # string-keyed map of every prior step's output. Internal plumbing keys
+  # (`__cascade__`, `__map_index__`, …) are dropped so only real domain data is
+  # dispatched. Key conflicts between steps resolve in `Map.merge` order.
+  defp prior_step_outputs(ctx) do
+    ctx
+    |> Map.get(:__cascade__, Map.get(ctx, "__cascade__", %{}))
+    |> Map.values()
+    |> Enum.reduce(%{}, fn result, acc -> Map.merge(acc, string_keyed(result)) end)
+  end
+
+  # Stringifies a map's keys and drops engine-internal `__*` plumbing keys.
+  defp string_keyed(map) when is_map(map) do
+    map
+    |> Enum.reject(fn {k, _v} -> internal_key?(k) end)
+    |> Map.new(fn {k, v} -> {to_string(k), v} end)
+  end
+
+  defp string_keyed(_), do: %{}
+
+  defp internal_key?(k), do: k |> to_string() |> String.starts_with?("__")
+
   # The `"machine"` marker is read by `Zaq.Engine.TriggerNode` to set
   # skip_permissions on the triggered run. Only added when explicitly requested
   # so non-machine dispatches keep a clean request payload.
   defp maybe_mark_machine(request, true), do: Map.put(request, "machine", true)
   defp maybe_mark_machine(request, false), do: request
 
-  defp validate_event_name(event_name) when event_name in @allowed_event_names, do: :ok
-
-  defp validate_event_name(event_name) do
-    {:error,
-     "unsupported event_name #{inspect(event_name)}, allowed: #{Enum.join(@allowed_event_names, ", ")}"}
+  defp validate_event_name(event_name) when is_binary(event_name) do
+    if String.trim(event_name) == "", do: {:error, "event_name must not be blank"}, else: :ok
   end
 
-  def allowed_event_names, do: @allowed_event_names
+  defp validate_event_name(event_name),
+    do: {:error, "event_name must be a string, got: #{inspect(event_name)}"}
+
+  # Resolves a destination (string or atom) to an allowlisted node role atom.
+  defp resolve_destination(destination) when is_atom(destination),
+    do: resolve_destination(Atom.to_string(destination))
+
+  defp resolve_destination(destination) when is_binary(destination) do
+    case Map.fetch(@destinations, destination) do
+      {:ok, role} ->
+        {:ok, role}
+
+      :error ->
+        {:error,
+         "unsupported destination #{inspect(destination)}, allowed: #{Enum.join(Map.keys(@destinations), ", ")}"}
+    end
+  end
+
+  defp resolve_destination(other),
+    do: {:error, "destination must be a string, got: #{inspect(other)}"}
 end

--- a/test/zaq/agent/tools/registry_test.exs
+++ b/test/zaq/agent/tools/registry_test.exs
@@ -40,6 +40,7 @@ defmodule Zaq.Agent.Tools.RegistryTest do
              "arithmetic.square",
              "workflow.condition",
              "workflow.run_agent",
+             "workflow.dispatch_event",
              "advanced.lua_eval"
            ]
   end
@@ -126,6 +127,7 @@ defmodule Zaq.Agent.Tools.RegistryTest do
              "arithmetic.square",
              "workflow.condition",
              "workflow.run_agent",
+             "workflow.dispatch_event",
              "advanced.lua_eval"
            ]
   end

--- a/test/zaq/agent/tools/workflow/dispatch_event_agent_tool_test.exs
+++ b/test/zaq/agent/tools/workflow/dispatch_event_agent_tool_test.exs
@@ -1,0 +1,244 @@
+defmodule Zaq.Agent.Tools.Workflow.DispatchEventAgentToolTest do
+  @moduledoc """
+  Drives `DispatchEvent` end-to-end as an agent tool: a real `react` agent is
+  created with `enabled_tool_keys: ["workflow.dispatch_event"]`, the LLM (stubbed
+  via `OpenAIStub`) emits a tool call for `dispatch_event`, and the agent pipeline
+  executes the tool. The `node_router` injected into the tool context (exactly as
+  `Zaq.Agent.Executor` injects the live `Zaq.NodeRouter`) captures the dispatched
+  event, proving it reached the engine.
+
+  `async: false` because `OpenAIStub` binds an ephemeral HTTP port and the tool
+  runs in a task under `Jido.Action.TaskSupervisor`; the capturing router is a
+  module, so it forwards to a registered observer process.
+  """
+  use Zaq.DataCase, async: false
+
+  import Zaq.SystemConfigFixtures
+
+  alias Zaq.Agent
+  alias Zaq.Agent.Executor
+  alias Zaq.Agent.ServerManager
+  alias Zaq.Agent.Tools.Registry
+  alias Zaq.Engine.Messages.Incoming
+  alias Zaq.Event
+  alias Zaq.TestSupport.OpenAIStub
+
+  @observer :dispatch_event_agent_observer
+
+  # Captures every event the pipeline dispatches through the injected node_router
+  # (the dispatch_event tool's engine event, plus typing/status events). A module
+  # can't close over the test pid, so it forwards to a registered observer.
+  defmodule CaptureRouter do
+    def dispatch(event) do
+      pid = Process.whereis(:dispatch_event_agent_observer) || self()
+      send(pid, {:dispatched, event})
+      # async dispatch → nil response; DispatchEvent treats nil as success.
+      event
+    end
+  end
+
+  # Skips the real status/typing broadcast machinery — not under test here.
+  defmodule StubStatus do
+    def broadcast(incoming, _stage, _message, _node_router), do: incoming
+    def broadcast(incoming, _stage, _message, _node_router, _opts), do: incoming
+  end
+
+  setup do
+    Process.register(self(), @observer)
+    :ok
+  end
+
+  test "workflow.dispatch_event is whitelisted and resolves to the tool module" do
+    assert Registry.valid_tool_key?("workflow.dispatch_event")
+
+    assert {:ok, [Zaq.Agent.Tools.Workflow.DispatchEvent]} =
+             Registry.resolve_modules(["workflow.dispatch_event"])
+  end
+
+  test "an agent calls the dispatch_event tool and the event reaches the engine" do
+    handler = fn conn, body ->
+      payload = Jason.decode!(body)
+
+      # The follow-up request carries the tool's output; answer with final text.
+      has_tool_output =
+        body =~ "function_call_output" or
+          Enum.any?(
+            Map.get(payload, "input", []),
+            &match?(%{"type" => "function_call_output"}, &1)
+          )
+
+      if has_tool_output do
+        {200, streamed_reply(conn.request_path, "Done — lead dispatched.", "gpt-4.1-mini")}
+      else
+        {200,
+         tool_call_reply(
+           conn.request_path,
+           "dispatch_event",
+           ~s({"event_name":"lead_identified","input":{"email":"lead@acme.com"}}),
+           "gpt-4.1-mini"
+         )}
+      end
+    end
+
+    {child_spec, endpoint} = OpenAIStub.server(handler, self())
+    start_supervised!(child_spec)
+
+    credential =
+      ai_credential_fixture(%{
+        name: "Dispatch Event Agent Credential #{System.unique_integer([:positive, :monotonic])}",
+        provider: "openai",
+        endpoint: endpoint,
+        api_key: "test-key"
+      })
+
+    {:ok, agent} =
+      Agent.create_agent(%{
+        name: "Dispatch Event Agent #{System.unique_integer([:positive])}",
+        description: "",
+        job: "Use the dispatch_event tool to dispatch a lead_identified event, then answer.",
+        model: "gpt-4.1-mini",
+        credential_id: credential.id,
+        strategy: "react",
+        enabled_tool_keys: ["workflow.dispatch_event"],
+        conversation_enabled: false,
+        active: true,
+        advanced_options: %{"stream" => false}
+      })
+
+    on_exit(fn -> _ = ServerManager.stop_server(agent) end)
+
+    incoming = %Incoming{content: "dispatch a lead", channel_id: "bo-test", provider: :web}
+
+    outgoing =
+      Executor.run(incoming,
+        agent_id: to_string(agent.id),
+        node_router: CaptureRouter,
+        status_module: StubStatus
+      )
+
+    assert is_binary(outgoing.body)
+
+    # The tool actually dispatched the event to the engine via the injected router.
+    assert_receive {:dispatched, %Event{name: "lead_identified"} = event}, 2_000
+    assert event.next_hop.destination == :engine
+    assert event.request == %{"email" => "lead@acme.com"}
+  end
+
+  # ── OpenAI Responses-API stub helpers (mirrors the channels/agent suites) ──────
+
+  defp streamed_reply("/v1/chat/completions", text, model) do
+    chunk =
+      Jason.encode!(%{
+        "id" => "chatcmpl-test",
+        "object" => "chat.completion.chunk",
+        "model" => model,
+        "choices" => [%{"index" => 0, "delta" => %{"content" => text}, "finish_reason" => nil}]
+      })
+
+    done_chunk =
+      Jason.encode!(%{
+        "id" => "chatcmpl-test",
+        "object" => "chat.completion.chunk",
+        "model" => model,
+        "choices" => [%{"index" => 0, "delta" => %{}, "finish_reason" => "stop"}],
+        "usage" => %{"prompt_tokens" => 5, "completion_tokens" => 1, "total_tokens" => 6}
+      })
+
+    "data: #{chunk}\n\ndata: #{done_chunk}\n\ndata: [DONE]\n\n"
+  end
+
+  defp streamed_reply(_path, text, model) do
+    delta_event = Jason.encode!(%{"delta" => text})
+
+    completed_event =
+      Jason.encode!(%{
+        "response" => %{
+          "id" => "resp_test",
+          "model" => model,
+          "usage" => %{"input_tokens" => 5, "output_tokens" => 1, "total_tokens" => 6}
+        }
+      })
+
+    [
+      "event: response.output_text.delta\n",
+      "data: #{delta_event}\n\n",
+      "event: response.completed\n",
+      "data: #{completed_event}\n\n"
+    ]
+    |> IO.iodata_to_binary()
+  end
+
+  defp tool_call_reply("/v1/chat/completions", _tool_name, _arguments_json, model) do
+    done_chunk =
+      Jason.encode!(%{
+        "id" => "chatcmpl-tool",
+        "object" => "chat.completion.chunk",
+        "model" => model,
+        "choices" => [%{"index" => 0, "delta" => %{}, "finish_reason" => "tool_calls"}]
+      })
+
+    "data: #{done_chunk}\n\ndata: [DONE]\n\n"
+  end
+
+  defp tool_call_reply(_path, tool_name, arguments_json, model) do
+    # `output_item.added` registers the tool call with `expects_arg_fragments`;
+    # ReqLLM then accumulates the arguments from the streamed
+    # `function_call_arguments.delta` events (matched by `output_index`). Inlining
+    # arguments only on the item/completed output is NOT enough — they are lost.
+    output_item =
+      Jason.encode!(%{
+        "output_index" => 0,
+        "item" => %{
+          "type" => "function_call",
+          "call_id" => "call_dispatch_1",
+          "id" => "call_dispatch_1",
+          "name" => tool_name,
+          "arguments" => ""
+        }
+      })
+
+    args_delta =
+      Jason.encode!(%{
+        "output_index" => 0,
+        "item_id" => "call_dispatch_1",
+        "delta" => arguments_json
+      })
+
+    args_done =
+      Jason.encode!(%{
+        "output_index" => 0,
+        "item_id" => "call_dispatch_1",
+        "arguments" => arguments_json
+      })
+
+    completed_event =
+      Jason.encode!(%{
+        "response" => %{
+          "id" => "resp_tool_1",
+          "model" => model,
+          "status" => "completed",
+          "output" => [
+            %{
+              "type" => "function_call",
+              "id" => "call_dispatch_1",
+              "name" => tool_name,
+              "arguments" => arguments_json
+            }
+          ],
+          "usage" => %{"input_tokens" => 5, "output_tokens" => 1, "total_tokens" => 6}
+        }
+      })
+
+    [
+      "event: response.output_item.added\n",
+      "data: #{output_item}\n\n",
+      "event: response.function_call_arguments.delta\n",
+      "data: #{args_delta}\n\n",
+      "event: response.function_call_arguments.done\n",
+      "data: #{args_done}\n\n",
+      "event: response.completed\n",
+      "data: #{completed_event}\n\n"
+    ]
+    |> IO.iodata_to_binary()
+  end
+end

--- a/test/zaq/agent/tools/workflow/dispatch_event_test.exs
+++ b/test/zaq/agent/tools/workflow/dispatch_event_test.exs
@@ -39,6 +39,117 @@ defmodule Zaq.Agent.Tools.Workflow.DispatchEventTest do
       assert event.name == "lead_identified"
     end
 
+    test "dispatches an empty request when no input is given" do
+      assert {:ok, %{dispatched: %{}}} =
+               DispatchEvent.run(%{event_name: "lead_identified"}, @ctx)
+
+      assert_received {:dispatched, %Event{} = event}
+      assert event.request == %{}
+      assert event.name == "lead_identified"
+    end
+
+    test "treats nil input as an empty request" do
+      assert {:ok, %{dispatched: %{}}} =
+               DispatchEvent.run(%{input: nil, event_name: "lead_identified"}, @ctx)
+    end
+
+    test "dispatches a scalar input verbatim as the request" do
+      assert {:ok, %{dispatched: "seeds ready"}} =
+               DispatchEvent.run(
+                 %{input: "seeds ready", event_name: "notify_channel", destination: "channels"},
+                 @ctx
+               )
+
+      assert_received {:dispatched, %Event{} = event}
+      assert event.request == "seeds ready"
+      assert event.next_hop.destination == :channels
+    end
+
+    test "a scalar input bypasses the cascade merge" do
+      ctx = Map.put(@ctx, :__cascade__, %{"step_a" => %{"foo" => 1}})
+
+      assert {:ok, %{dispatched: "just this"}} =
+               DispatchEvent.run(%{input: "just this", event_name: "notify_channel"}, ctx)
+    end
+
+    test "defaults the destination to :engine when not set" do
+      assert {:ok, _} = DispatchEvent.run(%{event_name: "lead_identified"}, @ctx)
+
+      assert_received {:dispatched, %Event{} = event}
+      assert event.next_hop.destination == :engine
+    end
+
+    test "routes to an explicit destination role" do
+      assert {:ok, _} =
+               DispatchEvent.run(
+                 %{event_name: "lead_identified", destination: "agent"},
+                 @ctx
+               )
+
+      assert_received {:dispatched, %Event{} = event}
+      assert event.next_hop.destination == :agent
+    end
+
+    test "accepts an atom destination" do
+      assert {:ok, _} =
+               DispatchEvent.run(
+                 %{event_name: "lead_identified", destination: :channels},
+                 @ctx
+               )
+
+      assert_received {:dispatched, %Event{} = event}
+      assert event.next_hop.destination == :channels
+    end
+
+    test "rejects an unknown destination before dispatching" do
+      assert {:error, reason} =
+               DispatchEvent.run(
+                 %{event_name: "lead_identified", destination: "mars"},
+                 @ctx
+               )
+
+      assert reason =~ "unsupported destination"
+      refute_received {:dispatched, _}
+    end
+
+    test "dispatches the merged outputs of prior steps from the cascade" do
+      ctx =
+        Map.put(@ctx, :__cascade__, %{
+          "step_a" => %{"foo" => 1, :nested => %{"x" => true}},
+          "step_b" => %{bar: 2}
+        })
+
+      assert {:ok, %{dispatched: dispatched}} =
+               DispatchEvent.run(%{event_name: "lead_identified"}, ctx)
+
+      assert dispatched == %{"foo" => 1, "nested" => %{"x" => true}, "bar" => 2}
+    end
+
+    test "drops engine-internal plumbing keys from the cascade" do
+      ctx =
+        Map.put(@ctx, :__cascade__, %{
+          "step_a" => %{"keep" => 1, :__cascade__ => %{}, "__map_index__" => 3}
+        })
+
+      assert {:ok, %{dispatched: %{"keep" => 1} = dispatched}} =
+               DispatchEvent.run(%{event_name: "lead_identified"}, ctx)
+
+      refute Map.has_key?(dispatched, "__cascade__")
+      refute Map.has_key?(dispatched, "__map_index__")
+    end
+
+    test "explicit input is layered on top of prior outputs and wins on conflicts" do
+      ctx = Map.put(@ctx, :__cascade__, %{"step_a" => %{"foo" => 1, "bar" => 2}})
+
+      assert {:ok, %{dispatched: dispatched}} =
+               DispatchEvent.run(
+                 %{input: %{"bar" => 99, "extra" => "added"}, event_name: "lead_identified"},
+                 ctx
+               )
+
+      assert dispatched == %{"foo" => 1, "bar" => 99, "extra" => "added"}
+    end
+
     test "stringifies atom-keyed input" do
       input = %{email: "a@b.com", active: true}
 
@@ -101,31 +212,40 @@ defmodule Zaq.Agent.Tools.Workflow.DispatchEventTest do
       refute Map.has_key?(dispatched, "machine")
     end
 
-    test "rejects non-allowlisted event names" do
-      assert {:error, reason} =
+    test "dispatches any event name — there is no allowlist" do
+      assert {:ok, %{dispatched: %{}}} =
                DispatchEvent.run(%{input: %{}, event_name: "any_event_name_works"}, @ctx)
 
-      assert reason =~ "unsupported event_name"
-      assert reason =~ "lead_identified"
+      assert_received {:dispatched, %Event{} = event}
+      assert event.name == "any_event_name_works"
+    end
+
+    test "rejects a blank event name" do
+      assert {:error, reason} =
+               DispatchEvent.run(%{input: %{}, event_name: "   "}, @ctx)
+
+      assert reason =~ "must not be blank"
     end
   end
 
   describe "schema/0" do
-    test "does not expose arbitrary destination or hop type controls" do
+    test "exposes input, event_name, destination and machine, but no raw hop controls" do
       keys = Keyword.keys(DispatchEvent.schema())
 
       assert :input in keys
       assert :event_name in keys
+      assert :destination in keys
       assert :machine in keys
-      refute :destination in keys
+      # The raw event-struct name and hop type stay internal.
       refute :name in keys
       refute :type in keys
     end
-  end
 
-  describe "allowed_event_names/0" do
-    test "returns the workflow event allowlist" do
-      assert DispatchEvent.allowed_event_names() == ["lead_identified"]
+    test "destination is optional and defaults to \"engine\"" do
+      destination_opts = Keyword.fetch!(DispatchEvent.schema(), :destination)
+
+      refute destination_opts[:required]
+      assert destination_opts[:default] == "engine"
     end
   end
 end

--- a/test/zaq/engine/workflows/dispatch_event_workflow_test.exs
+++ b/test/zaq/engine/workflows/dispatch_event_workflow_test.exs
@@ -1,0 +1,278 @@
+defmodule Zaq.Engine.Workflows.DispatchEventWorkflowTest do
+  @moduledoc """
+  Exercises `DispatchEvent` in three shapes within a single workflow run:
+
+    1. As a plain second node with **no `input` mapping** — it forwards the merged
+       outputs of every prior step (the run's cascade). Reaches `:engine`.
+    2. Inside a `Batch` body **with a per-item `input`** — each fan-out fork
+       dispatches its own item. Reaches `:engine`.
+    3. As a node with an explicit **`destination: "channels"`** and a string
+       message `input`. Reaches `:channels`.
+
+  Each dispatch must reach the correct node role with the correct request payload.
+
+  The real `DispatchEvent` defaults to the live `Zaq.NodeRouter`, so a
+  `BridgeDispatchEvent` wrapper injects the Mox router (whose stub captures every
+  dispatched event) while delegating all request/machine logic to the production
+  tool. `async: false` because the batch runs in `Task` children sharing the Ecto
+  sandbox.
+  """
+  use Zaq.DataCase, async: false
+
+  import Mox
+
+  alias Zaq.Agent.Tools.Workflow.DispatchEvent
+  alias Zaq.Engine.Workflows
+
+  @batch_module "Zaq.Agent.Tools.Workflow.Batch"
+
+  # ── Inline step modules ────────────────────────────────────────────────────────
+
+  # First node: emits facts the second (no-input) DispatchEvent node forwards.
+  defmodule SeedLead do
+    @moduledoc false
+    use Zaq.Engine.Workflows.Action,
+      name: "seed_lead",
+      description: "Emit a readiness fact plus a payload field.",
+      schema: [count: [type: :integer, required: false, default: 1, doc: "Unused."]],
+      output_schema: [
+        ready: [type: :boolean, required: true, doc: "Always true."],
+        lead_id: [type: :integer, required: true, doc: "A payload field to forward."]
+      ]
+
+    @impl Jido.Action
+    def run(_params, _ctx), do: {:ok, %{ready: true, lead_id: 7}}
+  end
+
+  # Emits the fixed list of items the batch fans out over.
+  defmodule SeedItems do
+    @moduledoc false
+    use Zaq.Engine.Workflows.Action,
+      name: "seed_items",
+      description: "Emit a fixed list of items to fan out over.",
+      schema: [count: [type: :integer, required: false, default: 3, doc: "How many items."]],
+      output_schema: [items: [type: {:list, :map}, required: true, doc: "Items to dispatch."]]
+
+    @impl Jido.Action
+    def run(params, _ctx) do
+      count = Map.get(params, :count, 3)
+
+      items =
+        Enum.map(1..count, fn i ->
+          %{"id" => i, "email" => "user#{i}@example.com", "name" => "User #{i}"}
+        end)
+
+      {:ok, %{items: items}}
+    end
+  end
+
+  # Identity step: one required `input` makes it the batch's fan-out field, and
+  # forwarding `input` lets the downstream DispatchEvent send it as the payload.
+  defmodule PrepareItem do
+    @moduledoc false
+    use Zaq.Engine.Workflows.Action,
+      name: "prepare_item",
+      description: "Pass a single batch item through as `input`.",
+      schema: [input: [type: :map, required: true, doc: "One item from the batch."]],
+      output_schema: [input: [type: :map, required: true, doc: "The item, unchanged."]]
+
+    @impl Jido.Action
+    def run(%{input: input}, _ctx), do: {:ok, %{input: input}}
+  end
+
+  # Routes the real DispatchEvent through the Mox router so events are captured
+  # without hitting the live engine node. `input` is optional (as in production).
+  defmodule BridgeDispatchEvent do
+    @moduledoc false
+    use Zaq.Engine.Workflows.Action,
+      name: "bridge_dispatch_event",
+      schema: [
+        input: [type: :any, required: false, default: %{}],
+        event_name: [type: :string, required: true],
+        destination: [type: :string, required: false, default: "engine"],
+        machine: [type: :boolean, required: false, default: false]
+      ],
+      output_schema: [dispatched: [type: :any, required: true]]
+
+    @impl Jido.Action
+    def run(params, ctx) do
+      DispatchEvent.run(params, Map.put(ctx, :node_router, Zaq.NodeRouterMock))
+    end
+  end
+
+  # ── Setup ──────────────────────────────────────────────────────────────────────
+
+  setup do
+    test_pid = self()
+
+    Mox.set_mox_global()
+
+    # Capture every dispatched event, regardless of name.
+    stub(Zaq.NodeRouterMock, :dispatch, fn event ->
+      send(test_pid, {:dispatched, event})
+      event
+    end)
+
+    :ok
+  end
+
+  # ── Test ───────────────────────────────────────────────────────────────────────
+
+  test "dispatches from a no-input second node, a per-item batch, and a channels node to the right destinations" do
+    {:ok, workflow} = Workflows.create_workflow(build())
+
+    source_event = %{
+      "request" => nil,
+      "assigns" => %{"trigger_type" => "manual", "input" => %{}},
+      "trace_id" => Ecto.UUID.generate()
+    }
+
+    assert {:ok, run} = Workflows.create_and_start_run(workflow, source_event)
+    assert run.status == "completed"
+
+    events = drain_dispatched([])
+
+    # ── Step 1: the no-input second node forwards the prior step's outputs ──────
+    lead_ready = Enum.filter(events, &(&1.name == "lead_ready"))
+    assert length(lead_ready) == 1
+    [ready_event] = lead_ready
+
+    assert ready_event.next_hop.destination == :engine
+    assert ready_event.next_hop.type == :async
+    # No `input` mapping → the request is exactly `seed_lead`'s output.
+    assert ready_event.request == %{"ready" => true, "lead_id" => 7}
+
+    # ── Step 2: the batch dispatches one event per item, each with its payload ──
+    lead_identified = Enum.filter(events, &(&1.name == "lead_identified"))
+    assert length(lead_identified) == 3, "expected one lead_identified event per item"
+
+    for event <- lead_identified do
+      assert event.next_hop.destination == :engine
+      assert event.next_hop.type == :async
+    end
+
+    # Each per-item event carries its own item payload (distinct ids 1..3).
+    by_id =
+      Map.new(lead_identified, fn event -> {event.request["id"], event.request} end)
+
+    assert Map.keys(by_id) |> Enum.sort() == [1, 2, 3]
+
+    for i <- 1..3 do
+      req = by_id[i]
+      assert req["id"] == i
+      assert req["email"] == "user#{i}@example.com"
+      assert req["name"] == "User #{i}"
+      # The batch node set `machine: true` — the marker rides on each dispatch.
+      assert req["machine"] == true
+    end
+
+    # The no-input second-node dispatch carried no machine marker.
+    refute Map.has_key?(ready_event.request, "machine")
+
+    # ── Step 3: the channels dispatch routes to :channels with a string message ─
+    channel_events = Enum.filter(events, &(&1.name == "notify_channel"))
+    assert length(channel_events) == 1
+    [channel_event] = channel_events
+
+    assert channel_event.next_hop.destination == :channels
+    assert channel_event.next_hop.type == :async
+    # The scalar `input` is dispatched verbatim — the request IS the string, not a map.
+    assert channel_event.request == "seeds ready"
+    assert is_binary(channel_event.request)
+  end
+
+  # ── Workflow definition ─────────────────────────────────────────────────────────
+  #
+  #   seed_lead ──(ready eq true)──> dispatch_lead        (DispatchEvent, no input)
+  #   dispatch_lead ──(dispatched not_empty)──> seed_items
+  #   seed_items ──(items not_empty, items→items)──> process_items  (Batch)
+  #       process: [prepare_item, dispatch_item]          (DispatchEvent, per-item input)
+  #   seed_items ──(items not_empty)──> dispatch_channel  (DispatchEvent, destination: channels)
+  defp build do
+    %{
+      name: "Dispatch Event Workflow",
+      description: "A no-input second-node dispatch and a per-item batch dispatch.",
+      status: "active",
+      nodes: [
+        %{name: "seed_lead", type: "action", module: inspect(SeedLead), params: %{}, index: 0},
+        %{
+          name: "dispatch_lead",
+          type: "action",
+          module: inspect(BridgeDispatchEvent),
+          params: %{"event_name" => "lead_ready"},
+          index: 1
+        },
+        %{name: "seed_items", type: "action", module: inspect(SeedItems), params: %{}, index: 2},
+        %{
+          name: "process_items",
+          type: "action",
+          module: @batch_module,
+          params: %{
+            "delivery" => "item",
+            "strategy" => "skip_and_continue",
+            "batch_size" => 5,
+            "process" => [
+              %{
+                "name" => "prepare_item",
+                "type" => "action",
+                "module" => inspect(PrepareItem),
+                "params" => %{}
+              },
+              %{
+                "name" => "dispatch_item",
+                "type" => "action",
+                "module" => inspect(BridgeDispatchEvent),
+                "params" => %{"event_name" => "lead_identified", "machine" => true}
+              }
+            ]
+          },
+          index: 3
+        },
+        %{
+          name: "dispatch_channel",
+          type: "action",
+          module: inspect(BridgeDispatchEvent),
+          # Routed to the channels node with a bare string payload (not a map) —
+          # a scalar `input` is dispatched verbatim as the request.
+          params: %{
+            "event_name" => "notify_channel",
+            "destination" => "channels",
+            "input" => "seeds ready"
+          },
+          index: 4
+        }
+      ],
+      edges: [
+        %{
+          from: "seed_lead",
+          to: "dispatch_lead",
+          condition: %{"field" => "ready", "op" => "eq", "value" => true}
+        },
+        %{
+          from: "dispatch_lead",
+          to: "seed_items",
+          condition: %{"field" => "dispatched", "op" => "not_empty"}
+        },
+        %{
+          from: "seed_items",
+          to: "process_items",
+          condition: %{"field" => "items", "op" => "not_empty"},
+          mapping: %{"items" => "items"}
+        },
+        %{
+          from: "seed_items",
+          to: "dispatch_channel",
+          condition: %{"field" => "items", "op" => "not_empty"}
+        }
+      ]
+    }
+  end
+
+  defp drain_dispatched(acc) do
+    receive do
+      {:dispatched, event} -> drain_dispatched([event | acc])
+    after
+      200 -> acc
+    end
+  end
+end

--- a/test/zaq/engine/workflows/dispatch_fifty_items_test.exs
+++ b/test/zaq/engine/workflows/dispatch_fifty_items_test.exs
@@ -1,0 +1,116 @@
+defmodule Zaq.Engine.Workflows.DispatchFiftyItemsTest do
+  @moduledoc """
+  Covers the `UseCases.DispatchFiftyItems` example: a 50-item list fanned out
+  through a `Batch` node, dispatching one `lead_identified` event per item.
+
+  The real `DispatchEvent` defaults to the live `Zaq.NodeRouter`, which the
+  `StepRunner` does not override. A `BridgeDispatchEvent` wrapper injects the Mox
+  router (whose stub captures each dispatched event) while delegating all real
+  request/machine logic to the production tool — the same seam the lead-pipeline
+  e2e test uses. Runs `async: false` because the batch executes in `Task` children
+  that share the Ecto sandbox.
+  """
+  use Zaq.DataCase, async: false
+
+  alias Zaq.Agent.Tools.Workflow.DispatchEvent
+  alias Zaq.Engine.Workflows
+  alias Zaq.Engine.Workflows.UseCases.DispatchFiftyItems
+
+  # Routes the real DispatchEvent through the Mox router so the dispatched events
+  # can be captured, without hitting the live engine node.
+  defmodule BridgeDispatchEvent do
+    @moduledoc false
+    use Zaq.Engine.Workflows.Action,
+      name: "bridge_dispatch_event",
+      schema: [
+        input: [type: :map, required: true],
+        event_name: [type: :string, required: true],
+        machine: [type: :boolean, required: false, default: false]
+      ],
+      output_schema: [dispatched: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(params, ctx) do
+      DispatchEvent.run(params, Map.put(ctx, :node_router, Zaq.NodeRouterMock))
+    end
+  end
+
+  setup do
+    test_pid = self()
+
+    Mox.set_mox_global()
+
+    stub(Zaq.NodeRouterMock, :dispatch, fn event ->
+      if event.name == "lead_identified", do: send(test_pid, {:dispatched, event})
+      event
+    end)
+
+    :ok
+  end
+
+  test "seeds 50 items, fans out via Batch, and dispatches one event per item" do
+    build = swap_dispatch_module(DispatchFiftyItems.build())
+
+    {:ok, workflow} = Workflows.create_workflow(build)
+
+    source_event = %{
+      "request" => nil,
+      "assigns" => %{"trigger_type" => "manual", "input" => %{}},
+      "trace_id" => Ecto.UUID.generate()
+    }
+
+    assert {:ok, run} = Workflows.create_and_start_run(workflow, source_event)
+    assert run.status == "completed"
+
+    dispatched = drain_dispatched([])
+
+    assert length(dispatched) == 50, "expected one lead_identified event per item"
+
+    # Every dispatched event carries its item payload (the 50 distinct ids).
+    ids =
+      dispatched
+      |> Enum.map(fn event ->
+        req = event.request || %{}
+        Map.get(req, "id") || Map.get(req, :id)
+      end)
+      |> Enum.sort()
+
+    assert ids == Enum.to_list(1..50)
+  end
+
+  test "build/0 is a persistable, valid workflow definition" do
+    assert {:ok, workflow} = Workflows.create_workflow(DispatchFiftyItems.build())
+    assert workflow.status == "active"
+    assert Enum.any?(workflow.nodes, &(&1.name == "process_items"))
+  end
+
+  # Point the batch body's dispatch step at the bridge so dispatches hit the Mox
+  # router; everything else stays the production definition.
+  defp swap_dispatch_module(build) do
+    nodes =
+      Enum.map(build.nodes, fn node ->
+        if node.name == "process_items", do: patch_batch(node), else: node
+      end)
+
+    %{build | nodes: nodes}
+  end
+
+  defp patch_batch(node) do
+    process =
+      Enum.map(node.params["process"], fn bnode ->
+        if bnode["name"] == "dispatch_item",
+          do: Map.put(bnode, "module", inspect(BridgeDispatchEvent)),
+          else: bnode
+      end)
+
+    %{node | params: Map.put(node.params, "process", process)}
+  end
+
+  defp drain_dispatched(acc) do
+    receive do
+      {:dispatched, event} -> drain_dispatched([event | acc])
+    after
+      0 -> acc
+    end
+  end
+end

--- a/test/zaq/engine/workflows/steps/batch_sequential_timing_test.exs
+++ b/test/zaq/engine/workflows/steps/batch_sequential_timing_test.exs
@@ -29,7 +29,7 @@ defmodule Zaq.Engine.Workflows.Steps.BatchSequentialTimingTest do
   @sleep_module "Zaq.Agent.Tools.Workflow.Sleep"
 
   @item_count 3
-  @sleep_ms 2_000
+  @sleep_ms 200
 
   @source_event %{
     "request" => nil,


### PR DESCRIPTION
fix #538 