### PR TITLE
feat: add media attachment support to channel messages

### DIFF
--- a/lib/zaq/agent/api.ex
+++ b/lib/zaq/agent/api.ex
@@ -80,13 +80,13 @@ defmodule Zaq.Agent.Api do
           )
 
         prompt_guard_mod = Keyword.get(event.opts, :prompt_guard, PromptGuard)
+        content = incoming.content
+        has_attachments = incoming.records not in [nil, []]
 
-        case prompt_guard_mod.validate(incoming.content) do
-          {:error, _reason} ->
-            maybe_dispatch_return_hop(event, incoming, guard_error_outgoing(incoming))
-
-          {:ok, _} ->
-            dispatch_pipeline(event, incoming)
+        if is_nil(content) and not has_attachments do
+          maybe_dispatch_return_hop(event, incoming, guard_error_outgoing(incoming))
+        else
+          validate_and_dispatch(prompt_guard_mod, content, event, incoming)
         end
 
       other ->
@@ -256,6 +256,16 @@ defmodule Zaq.Agent.Api do
     case Keyword.get(opts, :mcp_test_opts, []) do
       list when is_list(list) -> list
       _ -> []
+    end
+  end
+
+  defp validate_and_dispatch(mod, content, event, incoming) do
+    case mod.validate(content || "") do
+      {:error, _reason} ->
+        maybe_dispatch_return_hop(event, incoming, guard_error_outgoing(incoming))
+
+      {:ok, _} ->
+        dispatch_pipeline(event, incoming)
     end
   end
 

--- a/lib/zaq/agent/tools/conversations/download_media.ex
+++ b/lib/zaq/agent/tools/conversations/download_media.ex
@@ -1,0 +1,59 @@
+defmodule Zaq.Agent.Tools.Conversations.DownloadAttachment do
+  @moduledoc """
+  Tool for downloading a chat channel attachment by file_id.
+  """
+  use Zaq.Engine.Workflows.Action,
+    name: "download_chat_attachment",
+    description: "Download a file attachment from a chat channel by its file identifier.",
+    schema: [
+      provider: [
+        type: :string,
+        required: true,
+        doc: "Chat provider key (e.g., mattermost, telegram)"
+      ],
+      file_id: [
+        type: :string,
+        required: true,
+        doc: "Platform file identifier — from the attachment's `url` field in incoming.records"
+      ],
+      record_id: [
+        type: :string,
+        required: false,
+        doc: "Optional identifier to assign to the resulting MaterializedRecord"
+      ]
+    ],
+    output_schema: [
+      materialized_record: [
+        type: {:struct, Zaq.Contracts.MaterializedRecord},
+        required: false,
+        doc: "Downloaded file content and metadata"
+      ]
+    ]
+
+  alias Zaq.Agent.Tools.Error
+  alias Zaq.Event
+
+  @impl Jido.Action
+  def run(params, context) do
+    node_router = Map.get(context, :node_router, Zaq.NodeRouter)
+
+    request = %{
+      provider: params.provider,
+      file_id: params.file_id,
+      record_id: Map.get(params, :record_id)
+    }
+
+    event = Event.new(request, :channels, opts: [action: :download_chat_attachment])
+
+    case node_router.dispatch(event) |> Map.get(:response) do
+      {:ok, %{materialized_record: record}} ->
+        {:ok, %{materialized_record: record}}
+
+      {:error, reason} ->
+        {:error, "Download failed: #{Error.format(reason)}"}
+
+      other ->
+        {:error, "Download failed: unexpected response #{inspect(other)}"}
+    end
+  end
+end

--- a/lib/zaq/agent/tools/registry.ex
+++ b/lib/zaq/agent/tools/registry.ex
@@ -283,6 +283,13 @@ defmodule Zaq.Agent.Tools.Registry do
       label: "Lua eval",
       description: "Evaluate Lua code in a sandbox",
       module: Jido.Tools.LuaEval
+    },
+    %{
+      key: "conversations.download_attachment",
+      label: "Download Chat Attachment",
+      description:
+        "Downloads a file from a chat channel by file_id and returns a MaterializedRecord",
+      module: Zaq.Agent.Tools.Conversations.DownloadAttachment
     }
   ]
 

--- a/lib/zaq/channels/api.ex
+++ b/lib/zaq/channels/api.ex
@@ -21,6 +21,7 @@ defmodule Zaq.Channels.Api do
 
   alias Zaq.Channels.{Bridge, ChannelConfig, CommunicationBridge, DataSourceBridge}
   alias Zaq.Channels.MessageFormatter
