### PR TITLE
fix(channels): normalise sub-providers so imap replies convert markdown to html

### DIFF
--- a/lib/zaq/channels/bridge.ex
+++ b/lib/zaq/channels/bridge.ex
@@ -288,19 +288,6 @@ defmodule Zaq.Channels.Bridge do
 
   def provider_to_bridge_key(_provider), do: nil
 
-  @doc """
-  Inverse of `provider_to_bridge_key/1`: every provider string that may be
-  stored in `channel_configs` under a given configured bridge key.
-
-  `config :zaq, :channels` is keyed by bridge (`:email`), but rows are stored
-  under sub-providers (`"email:imap"`, `"email:smtp"`). Callers that filter
-  configs by provider string must expand the bridge key first, or enabled
-  sub-provider channels are silently skipped.
-  """
-  @spec bridge_key_to_providers(atom()) :: [String.t()]
-  def bridge_key_to_providers(:email), do: ["email", @smtp_provider, @imap_provider]
-  def bridge_key_to_providers(key) when is_atom(key), do: [Atom.to_string(key)]
-
   @doc "Resolves configured bridge for provider."
   @spec resolve_bridge(atom() | String.t()) :: {:ok, module()} | {:error, term()}
   def resolve_bridge(provider, opts \\ []) do

--- a/lib/zaq/channels/bridge.ex
+++ b/lib/zaq/channels/bridge.ex
@@ -288,6 +288,19 @@ defmodule Zaq.Channels.Bridge do
 
   def provider_to_bridge_key(_provider), do: nil
 
+  @doc """
+  Inverse of `provider_to_bridge_key/1`: every provider string that may be
+  stored in `channel_configs` under a given configured bridge key.
+
+  `config :zaq, :channels` is keyed by bridge (`:email`), but rows are stored
+  under sub-providers (`"email:imap"`, `"email:smtp"`). Callers that filter
+  configs by provider string must expand the bridge key first, or enabled
+  sub-provider channels are silently skipped.
+  """
+  @spec bridge_key_to_providers(atom()) :: [String.t()]
+  def bridge_key_to_providers(:email), do: ["email", @smtp_provider, @imap_provider]
+  def bridge_key_to_providers(key) when is_atom(key), do: [Atom.to_string(key)]
+
   @doc "Resolves configured bridge for provider."
   @spec resolve_bridge(atom() | String.t()) :: {:ok, module()} | {:error, term()}
   def resolve_bridge(provider, opts \\ []) do

