### PR TITLE
fix(Utils): Map Utils read_any/2 carry false as a value not as nil

### DIFF
--- a/lib/zaq/utils/map.ex
+++ b/lib/zaq/utils/map.ex
@@ -3,7 +3,10 @@ defmodule Zaq.Utils.Map do
 
   @spec read_any(map(), [atom() | String.t()]) :: term() | nil
   def read_any(map, keys) when is_map(map) and is_list(keys) do
-    Enum.find_value(keys, fn key -> Map.get(map, key) end)
+    case Enum.find(keys, &Map.has_key?(map, &1)) do
+      nil -> nil
+      key -> Map.get(map, key)
+    end
   end
 
   def read_any(_map, _keys), do: nil

--- a/test/zaq/channels/jido_connect_bridge_test.exs
+++ b/test/zaq/channels/jido_connect_bridge_test.exs
@@ -1596,6 +1596,50 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
     assert is_binary(params[:query]) || is_binary(params["query"])
   end
 
+  test "list_files excludes shared-with-me clause when nested filters disable shared items" do
+    config = insert_data_source_config(:google_drive)
+    credential = create_credential!()
+    _grant = create_active_grant!(credential, config.id)
+
+    assert {:ok, _page} =
+             JidoConnectBridge.list_files(config, %{
+               "filters" => %{
+                 "parent" => "folder-1",
+                 "include_shared" => false,
+                 "trashed" => false
+               }
+             })
+
+    assert_received {:invoke_files, params, _opts}
+    query = params[:query] || params["query"]
+
+    assert query =~ "'folder-1' in parents"
+    assert query =~ "trashed = false"
+    refute query =~ "sharedWithMe = true"
+  end
+
+  test "list_files includes shared-with-me clause when root filters enable shared items" do
+    config = insert_data_source_config(:google_drive)
+    credential = create_credential!()
+    _grant = create_active_grant!(credential, config.id)
+
+    assert {:ok, _page} =
+             JidoConnectBridge.list_files(config, %{
+               "filters" => %{
+                 "parent" => "root",
+                 "include_shared" => true,
+                 "trashed" => false
+               }
+             })
+
+    assert_received {:invoke_files, params, _opts}
+    query = params[:query] || params["query"]
+
+    assert query =~ "'root' in parents"
+    assert query =~ "sharedWithMe = true"
+    assert query =~ "trashed = false"
+  end
+
   test "list_files with atom filter keys" do
     config = insert_data_source_config(:google_drive)
     credential = create_credential!()

--- a/test/zaq/utils/map_test.exs
+++ b/test/zaq/utils/map_test.exs
@@ -5,6 +5,23 @@ defmodule Zaq.Utils.MapTest do
   alias Zaq.Utils.Map
 
   describe "read_any/2" do
+    test "returns the first present key even when the value is false" do
+      assert Map.read_any(%{"include_shared" => false}, [:include_shared, "include_shared"]) ==
+               false
+
+      assert Map.read_any(%{include_shared: false}, [:include_shared, "include_shared"]) == false
+    end
+
+    test "preserves other falsey values from present keys" do
+      assert Map.read_any(%{count: 0}, [:count]) == 0
+      assert Map.read_any(%{items: []}, [:items]) == []
+      assert Map.read_any(%{label: ""}, [:label]) == ""
+    end
+
+    test "returns nil only when none of the requested keys exists" do
+      assert Map.read_any(%{"include_shared" => false}, [:missing, "other_missing"]) == nil
+    end
+
     test "returns nil when map argument is invalid" do
       assert Map.read_any("not-a-map", [:subject, "subject"]) == nil
     end

--- a/test/zaq_web/live/bo/ai/ingestion_live_test.exs
+++ b/test/zaq_web/live/bo/ai/ingestion_live_test.exs
@@ -277,6 +277,18 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
       assert has_element?(view, "span", "No Preview.txt")
     end
 
+    test "provider browsing dispatches root and nested shared filters distinctly", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/bo/ingestion/google_drive")
+
+      assert_received {:list_files, "google_drive", root_params}
+      assert root_params["filters"] == %{}
+
+      render_hook(view, "navigate", %{"path" => "folder-1"})
+
+      assert_received {:list_files, "google_drive",
+                       %{"filters" => %{"parent" => "folder-1", "include_shared" => false}}}
+    end
+
     test "previews provider records by URL and queues external ingestion", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/bo/ingestion/google_drive")
       assert_received {:list_files, "google_drive", _params}


### PR DESCRIPTION
this fix correctly forwards `false` params to jido_connect for data source items list filtering