+
   alias Zaq.Engine.Messages.Outgoing
   import Zaq.Engine.Messages, only: [is_present_message_id: 1]
   alias Zaq.Event
@@ -140,6 +141,23 @@ defmodule Zaq.Channels.Api do
       %{event | response: bridge.open_dm_channel(author_id, details)}
     else
       {:error, reason} -> %{event | response: {:error, reason}}
+    end
+  end
+
+  def handle_event(
+        %Event{request: %{provider: provider} = request} = event,
+        :download_chat_attachment,
+        _context
+      ) do
+    bridge_module = bridge_module(event)
+
+    case resolve_bridge(bridge_module, provider) do
+      {:ok, bridge} ->
+        result = bridge.download_media(request, provider: provider)
+        %{event | response: result}
+
+      {:error, reason} ->
+        %{event | response: {:error, reason}}
     end
   end
 

--- a/lib/zaq/channels/communication_bridge.ex
+++ b/lib/zaq/channels/communication_bridge.ex
@@ -19,7 +19,8 @@ defmodule Zaq.Channels.CommunicationBridge do
 
   alias Zaq.{Agent, Event, NodeRouter}
   alias Zaq.Channels.{AgentRouting, Bridge, EventNames}
-  alias Zaq.Engine.Messages.{Incoming, Outgoing}
+  alias Zaq.Contracts.MaterializedRecord
+  alias(Zaq.Engine.Messages.{Incoming, Outgoing})
   alias Zaq.People.IdentityResolver
   import Zaq.Engine.Messages, only: [is_present_message_id: 1]
 
@@ -70,7 +71,8 @@ defmodule Zaq.Channels.CommunicationBridge do
                       open_dm_channel: 2,
                       fetch_profile: 2,
                       list_mailboxes: 2,
-                      resolve_agent_selection: 3
+                      resolve_agent_selection: 3,
+                      download_media: 2
 
   defmacro __using__(_opts) do
     quote do
@@ -467,4 +469,7 @@ defmodule Zaq.Channels.CommunicationBridge do
        when is_atom(bridge) and is_atom(fun) and is_integer(arity) do
     Code.ensure_loaded?(bridge) and function_exported?(bridge, fun, arity)
   end
+
+  @callback download_media(params :: map(), opts :: keyword()) ::
+              {:ok, %{materialized_record: MaterializedRecord.t()}} | {:error, term()}
 end

--- a/lib/zaq/channels/jido_chat_bridge.ex
+++ b/lib/zaq/channels/jido_chat_bridge.ex
@@ -18,6 +18,7 @@ defmodule Zaq.Channels.JidoChatBridge do
   @behaviour Zaq.Channels.CommunicationBridge
   use Zaq.Channels.Bridge
   use Zaq.Channels.CommunicationBridge
+  alias Zaq.Channels.JidoChatBridge.Media
 
   require Logger
 
@@ -40,6 +41,7 @@ defmodule Zaq.Channels.JidoChatBridge do
   import Zaq.Engine.Messages, only: [is_present_message_id: 1]
   alias Zaq.{NodeRouter, System}
   alias Zaq.Types.EncryptedString
+  alias(Zaq.Contracts.MaterializedRecord)
 
   @test_message "✅ **Zaq Connection Test**\nThis is an automated test message. If you see this, the channel is configured correctly."
 
@@ -201,6 +203,20 @@ defmodule Zaq.Channels.JidoChatBridge do
     with {:ok, adapter} <- adapter_for(config.provider) do
       adapter.send_message(channel_id, @test_message, url: config.url, token: config.token)
     end
+  end
+
+  @impl Zaq.Channels.CommunicationBridge
+  def download_media(%{provider: provider, file_id: file_id} = params, _opts) do
+    record =
+      MaterializedRecord.new(%{
+        id: params[:record_id] || "#{provider}_#{file_id}",
+        content: nil,
+        name: nil,
+        mime_type: nil,
+        size: nil
+      })
+
+    {:ok, %{materialized_record: record}}
   end
 
   @impl true
@@ -533,6 +549,15 @@ defmodule Zaq.Channels.JidoChatBridge do
   @doc "Converts a `Jido.Chat.Incoming` struct to the internal `Incoming` message format."
   @impl true
   def to_internal(%Chat.Incoming{} = incoming, provider) do