--- a/lib/zaq/channels/channel_config.ex
+++ b/lib/zaq/channels/channel_config.ex
@@ -226,11 +226,25 @@ defmodule Zaq.Channels.ChannelConfig do
   """
   def list_enabled_by_kind(kind, providers) when kind in [:ingestion, :data_source, :retrieval] do
     kind_str = kind_to_config_kind(kind)
+    providers = normalize_filter_providers(providers)
 
     __MODULE__
-    |> where([c], c.kind == ^kind_str and c.enabled == true and c.provider in ^providers)
+    |> where(
+      [c],
+      c.kind == ^kind_str and c.enabled == true and
+        (c.provider in ^providers or fragment("split_part(?, ':', 1)", c.provider) in ^providers)
+    )
     |> Zaq.Repo.all()
   end
+
+  defp normalize_filter_providers(providers) when is_list(providers) do
+    providers
+    |> Enum.map(&to_string/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp normalize_filter_providers(_providers), do: []
 
   defp kind_to_config_kind(:ingestion), do: "data_source"
   defp kind_to_config_kind(kind), do: Atom.to_string(kind)

--- a/lib/zaq/channels/message_formatter.ex
+++ b/lib/zaq/channels/message_formatter.ex
@@ -73,16 +73,13 @@ defmodule Zaq.Channels.MessageFormatter do
     end
   end
 
+  # Providers are normalised through `Bridge.provider_to_bridge_key/1` for both
+  # atoms and strings. Sub-providers such as `:"email:imap"` are not config keys
+  # in their own right — they map back onto `:email`. Using the raw provider as
+  # the key made IMAP replies miss `:message_format` and ship as raw markdown.
   defp provider_channel_config(provider) do
-    key =
-      cond do
-        is_atom(provider) -> provider
-        is_binary(provider) -> Bridge.provider_to_bridge_key(provider)
-        true -> nil
-      end
-
     Application.get_env(:zaq, :channels, %{})
-    |> Map.get(key, %{})
+    |> Map.get(Bridge.provider_to_bridge_key(provider), %{})
   end
 
   defp provider_message_format(provider_config) when is_map(provider_config),

--- a/lib/zaq/channels/supervisor.ex
+++ b/lib/zaq/channels/supervisor.ex
@@ -17,7 +17,7 @@ defmodule Zaq.Channels.Supervisor do
 
   require Logger
 
-  alias Zaq.Channels.{Bridge, ChannelConfig, CommunicationBridge, DataSourceBridge}
+  alias Zaq.Channels.{ChannelConfig, CommunicationBridge, DataSourceBridge}
 
   # ETS table: bridge_id => %{listener_pids: [pid], state_pid: pid | nil}
   @table :zaq_channels_listeners
@@ -260,15 +260,13 @@ defmodule Zaq.Channels.Supervisor do
 
   defp bridge_id(config), do: "#{config.provider}_#{config.id}"
 
-  # Expands each configured bridge key into every provider string that may be
-  # stored under it. `config :zaq, :channels` is keyed by bridge (`:email`)
-  # while rows use sub-providers (`"email:imap"`), so comparing the raw key
-  # against `channel_configs.provider` skipped IMAP channels on every cold boot.
+  # ChannelConfig handles sub-provider matching (`email` matches `email:imap`),
+  # so the supervisor only needs to pass configured base provider keys.
   defp configured_providers do
     :zaq
     |> Application.get_env(:channels, %{})
     |> Enum.flat_map(fn {provider, cfg} ->
-      if Map.has_key?(cfg, :adapter), do: Bridge.bridge_key_to_providers(provider), else: []
+      if is_map(cfg) and Map.has_key?(cfg, :adapter), do: [to_string(provider)], else: []
     end)
   end
 end

--- a/lib/zaq/channels/supervisor.ex
+++ b/lib/zaq/channels/supervisor.ex
@@ -17,7 +17,7 @@ defmodule Zaq.Channels.Supervisor do
 
   require Logger
 
-  alias Zaq.Channels.{ChannelConfig, CommunicationBridge, DataSourceBridge}
+  alias Zaq.Channels.{Bridge, ChannelConfig, CommunicationBridge, DataSourceBridge}
 
   # ETS table: bridge_id => %{listener_pids: [pid], state_pid: pid | nil}
   @table :zaq_channels_listeners
@@ -260,11 +260,15 @@ defmodule Zaq.Channels.Supervisor do
 
   defp bridge_id(config), do: "#{config.provider}_#{config.id}"
 
+  # Expands each configured bridge key into every provider string that may be
+  # stored under it. `config :zaq, :channels` is keyed by bridge (`:email`)
+  # while rows use sub-providers (`"email:imap"`), so comparing the raw key
+  # against `channel_configs.provider` skipped IMAP channels on every cold boot.
   defp configured_providers do
     :zaq
     |> Application.get_env(:channels, %{})
     |> Enum.flat_map(fn {provider, cfg} ->
-      if Map.has_key?(cfg, :adapter), do: [Atom.to_string(provider)], else: []
+      if Map.has_key?(cfg, :adapter), do: Bridge.bridge_key_to_providers(provider), else: []
     end)
   end
 end

--- a/test/zaq/channels/channel_config_test.exs
+++ b/test/zaq/channels/channel_config_test.exs
@@ -335,6 +335,36 @@ defmodule Zaq.Channels.ChannelConfigTest do
     assert result.id == retrieval_enabled.id
   end
 
+  test "list_enabled_by_kind/2 matches provider prefix before colon" do
+    assert {:ok, smtp} =
+             ChannelConfig.upsert_by_provider("email:smtp", %{
+               name: "Email SMTP",
+               kind: "retrieval",
+               enabled: true,
+               settings: %{"relay" => "smtp.example.com", "port" => "587"}
+             })
+
+    imap = upsert_imap_config(enabled: true, mailbox: "INBOX")
+
+    result_ids =
+      :retrieval
+      |> ChannelConfig.list_enabled_by_kind(["email"])
+      |> Enum.map(& &1.id)
+
+    assert Enum.sort(result_ids) == Enum.sort([smtp.id, imap.id])
+  end
+
+  test "list_enabled_by_kind/2 excludes disabled provider-prefix matches" do
+    _disabled_imap = upsert_imap_config(enabled: false, mailbox: "Archive")
+
+    result_providers =
+      :retrieval
+      |> ChannelConfig.list_enabled_by_kind(["email"])
+      |> Enum.map(& &1.provider)
+
+    refute "email:imap" in result_providers
+  end
+
   test "get_by_provider/1 ignores disabled configs" do
     _disabled = insert_channel_config(%{provider: "mattermost", enabled: false})
     enabled = insert_channel_config(%{provider: "slack", enabled: true})
@@ -562,6 +592,33 @@ defmodule Zaq.Channels.ChannelConfigTest do
     %ChannelConfig{}
     |> ChannelConfig.changeset(Map.merge(defaults, attrs))
     |> Repo.insert!()
+  end
+
+  defp upsert_imap_config(opts) do
+    enabled = Keyword.fetch!(opts, :enabled)
+    mailbox = Keyword.fetch!(opts, :mailbox)
+
+    attrs = %{
+      name: "Email IMAP",
+      provider: "email:imap",
+      kind: "retrieval",
+      token: "imap-secret",
+      enabled: enabled,
+      settings: %{"imap" => %{"selected_mailboxes" => [mailbox]}}
+    }
+
+    case ChannelConfig.get_any_by_provider("email:imap") do
+      nil ->
+        insert_channel_config(attrs)
+
+      existing ->
+        assert {:ok, updated} =
+                 existing
+                 |> ChannelConfig.changeset(attrs)
+                 |> Repo.update()
+
+        updated
+    end
   end
 
   defp insert_configured_agent do

--- a/test/zaq/channels/email_html_delivery_test.exs
+++ b/test/zaq/channels/email_html_delivery_test.exs
@@ -1,0 +1,218 @@
+defmodule Zaq.Channels.EmailHtmlDeliveryTest do
+  @moduledoc """
+  End-to-end coverage of the agent-reply -> email HTML delivery path.
+
+  Walks the real seam, with no stubbed hops in between:
+
+      %Outgoing{provider: :email}
+        -> Zaq.Channels.Api (:deliver_outgoing)
+        -> Zaq.Channels.Bridge resolves Zaq.Channels.EmailBridge
+        -> Zaq.Channels.MessageFormatter (markdown -> HTML, driven by real config)
+        -> Zaq.Channels.EmailBridge.send_reply/2
+        -> Zaq.Engine.Notifications.EmailNotification
+        -> Swoosh (captured via Swoosh.Adapters.Test)
+
+  The bridge is resolved from the real `config :zaq, :channels` entry rather than
+  a test stub: if `email: %{message_format: :html}` is dropped from config, these
+  tests fail instead of silently shipping raw markdown to recipients.
+  """
+
+  use Zaq.DataCase, async: false
+
+  alias Zaq.Channels.Api
+  alias Zaq.Channels.ChannelConfig
+  alias Zaq.Engine.Messages.Outgoing
+  alias Zaq.Event
+
+  @markdown """
+  # Deployment status
+
+  The **build** passed. See [the run](https://ci.example.com) for details.
+
+  - migrations applied
+  - cache warmed
+  """
+
+  describe "agent reply delivered as HTML email" do
+    test "email provider is configured to format outbound bodies as html" do
+      # Guards the premise of every other test in this file. MessageFormatter is
+      # a no-op unless the provider declares :message_format, so a config
+      # regression here would otherwise make the suite pass on unformatted mail.
+      email_config = Application.get_env(:zaq, :channels, %{}) |> Map.get(:email, %{})
+
+      assert email_config[:bridge] == Zaq.Channels.EmailBridge
+      assert email_config[:message_format] == :html
+    end
+
+    test "markdown agent reply reaches SMTP as converted html" do
+      upsert_smtp_channel()
+
+      assert :ok = deliver(@markdown, %{"subject" => "Deploy report"})
+
+      assert_receive {:email, email}
+
+      assert email.subject == "Deploy report"
+      assert email.to == [{"", "ops@example.com"}]
+
+      # --- the conversion actually happened ---
+      assert email.html_body =~ "<h1>"
+      assert email.html_body =~ "Deployment status"
+      assert email.html_body =~ "<strong>build</strong>"
+      assert email.html_body =~ ~s(href="https://ci.example.com")
+      assert email.html_body =~ "<li>"
+      assert email.html_body =~ "migrations applied"
+
+      # --- and no markdown syntax survived into the recipient's inbox ---
+      refute email.html_body =~ "**build**"
+      refute email.html_body =~ "# Deployment status"
+      refute email.html_body =~ "[the run]"
+      refute email.html_body =~ "- migrations applied"
+    end
+
+    test "text part is the de-tagged twin of the html part" do
+      upsert_smtp_channel()
+
+      assert :ok = deliver(@markdown, %{"subject" => "Deploy report"})
+
+      assert_receive {:email, email}
+
+      # Multipart alternative: readable text for clients that refuse HTML.
+      assert is_binary(email.text_body)
+      assert email.text_body =~ "Deployment status"
+      assert email.text_body =~ "build passed"
+      assert email.text_body =~ "migrations applied"
+
+      refute email.text_body =~ "<h1>"
+      refute email.text_body =~ "<strong>"
+      refute email.text_body =~ "<li>"
+      refute email.text_body =~ "**"
+    end
+
+    test "html special characters in the agent reply are escaped, not injected" do
+      upsert_smtp_channel()
+
+      body = "Compare `a < b` and <script>alert('xss')</script> in **prod**."
+
+      assert :ok = deliver(body, %{"subject" => "Escaping"})
+
+      assert_receive {:email, email}
+
+      assert email.html_body =~ "<strong>prod</strong>"
+      # The raw tag must arrive escaped, never as a live element.
+      refute email.html_body =~ "<script>"
+      assert email.html_body =~ "&lt;script&gt;"
+    end
+
+    test "formatter stamps the html format so EmailNotification picks the html branch" do
+      upsert_smtp_channel()
+
+      # Regression guard for the Api -> EmailBridge handoff: EmailBridge reads
+      # `format` out of metadata to decide which body becomes the HTML part.
+      # If MessageFormatter stops stamping it, text and html silently swap roles.
+      assert :ok = deliver("**bold**", %{"subject" => "Format relay"})
+
+      assert_receive {:email, email}
+
+      assert email.html_body =~ "<strong>bold</strong>"
+      refute email.text_body =~ "<strong>"
+      assert email.text_body =~ "bold"
+    end
+
+    # An agent reply to an IMAP-received mail carries the provider verbatim from
+    # the incoming message (`Outgoing.from_incoming/2`), and the IMAP parser
+    # stamps `:"email:imap"` — not `:email`. The formatter must map that back to
+    # the `:email` config key, or replies ship as raw markdown.
+    test "markdown is converted for replies on the :\"email:imap\" provider" do
+      upsert_smtp_channel()
+
+      assert :ok = deliver(@markdown, %{"subject" => "IMAP reply"}, :"email:imap")
+
+      assert_receive {:email, email}
+
+      assert email.html_body =~ "<h1>"
+      assert email.html_body =~ "<strong>build</strong>"
+      assert email.html_body =~ "<li>"
+
+      refute email.html_body =~ "**build**"
+      refute email.html_body =~ "# Deployment status"
+    end
+
+    test "markdown is converted for the string form of the imap provider" do
+      upsert_smtp_channel()
+
+      assert :ok = deliver(@markdown, %{"subject" => "IMAP reply"}, "email:imap")
+
+      assert_receive {:email, email}
+
+      assert email.html_body =~ "<strong>build</strong>"
+      refute email.html_body =~ "**build**"
+    end
+
+    test "routing metadata survives formatting" do
+      upsert_smtp_channel()
+
+      assert :ok =
+               deliver("**hi**", %{
+                 "subject" => "Metadata",
+                 "request_id" => "req-42"
+               })
+
+      assert_receive {:email, email}
+
+      assert email.subject == "Metadata"
+      assert email.html_body =~ "<strong>hi</strong>"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Drives the real Channels API boundary — no bridge_module override, so
+  # Zaq.Channels.Bridge resolves the email bridge from application config.
+  defp deliver(body, metadata, provider \\ :email) do
+    outgoing = %Outgoing{
+      body: body,
+      channel_id: "ops@example.com",
+      provider: provider,
+      metadata: metadata
+    }
+
+    outgoing
+    |> Event.new(:channels, opts: [action: :deliver_outgoing])
+    |> Api.handle_event(:deliver_outgoing, nil)
+    |> Map.fetch!(:response)
+  end
+
+  defp smtp_settings(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "relay" => "",
+        "port" => "587",
+        "transport_mode" => "starttls",
+        "tls" => "enabled",
+        "tls_verify" => "verify_peer",
+        "ca_cert_path" => nil,
+        "username" => nil,
+        "password" => nil,
+        "from_email" => "noreply@example.com",
+        "from_name" => "ZAQ"
+      },
+      overrides
+    )
+  end
+
+  defp upsert_smtp_channel(attrs \\ %{}) do
+    defaults = %{
+      name: "Email SMTP",
+      kind: "retrieval",
+      enabled: true,
+      settings: smtp_settings()
+    }
+
+    assert {:ok, _channel} =
+             ChannelConfig.upsert_by_provider("email:smtp", Map.merge(defaults, attrs))
+
+    :ok
+  end
+end

--- a/test/zaq/channels/supervisor_test.exs
+++ b/test/zaq/channels/supervisor_test.exs
@@ -175,6 +175,23 @@ defmodule Zaq.Channels.SupervisorTest do
     end
   end
 
+  # An `email:imap` config is rejected by the changeset unless an enabled
+  # `email:smtp` config already exists — IMAP has no way to reply without it.
+  defp upsert_smtp_prerequisite do
+    {:ok, config} =
+      ChannelConfig.upsert_by_provider("email:smtp", %{
+        name: "Email SMTP Bootstrap",
+        kind: "retrieval",
+        provider: "email:smtp",
+        enabled: true,
+        url: "smtp.example.com",
+        token: "tok",
+        settings: %{"smtp" => %{"from_email" => "noreply@example.com"}}
+      })
+
+    config
+  end
+
   setup do
     previous_channels = Application.get_env(:zaq, :channels, %{})
 
@@ -396,6 +413,81 @@ defmodule Zaq.Channels.SupervisorTest do
     assert_receive {:bootstrap_sync, "data_source", "google_drive", ^ds_id}
     refute_received {:bootstrap_sync, _, "slack", _}
     refute_received {:bootstrap_sync, _, "discord", _}
+  end
+
+  # Channel configs are stored under sub-provider keys (`email:imap`,
+  # `email:smtp`) while `config :zaq, :channels` is keyed by bridge
+  # (`email`). Bootstrap must reconcile the two, otherwise an enabled IMAP
+  # channel is skipped on every cold start and no listener is ever spawned —
+  # the channel only comes up if someone toggles it in the BO afterwards.
+  test "start_link/1 bootstraps sub-provider configs such as email:imap" do
+    Process.register(self(), :supervisor_bootstrap_observer)
+
+    on_exit(fn ->
+      if Process.whereis(:supervisor_bootstrap_observer) do
+        Process.unregister(:supervisor_bootstrap_observer)
+      end
+    end)
+
+    upsert_smtp_prerequisite()
+
+    {:ok, imap_config} =
+      ChannelConfig.upsert_by_provider("email:imap", %{
+        name: "Email IMAP Bootstrap",
+        kind: "retrieval",
+        provider: "email:imap",
+        enabled: true,
+        url: "imap.example.com",
+        token: "tok",
+        settings: %{"imap" => %{"selected_mailboxes" => ["INBOX"]}}
+      })
+
+    imap_id = imap_config.id
+
+    Application.put_env(:zaq, :channels, %{
+      email: %{bridge: BootstrapSyncBridge, adapter: StubAdapter}
+    })
+
+    with_stopped_channel_supervisor(fn ->
+      assert {:ok, _pid} = Supervisor.start_link([])
+    end)
+
+    assert_receive {:bootstrap_sync, "retrieval", "email:imap", ^imap_id}
+  end
+
+  test "start_link/1 still ignores providers absent from channel config" do
+    Process.register(self(), :supervisor_bootstrap_observer)
+
+    on_exit(fn ->
+      if Process.whereis(:supervisor_bootstrap_observer) do
+        Process.unregister(:supervisor_bootstrap_observer)
+      end
+    end)
+
+    upsert_smtp_prerequisite()
+
+    {:ok, _} =
+      ChannelConfig.upsert_by_provider("email:imap", %{
+        name: "Email IMAP Unconfigured",
+        kind: "retrieval",
+        provider: "email:imap",
+        enabled: true,
+        url: "imap.example.com",
+        token: "tok",
+        settings: %{"imap" => %{"selected_mailboxes" => ["INBOX"]}}
+      })
+
+    # No `email` key at all — widening the allowlist must not start runtimes
+    # for bridges the application is not configured for.
+    Application.put_env(:zaq, :channels, %{
+      mattermost: %{bridge: BootstrapSyncBridge, adapter: StubAdapter}
+    })
+
+    with_stopped_channel_supervisor(fn ->
+      assert {:ok, _pid} = Supervisor.start_link([])
+    end)
+
+    refute_received {:bootstrap_sync, _, "email:imap", _}
   end
 
   test "stop_bridge_runtime/2 returns not_running when missing", %{config: config} do


### PR DESCRIPTION
- Email conversion through the IMAP route
- Bootstrap email sub provider configs on cold start