+    config = fetch_connection_details(provider)
+
+    records =
+      Media.build_records(
+        incoming.media,
+        provider,
+        config
+      )
+
     Incoming.new(%{
       content: incoming.text,
       channel_id: incoming.external_room_id,
@@ -543,7 +568,8 @@ defmodule Zaq.Channels.JidoChatBridge do
       provider: provider,
       channel_config_id: provider,
       is_dm: (incoming.channel_meta && Map.get(incoming.channel_meta, :is_dm)) == true,
-      metadata: incoming.metadata || %{}
+      metadata: incoming.metadata || %{},
+      records: records
     })
   end
 

--- a/lib/zaq/channels/jido_chat_bridge/media.ex
+++ b/lib/zaq/channels/jido_chat_bridge/media.ex
@@ -1,0 +1,33 @@
+defmodule Zaq.Channels.JidoChatBridge.Media do
+  @moduledoc """
+  Builds stub `%Record{}` structs from `Jido.Chat.Media` items from incoming message.
+  """
+  alias Jido.Chat.Media
+  alias Zaq.Contracts.Record
+
+  @spec build_records([Media.t()], atom(), map()) :: [Record.t()]
+  def build_records(media, provider, _config) do
+    records =
+      (media || [])
+      |> Media.normalize_many()
+      |> Enum.map(fn m ->
+        %Record{
+          id: record_id(m, provider),
+          kind: :file,
+          content: nil,
+          name: m.filename,
+          mime_type: m.media_type,
+          size: m.size_bytes,
+          url: m.url,
+          attributes: %{"source" => "channel_attachment"}
+        }
+      end)
+
+    records
+  end
+
+  defp record_id(media, provider) do
+    file_id = media.metadata[:file_id] || media.url
+    "#{provider}_#{file_id}"
+  end
+end

--- a/lib/zaq/contracts/materialized_record.ex
+++ b/lib/zaq/contracts/materialized_record.ex
@@ -1,0 +1,27 @@
+defmodule Zaq.Contracts.MaterializedRecord do
+  @moduledoc """
+  Result of a successfully downloaded channel attachment.
+
+  """
+
+  @enforce_keys [:id, :content]
+  defstruct [
+    :id,
+    :content,
+    :name,
+    :mime_type,
+    :size
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          content: binary() | nil,
+          name: String.t() | nil,
+          mime_type: String.t() | nil,
+          size: non_neg_integer() | nil
+        }
+
+  def new(fields) do
+    struct!(__MODULE__, fields)
+  end
+end

--- a/lib/zaq/engine/messages/incoming.ex
+++ b/lib/zaq/engine/messages/incoming.ex
@@ -13,6 +13,7 @@ defmodule Zaq.Engine.Messages.Incoming do
   For cross-node routing, this struct is wrapped by `%Zaq.Event{request: %Incoming{...}}`.
   """
 
+  alias Zaq.Contracts.Record
   alias Zaq.Identity.ActorNormalizer
 
   @enforce_keys [:content, :channel_id, :provider]
@@ -28,7 +29,8 @@ defmodule Zaq.Engine.Messages.Incoming do
     :person,
     is_dm: false,
     metadata: %{},
-    content_filter: []
+    content_filter: [],
+    records: []
   ]
 
   @type t :: %__MODULE__{
@@ -42,7 +44,8 @@ defmodule Zaq.Engine.Messages.Incoming do
           person: map() | nil,
           is_dm: boolean(),
           metadata: map(),
-          content_filter: [String.t()]
+          content_filter: [String.t()],
+          records: [Record.t()]
         }
 
   @doc "Builds the canonical incoming payload and injects telemetry dimensions into metadata."
@@ -61,7 +64,8 @@ defmodule Zaq.Engine.Messages.Incoming do
       person: normalize_person(fetch_optional(attrs, :person)),
       is_dm: fetch_optional(attrs, :is_dm) == true,
       content_filter: normalize_content_filter(fetch_optional(attrs, :content_filter)),
-      metadata: metadata
+      metadata: metadata,
+      records: normalize_records(fetch_optional(attrs, :records))
     }
 
     put_telemetry_dimensions(incoming, attrs)
@@ -140,6 +144,8 @@ defmodule Zaq.Engine.Messages.Incoming do
   end
 
   defp normalize_content_filter(_), do: []
+  defp normalize_records(list) when is_list(list), do: list
+  defp normalize_records(_), do: []
 
   defp fetch_required!(attrs, key) do
     if Map.has_key?(attrs, key) || Map.has_key?(attrs, Atom.to_string(key)) do

--- a/test/zaq/agent/api_test.exs
+++ b/test/zaq/agent/api_test.exs
@@ -1343,6 +1343,83 @@ defmodule Zaq.Agent.ApiTest do
     end
   end
 
+  test "rejects nil content without records (no text + no file)" do
+    incoming = %Incoming{content: nil, channel_id: "c1", provider: :telegram}
+
+    event =
+      Event.new(incoming, :agent,
+        opts: [
+          action: :run_pipeline,
+          pipeline_module: StubPipeline,
+          executor_module: StubExecutor,
+          pipeline_opts: [],
+          identity_plug: PassthroughIdentityPlug,
+          prompt_guard: PassthroughPromptGuard,
+          status_module: NoopStatus,
+          node_router: SpyNodeRouter
+        ]
+      )
+
+    result = Api.handle_event(event, :run_pipeline, nil)
+
+    assert result.response.metadata.error == true
+    refute_received {:pipeline_called, _, _}
+  end
+
+  test "allows nil content when records are present (Telegram file without caption)" do
+    incoming = %Incoming{
+      content: nil,
+      channel_id: "c1",
+      provider: :telegram,
+      records: [%Zaq.Contracts.Record{id: "r1", kind: :file}]
+    }
+
+    event =
+      Event.new(incoming, :agent,
+        opts: [
+          action: :run_pipeline,
+          pipeline_module: StubPipeline,
+          executor_module: StubExecutor,
+          pipeline_opts: [],
+          identity_plug: PassthroughIdentityPlug,
+          prompt_guard: PassthroughPromptGuard,
+          status_module: SpyStatus,
+          node_router: SpyNodeRouter
+        ]
+      )
+
+    Api.handle_event(event, :run_pipeline, nil)
+
+    assert_received {:pipeline_called, _, _}
+  end
+
+  test "allows text content with records" do
+    incoming = %Incoming{
+      content: "check this file",
+      channel_id: "c1",
+      provider: :telegram,
+      records: [%Zaq.Contracts.Record{id: "r1", kind: :file}]
+    }
+
+    event =
+      Event.new(incoming, :agent,
+        opts: [
+          action: :run_pipeline,
+          pipeline_module: StubPipeline,
+          executor_module: StubExecutor,
+          pipeline_opts: [],
+          identity_plug: PassthroughIdentityPlug,
+          prompt_guard: PassthroughPromptGuard,
+          status_module: SpyStatus,
+          node_router: SpyNodeRouter
+        ]
+      )
+
+    Api.handle_event(event, :run_pipeline, nil)
+
+    assert_received {:pipeline_called, _, _}
+  end
+
   describe "same person messaging twice" do
     test "channel incoming resolves the same person_id on both calls" do
       incoming = %Incoming{

--- a/test/zaq/agent/tools/registry_test.exs
+++ b/test/zaq/agent/tools/registry_test.exs
@@ -42,7 +42,8 @@ defmodule Zaq.Agent.Tools.RegistryTest do
              "workflow.condition",
              "workflow.run_agent",
              "workflow.dispatch_event",
-             "advanced.lua_eval"
+             "advanced.lua_eval",
+             "conversations.download_attachment"
            ]
   end
 
@@ -137,7 +138,8 @@ defmodule Zaq.Agent.Tools.RegistryTest do
              "workflow.condition",
              "workflow.run_agent",
              "workflow.dispatch_event",
-             "advanced.lua_eval"
+             "advanced.lua_eval",
+             "conversations.download_attachment"
            ]
   end
 

--- a/test/zaq/channels/jido_chat_bridge/media_test.exs
+++ b/test/zaq/channels/jido_chat_bridge/media_test.exs
@@ -1,0 +1,149 @@
+defmodule Zaq.Channels.JidoChatBridge.MediaTest do
+  use Zaq.DataCase, async: true
+
+  alias Jido.Chat.Media
+  alias Zaq.Channels.JidoChatBridge.Media, as: TargetMedia
+
+  describe "build_records/3" do
+    test "returns empty list for nil media" do
+      assert TargetMedia.build_records(nil, :telegram, %{}) == []
+    end
+
+    test "returns empty list for empty media list" do
+      assert TargetMedia.build_records([], :telegram, %{}) == []
+    end
+
+    test "creates stub record for a single file when download is unavailable" do
+      media = [
+        %Media{
+          kind: :file,
+          url: "telegram://file/abc123",
+          filename: "doc.pdf",
+          media_type: "application/pdf",
+          size_bytes: 1024
+        }
+      ]
+
+      [record] = TargetMedia.build_records(media, :telegram, %{})
+
+      assert record.id == "telegram_telegram://file/abc123"
+      assert record.kind == :file
+      assert record.content == nil
+      assert record.name == "doc.pdf"
+      assert record.mime_type == "application/pdf"
+      assert record.size == 1024
+      assert record.url == "telegram://file/abc123"
+      assert record.attributes["source"] == "channel_attachment"
+    end
+
+    test "creates stub records for multiple media items" do
+      media = [
+        %Media{
+          kind: :file,
+          url: "telegram://file/f1",
+          filename: "a.pdf",
+          media_type: "application/pdf"
+        },
+        %Media{kind: :file, url: "telegram://file/f2", filename: "b.png", media_type: "image/png"}
+      ]
+
+      records = TargetMedia.build_records(media, :telegram, %{})
+
+      assert length(records) == 2
+    end
+
+    test "handles media with only url and kind" do
+      media = [%Media{kind: :file, url: "telegram://file/xyz"}]
+
+      [record] = TargetMedia.build_records(media, :telegram, %{})
+
+      assert record.name == nil
+      assert record.mime_type == nil
+      assert record.size == nil
+    end
+
+    test "record_id uses url when no file_id in metadata" do
+      media = [%Media{kind: :file, url: "some-url"}]
+
+      [record] = TargetMedia.build_records(media, :telegram, %{})
+      assert record.id == "telegram_some-url"
+    end
+
+    test "record_id uses metadata.file_id when present" do
+      media = [
+        %Media{
+          kind: :file,
+          url: "telegram://file/abc123",
+          metadata: %{file_id: "custom_id"}
+        }
+      ]
+
+      [record] = TargetMedia.build_records(media, :telegram, %{})
+      assert record.id == "telegram_custom_id"
+    end
+
+    test "record_id uses url when metadata.file_id is nil" do
+      media = [
+        %Media{
+          kind: :file,
+          url: "fallback-url",
+          metadata: %{file_id: nil}
+        }
+      ]
+
+      [record] = TargetMedia.build_records(media, :telegram, %{})
+      assert record.id == "telegram_fallback-url"
+    end
+
+    test "handles all media kinds" do
+      media = [
+        %Media{
+          kind: :image,
+          url: "telegram://file/img1",
+          filename: "photo.jpg",
+          media_type: "image/jpeg"
+        },
+        %Media{
+          kind: :audio,
+          url: "telegram://file/aud1",
+          filename: "voice.ogg",
+          media_type: "audio/ogg"
+        },
+        %Media{
+          kind: :video,
+          url: "telegram://file/vid1",
+          filename: "clip.mp4",
+          media_type: "video/mp4"
+        },
+        %Media{
+          kind: :file,
+          url: "telegram://file/doc1",
+          filename: "notes.pdf",
+          media_type: "application/pdf"
+        }
+      ]
+
+      records = TargetMedia.build_records(media, :telegram, %{})
+
+      assert length(records) == 4
+      assert Enum.all?(records, &(&1.kind == :file))
+    end
+
+    test "provider is used in record_id prefix" do
+      media = [%Media{kind: :file, url: "telegram://file/abc"}]
+
+      tg_records = TargetMedia.build_records(media, :telegram, %{})
+      mm_records = TargetMedia.build_records(media, :mattermost, %{})
+
+      assert String.starts_with?(Enum.at(tg_records, 0).id, "telegram_")
+      assert String.starts_with?(Enum.at(mm_records, 0).id, "mattermost_")
+    end
+
+    test "record has attributes.source = channel_attachment" do
+      media = [%Media{kind: :file, url: "tg://doc"}]
+
+      [record] = TargetMedia.build_records(media, :test, %{})
+      assert record.attributes["source"] == "channel_attachment"
+    end
+  end
+end

--- a/test/zaq/channels/jido_chat_bridge_test.exs
+++ b/test/zaq/channels/jido_chat_bridge_test.exs
@@ -4,12 +4,15 @@ defmodule Zaq.Channels.JidoChatBridgeTest do
 
   alias Jido.Chat
   alias Jido.Chat.Author
+  alias Jido.Chat.Media
+
   alias Jido.Chat.ChannelMeta
   alias Jido.Chat.Incoming, as: ChatIncoming
   alias Zaq.Agent.{MCP, ServerManager}
   alias Zaq.Channels.{ChannelConfig, RetrievalChannel}
   alias Zaq.Channels.JidoChatBridge
   alias Zaq.Channels.JidoChatBridge.State
+
   alias Zaq.Channels.Supervisor
   alias Zaq.Engine.Conversations
   alias Zaq.Engine.Messages.{Incoming, Outgoing}
@@ -604,6 +607,7 @@ defmodule Zaq.Channels.JidoChatBridgeTest do
       assert msg.author_name == "alice"
       assert msg.provider == :mattermost
       assert msg.metadata[:raw] == "data"
+      assert msg.records == []
 
       assert msg.metadata["telemetry_dimensions"] == %{
                "channel_id" => "room1",
@@ -677,6 +681,178 @@ defmodule Zaq.Channels.JidoChatBridgeTest do
                "provider" => "mattermost"
              }
     end
+  end
+
+  test "maps media attachments from Chat.Incoming" do
+    incoming = %ChatIncoming{
+      text: "check this file",
+      external_room_id: "room1",
+      external_thread_id: nil,
+      external_message_id: "msg1",
+      author: %Author{user_id: "u1", user_name: "alice"},
+      metadata: %{},
+      media: [
+        %Media{
+          kind: :file,
+          url: "https://example.com/report.pdf",
+          filename: "report.pdf",
+          media_type: "application/pdf",
+          size_bytes: 1024
+        },
+        %Media{
+          kind: :image,
+          url: "https://example.com/photo.png",
+          filename: "photo.png",
+          media_type: "image/png",
+          size_bytes: 2048,
+          width: 800,
+          height: 600
+        }
+      ]
+    }
+
+    msg = JidoChatBridge.to_internal(incoming, :mattermost)
+
+    assert length(msg.records) == 2
+
+    first = Enum.at(msg.records, 0)
+    assert first.url == "https://example.com/report.pdf"
+    assert first.name == "report.pdf"
+    assert first.mime_type == "application/pdf"
+    assert first.size == 1024
+    assert first.kind == :file
+
+    second = Enum.at(msg.records, 1)
+    assert second.url == "https://example.com/photo.png"
+    assert second.name == "photo.png"
+    assert second.mime_type == "image/png"
+    assert second.size == 2048
+    assert second.kind == :file
+  end
+
+  test "handles nil media gracefully" do
+    incoming = %ChatIncoming{
+      text: "no files",
+      external_room_id: "room1",
+      external_thread_id: nil,
+      external_message_id: "msg1",
+      author: nil,
+      metadata: %{},
+      media: nil
+    }
+
+    msg = JidoChatBridge.to_internal(incoming, :mattermost)
+    assert msg.records == []
+  end
+
+  test "handles empty media list" do
+    incoming = %ChatIncoming{
+      text: "no files",
+      external_room_id: "room1",
+      external_thread_id: nil,
+      external_message_id: "msg1",
+      author: nil,
+      metadata: %{},
+      media: []
+    }
+
+    msg = JidoChatBridge.to_internal(incoming, :mattermost)
+    assert msg.records == []
+  end
+
+  test "maps single media attachment to single record" do
+    incoming = %ChatIncoming{
+      text: "single file",
+      external_room_id: "room1",
+      external_thread_id: nil,
+      external_message_id: "msg1",
+      author: nil,
+      metadata: %{},
+      media: [
+        %Media{
+          kind: :file,
+          url: "telegram://file/doc1",
+          filename: "report.pdf",
+          media_type: "application/pdf",
+          size_bytes: 42_000
+        }
+      ]
+    }
+
+    msg = JidoChatBridge.to_internal(incoming, :telegram)
+
+    assert length(msg.records) == 1
+    record = Enum.at(msg.records, 0)
+    assert record.url == "telegram://file/doc1"
+    assert record.name == "report.pdf"
+    assert record.mime_type == "application/pdf"
+    assert record.size == 42_000
+    assert record.kind == :file
+  end
+
+  test "maps media with file_id in metadata to record id" do
+    incoming = %ChatIncoming{
+      text: "file with metadata",
+      external_room_id: "room1",
+      external_thread_id: nil,
+      external_message_id: "msg1",
+      author: nil,
+      metadata: %{},
+      media: [
+        %Media{
+          kind: :file,
+          url: "telegram://file/abc123",
+          filename: "doc.pdf",
+          media_type: "application/pdf",
+          metadata: %{file_id: "abc123"}
+        }
+      ]
+    }
+
+    msg = JidoChatBridge.to_internal(incoming, :telegram)
+
+    assert length(msg.records) == 1
+    record = Enum.at(msg.records, 0)
+    assert record.id == "telegram_abc123"
+  end
+
+  test "records always have kind :file regardless of media kind" do
+    incoming = %ChatIncoming{
+      text: "various media",
+      external_room_id: "room1",
+      external_thread_id: nil,
+      external_message_id: "msg1",
+      author: nil,
+      metadata: %{},
+      media: [
+        %Media{kind: :image, url: "tg://img1", filename: "photo.jpg", media_type: "image/jpeg"},
+        %Media{kind: :video, url: "tg://vid1", filename: "clip.mp4", media_type: "video/mp4"}
+      ]
+    }
+
+    msg = JidoChatBridge.to_internal(incoming, :mattermost)
+
+    assert length(msg.records) == 2
+    assert Enum.all?(msg.records, &(&1.kind == :file))
+  end
+
+  test "record attributes include channel_attachment source" do
+    incoming = %ChatIncoming{
+      text: "attached file",
+      external_room_id: "room1",
+      external_thread_id: nil,
+      external_message_id: "msg1",
+      author: nil,
+      metadata: %{},
+      media: [
+        %Media{kind: :file, url: "tg://doc", filename: "notes.txt", media_type: "text/plain"}
+      ]
+    }
+
+    msg = JidoChatBridge.to_internal(incoming, :mattermost)
+
+    record = Enum.at(msg.records, 0)
+    assert record.attributes["source"] == "channel_attachment"
   end
 
   # ── resolve_roles/1 ───────────────────────────────────────────────────

--- a/test/zaq/engine/messages/incoming_test.exs
+++ b/test/zaq/engine/messages/incoming_test.exs
@@ -171,6 +171,77 @@ defmodule Zaq.Engine.Messages.IncomingTest do
     assert Incoming.team_ids(msg) == [7, 8]
   end
 
+  describe "records" do
+    alias Zaq.Contracts.Record
+
+    test "preserves records list passed to new/1" do
+      records = [
+        %Record{
+          id: "r1",
+          kind: :file,
+          content: "hello",
+          name: "doc.txt",
+          mime_type: "text/plain"
+        },
+        %Record{id: "r2", kind: :file, content: nil, name: "img.png", mime_type: "image/png"}
+      ]
+
+      msg =
+        Incoming.new(%{
+          content: "check these",
+          channel_id: "ch1",
+          provider: :telegram,
+          records: records
+        })
+
+      assert length(msg.records) == 2
+      assert Enum.at(msg.records, 0).id == "r1"
+      assert Enum.at(msg.records, 0).content == "hello"
+      assert Enum.at(msg.records, 1).id == "r2"
+      assert Enum.at(msg.records, 1).content == nil
+    end
+
+    test "records is empty list when records field is nil" do
+      msg =
+        Incoming.new(%{
+          content: "no records",
+          channel_id: "ch1",
+          provider: :telegram,
+          records: nil
+        })
+
+      assert msg.records == []
+    end
+
+    test "records is empty list when records field is not a list" do
+      msg =
+        Incoming.new(%{
+          content: "bad records",
+          channel_id: "ch1",
+          provider: :telegram,
+          records: "not-a-list"
+        })
+
+      assert msg.records == []
+    end
+
+    test "records defaults to empty list when not provided" do
+      msg =
+        Incoming.new(%{
+          content: "default",
+          channel_id: "ch1",
+          provider: :telegram
+        })
+
+      assert msg.records == []
+    end
+
+    test "struct defaults records to empty list" do
+      msg = %Incoming{content: "hi", channel_id: "ch1", provider: :telegram}
+      assert msg.records == []
+    end
+  end
+
   describe "new/1 required keys" do
     test "raises ArgumentError when :content key is missing" do
       attrs = %{channel_id: "ch1", provider: :mattermost}


### PR DESCRIPTION
Map Chat.Incoming media attachments to internal Record structs during to_internal/2, enabling file-based messages (images, documents, videos) from Telegram, Mattermost, etc.