### PR TITLE
refactor: design-migration-v2.8

### DIFF
--- a/lib/zaq_web/components/design_system/dropzone.ex
+++ b/lib/zaq_web/components/design_system/dropzone.ex
@@ -34,9 +34,17 @@ defmodule ZaqWeb.Components.DesignSystem.Dropzone do
 
   attr :hint, :string, default: @default_hint
 
+  attr :too_large_message, :string,
+    default: "File exceeds 20 MB limit.",
+    doc: "Shown when a queued file exceeds `max_file_size` from `allow_upload/3`."
+
   attr :folder_drop?, :boolean,
     default: true,
     doc: "Attaches the FolderDrop JS hook, which expands dropped directories."
+
+  attr :show_submit?, :boolean,
+    default: true,
+    doc: "When false, omit the inline submit control (modal footers use `form` + `type=submit`)."
 
   def upload_section(assigns) do
     assigns = assign(assigns, :upload, Map.fetch!(assigns.uploads, assigns.upload_name))
@@ -109,20 +117,20 @@ defmodule ZaqWeb.Components.DesignSystem.Dropzone do
             </div>
             <%= for err <- Phoenix.Component.upload_errors(@upload, entry) do %>
               <p class="zaq-text-caption mt-1" style="color: var(--zaq-text-color-body-danger)">
-                {upload_error_message(err)}
+                {upload_error_message(err, @too_large_message)}
               </p>
             <% end %>
           </div>
         <% end %>
 
-        <div :if={@upload.entries != []} style="margin-top: var(--zaq-scale-16)">
+        <div :if={@show_submit? and @upload.entries != []} style="margin-top: var(--zaq-scale-16)">
           <button
             id={"#{@id_prefix}-files-button"}
             type="submit"
             disabled={not @embedding_ready}
             class="zaq-btn zaq-btn-primary zaq-btn-text_label-default"
           >
-            {@submit_label} {length(@upload.entries)} file(s)
+            {submit_button_label(@submit_label, @upload.entries)}
           </button>
         </div>
 
@@ -149,8 +157,13 @@ defmodule ZaqWeb.Components.DesignSystem.Dropzone do
   def skip_reason("unsupported_format"), do: "unsupported format"
   def skip_reason(_), do: "skipped"
 
-  defp upload_error_message(:too_large), do: "File exceeds 20 MB limit."
-  defp upload_error_message(:not_accepted), do: "File type not supported."
-  defp upload_error_message(:too_many_files), do: "Too many files selected (max 10)."
-  defp upload_error_message(_), do: "Upload failed."
+  @doc "Shared `{verb} N file(s)` copy for inline and modal-footer submit buttons."
+  def submit_button_label(submit_label, entries) when is_list(entries) do
+    "#{submit_label} #{length(entries)} file(s)"
+  end
+
+  defp upload_error_message(:too_large, message), do: message
+  defp upload_error_message(:not_accepted, _message), do: "File type not supported."
+  defp upload_error_message(:too_many_files, _message), do: "Too many files selected (max 10)."
+  defp upload_error_message(_, _message), do: "Upload failed."
 end

--- a/lib/zaq_web/components/design_system/modal_upload.ex
+++ b/lib/zaq_web/components/design_system/modal_upload.ex
@@ -9,19 +9,28 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
     * **volume picker** — `volumes`; renders only when more than one is configured, so a
       single-volume deployment never sees a control with one option
     * **destination preview** — `destination`; renders only when given
+    * **description** — optional intro copy above the dropzone (workflows import)
+    * **error** — optional server-side failure banner (workflows JSON validation, etc.)
+    * **footer actions** — Cancel plus primary submit (wired to the dropzone form via
+      `form={id_prefix}-form`); submit shows `{submit_label} N file(s)` and stays disabled
+      until at least one file is queued
     * **dropzone wiring** — `upload_name`, `id_prefix`, the three event names, the two
-      labels, `hint` and `folder_drop?` are forwarded straight through, because two
-      dropzones in one DOM must not share element ids
+      labels, `hint`, `too_large_message` and `folder_drop?` are forwarded straight
+      through, because two dropzones in one DOM must not share element ids
 
-  Each is off or ingestion-shaped by default. Configure it; do not fork it — the skills
-  page needs the same dialog with a volume picker and flat (no folder-drop) uploads, not a
-  second modal.
+  Each is off or ingestion-shaped by default. Configure it; do not fork it — skills and
+  workflows need the same dialog with different wiring, not a second modal.
   """
 
   use Phoenix.Component
 
+  alias ZaqWeb.Components.DesignSystem.Button, as: DSButton
+
   import ZaqWeb.Components.BOModal
-  import ZaqWeb.Components.DesignSystem.Dropzone, only: [upload_section: 1, default_hint: 0]
+
+  import ZaqWeb.Components.DesignSystem.Dropzone,
+    only: [upload_section: 1, default_hint: 0, submit_button_label: 2]
+
   import ZaqWeb.CoreComponents, only: [icon: 1]
   import ZaqWeb.Select, only: [select: 1]
 
@@ -29,6 +38,15 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
   attr :id, :string, default: "upload-modal"
   attr :title, :string, default: "Upload data"
   attr :cancel_event, :string, default: "close_modal"
+  attr :cancel_label, :string, default: "Cancel"
+
+  attr :description, :string,
+    default: nil,
+    doc: "Optional intro copy shown above the dropzone."
+
+  attr :error, :string,
+    default: nil,
+    doc: "Optional server-side failure message (import validation, etc.)."
 
   # Ingestion-only chrome inside the dropzone.
   attr :embedding_ready, :boolean, default: true
@@ -55,10 +73,20 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
   attr :label, :string, default: "Upload"
   attr :submit_label, :string, default: "Upload"
   attr :hint, :string, default: nil
+  attr :too_large_message, :string, default: "File exceeds 20 MB limit."
   attr :folder_drop?, :boolean, default: true
 
   def modal_upload(assigns) do
-    assigns = assign(assigns, :volume_options, volume_options(assigns.volumes))
+    upload = Map.fetch!(assigns.uploads, assigns.upload_name)
+    entry_count = length(upload.entries)
+
+    assigns =
+      assigns
+      |> assign(:volume_options, volume_options(assigns.volumes))
+      |> assign(:form_id, "#{assigns.id_prefix}-form")
+      |> assign(:submit_button_id, "#{assigns.id_prefix}-files-button")
+      |> assign(:submit_button_label, submit_button_label(assigns.submit_label, upload.entries))
+      |> assign(:submit_disabled, entry_count == 0 or not assigns.embedding_ready)
 
     ~H"""
     <.form_dialog
@@ -67,6 +95,20 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
       title={@title}
       max_width_class="zaq-modal--width-xl"
     >
+      <:actions>
+        <DSButton.button variant={:secondary} phx-click={@cancel_event}>
+          {@cancel_label}
+        </DSButton.button>
+        <DSButton.button
+          variant={:primary}
+          type="submit"
+          form={@form_id}
+          id={@submit_button_id}
+          disabled={@submit_disabled}
+        >
+          {@submit_button_label}
+        </DSButton.button>
+      </:actions>
       <div class="zaq-layout-stack">
         <form :if={length(@volume_options) > 1} phx-change={@volume_event}>
           <.select
@@ -86,6 +128,14 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
           Uploads to <span class="zaq-text-code">{@destination}</span>
         </p>
 
+        <p
+          :if={@description}
+          class="zaq-text-body-sm"
+          style="color: var(--zaq-text-color-body-tertiary)"
+        >
+          {@description}
+        </p>
+
         <.upload_section
           uploads={@uploads}
           embedding_ready={@embedding_ready}
@@ -98,8 +148,14 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
           label={@label}
           submit_label={@submit_label}
           hint={@hint || default_hint()}
+          too_large_message={@too_large_message}
           folder_drop?={@folder_drop?}
+          show_submit?={false}
         />
+
+        <div :if={@error} class="px-3 py-2 rounded-xl bg-red-50 border border-red-100">
+          <p class="font-mono text-[0.72rem] text-red-500">{@error}</p>
+        </div>
       </div>
     </.form_dialog>
     """

--- a/lib/zaq_web/live/bo/ai/workflows_live.ex
+++ b/lib/zaq_web/live/bo/ai/workflows_live.ex
@@ -8,6 +8,7 @@ defmodule ZaqWeb.Live.BO.AI.WorkflowsLive do
   import ZaqWeb.Live.BO.AI.WorkflowRunHelpers, only: [manual_source_event: 1]
 
   alias ZaqWeb.Components.DesignSystem.Button, as: DSButton
+  alias ZaqWeb.Components.DesignSystem.ModalUpload
   alias ZaqWeb.Components.DesignSystem.Table, as: DSTable
 
   import DSTable,
@@ -24,7 +25,7 @@ defmodule ZaqWeb.Live.BO.AI.WorkflowsLive do
     ]
 
   alias Zaq.Event
-  alias ZaqWeb.Components.{BOFileUpload, BOLayout, BOModal}
+  alias ZaqWeb.Components.BOLayout
 
   @impl true
   def mount(_params, _session, socket) do
@@ -535,74 +536,25 @@ defmodule ZaqWeb.Live.BO.AI.WorkflowsLive do
       <%!-- space-y-4 wrapper --%>
 
       <%!-- Import modal --%>
-      <BOModal.form_dialog
+      <ModalUpload.modal_upload
         :if={@import_modal_open}
         id="import-modal"
         title="Import Workflow"
         cancel_event="close_import"
-      >
-        <form phx-submit="import_workflow" phx-change="validate_import" class="space-y-4">
-          <p class="font-mono text-[0.82rem] text-black">
-            Upload a <code class="text-black/70">.json</code>
-            or <code class="text-black/70">.jsonc</code>
-            workflow export file.
-          </p>
-
-          <BOFileUpload.drop_zone
-            upload={@uploads.workflow_file}
-            id="workflow-import-drop-zone"
-            accept_label=".json, .jsonc"
-          />
-
-          <div
-            :for={entry <- @uploads.workflow_file.entries}
-            class="flex items-center justify-between px-3 py-2 rounded-lg bg-black/[0.02] border border-black/10"
-          >
-            <span class="font-mono text-[0.8rem] text-[var(--zaq-color-ink)] truncate">
-              {entry.client_name}
-            </span>
-            <button
-              type="button"
-              phx-click="cancel_workflow_upload"
-              phx-value-ref={entry.ref}
-              class="ml-3 flex-shrink-0 font-mono text-[0.9rem] text-black/30 hover:text-red-400 transition-colors"
-              aria-label="Remove"
-            >
-              &times;
-            </button>
-          </div>
-
-          <%= for entry <- @uploads.workflow_file.entries,
-                  err <- upload_errors(@uploads.workflow_file, entry) do %>
-            <p class="font-mono text-[0.72rem] text-red-500">
-              {entry.client_name}: {upload_error_label(err)}
-            </p>
-          <% end %>
-
-          <p
-            :if={@import_error}
-            class="font-mono text-[0.72rem] text-red-500 bg-red-50 rounded px-3 py-2"
-          >
-            {@import_error}
-          </p>
-
-          <div class="flex justify-end gap-3 pt-2">
-            <button
-              type="button"
-              phx-click="close_import"
-              class="font-mono text-[0.82rem] text-[var(--zaq-color-ink)] px-4 py-2 rounded-lg border border-black/15 hover:bg-black/5 transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              class="font-mono text-[0.82rem] font-bold px-5 py-2.5 rounded-xl bg-[#03b6d4] text-white hover:bg-[#029ab3] transition-all"
-            >
-              Import
-            </button>
-          </div>
-        </form>
-      </BOModal.form_dialog>
+        uploads={@uploads}
+        upload_name={:workflow_file}
+        id_prefix="workflow-import"
+        submit_event="import_workflow"
+        change_event="validate_import"
+        file_cancel_event="cancel_workflow_upload"
+        label="Workflow export file"
+        submit_label="Import"
+        hint=".json, .jsonc — max 1 MB"
+        too_large_message="File exceeds 1 MB limit."
+        folder_drop?={false}
+        description="Upload a .json or .jsonc workflow export file."
+        error={@import_error}
+      />
     </BOLayout.bo_layout>
     """
   end
@@ -642,11 +594,6 @@ defmodule ZaqWeb.Live.BO.AI.WorkflowsLive do
   end
 
   defp node_router, do: Application.get_env(:zaq, :node_router, Zaq.NodeRouter)
-
-  defp upload_error_label(:too_large), do: "file exceeds size limit"
-  defp upload_error_label(:not_accepted), do: "file type not accepted"
-  defp upload_error_label(:too_many_files), do: "too many files"
-  defp upload_error_label(_), do: "upload failed"
 
   defp page_window(_current, total) when total <= 7, do: Enum.to_list(1..total)
 

--- a/storybook/ingestion/modal_upload.story.exs
+++ b/storybook/ingestion/modal_upload.story.exs
@@ -132,6 +132,32 @@ defmodule Storybook.Ingestion.ModalUpload do
           class="zaq-text-caption"
           style="color: var(--zaq-text-color-body-tertiary); margin-bottom: var(--zaq-scale-12);"
         >
+          Configured for workflow import — flat JSON upload with server-side error
+        </p>
+        <.modal_upload
+          id="import-modal"
+          title="Import Workflow"
+          cancel_event="close_import"
+          uploads={workflow_uploads()}
+          upload_name={:workflow_file}
+          id_prefix="workflow-import"
+          submit_event="import_workflow"
+          change_event="validate_import"
+          file_cancel_event="cancel_workflow_upload"
+          label="Workflow export file"
+          submit_label="Import"
+          hint=".json, .jsonc — max 1 MB"
+          too_large_message="File exceeds 1 MB limit."
+          folder_drop?={false}
+          description="Upload a .json or .jsonc workflow export file."
+          error="File is not valid JSON or JSONC."
+        />
+      </section>
+      <section>
+        <p
+          class="zaq-text-caption"
+          style="color: var(--zaq-text-color-body-tertiary); margin-bottom: var(--zaq-scale-12);"
+        >
           Blocked — no volume connected
         </p>
         <.modal_no_volume />
@@ -150,6 +176,25 @@ defmodule Storybook.Ingestion.ModalUpload do
         accept: :any,
         max_entries: 10,
         max_file_size: 5_242_880,
+        chunk_size: 64_000,
+        chunk_timeout: 10_000,
+        external: false,
+        auto_upload?: false,
+        progress_event: nil
+      }
+    }
+  end
+
+  defp workflow_uploads do
+    %{
+      workflow_file: %Phoenix.LiveView.UploadConfig{
+        ref: "phx-upload-ref",
+        entries: [],
+        errors: [],
+        name: :workflow_file,
+        accept: :any,
+        max_entries: 1,
+        max_file_size: 1_000_000,
         chunk_size: 64_000,
         chunk_timeout: 10_000,
         external: false,

--- a/test/zaq_web/components/design_system/dropzone_test.exs
+++ b/test/zaq_web/components/design_system/dropzone_test.exs
@@ -110,6 +110,17 @@ defmodule ZaqWeb.Components.DesignSystem.DropzoneTest do
       refute html =~ "FolderDrop"
     end
 
+    test "omits the inline submit control when show_submit? is false" do
+      html =
+        render_component(&Dropzone.upload_section/1,
+          uploads: %{files: upload_config(:files, [entry()])},
+          show_submit?: false
+        )
+
+      refute html =~ "upload-files-button"
+      refute html =~ "Upload 1 file(s)"
+    end
+
     test "two dropzones in one document produce distinct element ids" do
       ingestion =
         render_component(&Dropzone.upload_section/1, uploads: %{files: upload_config(:files)})
@@ -144,6 +155,20 @@ defmodule ZaqWeb.Components.DesignSystem.DropzoneTest do
       assert html =~ "disabled"
     end
 
+    test "uses a custom too_large_message when configured" do
+      entry = entry()
+      upload = upload_config(:files, [entry])
+
+      html =
+        render_component(&Dropzone.upload_section/1,
+          uploads: %{files: %{upload | errors: [{entry.ref, :too_large}]}},
+          too_large_message: "File exceeds 1 MB limit."
+        )
+
+      assert html =~ "File exceeds 1 MB limit."
+      refute html =~ "File exceeds 20 MB limit."
+    end
+
     test "renders skipped folder entries with their reason" do
       html =
         render_component(&Dropzone.upload_section/1,
@@ -156,6 +181,13 @@ defmodule ZaqWeb.Components.DesignSystem.DropzoneTest do
       assert html =~ ~s(data-testid="skipped-files")
       assert html =~ "notes.key"
       assert html =~ "unsupported format"
+    end
+  end
+
+  describe "submit_button_label/2" do
+    test "formats the shared submit copy" do
+      assert Dropzone.submit_button_label("Import", []) == "Import 0 file(s)"
+      assert Dropzone.submit_button_label("Upload", [%{}]) == "Upload 1 file(s)"
     end
   end
 

--- a/test/zaq_web/components/design_system/modal_upload_test.exs
+++ b/test/zaq_web/components/design_system/modal_upload_test.exs
@@ -138,6 +138,96 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUploadTest do
 
       refute html =~ ~s(phx-change="select_resource_volume")
     end
+
+    test "renders a footer Cancel wired to the cancel event" do
+      html = render_modal([])
+
+      assert html =~ ~s(phx-click="close_resource_modal")
+      assert html =~ "Cancel"
+      assert html =~ "zaq-modal-form-footer"
+    end
+
+    test "renders footer submit next to Cancel, disabled until a file is queued" do
+      html = render_modal([])
+
+      assert html =~ ~s(form="skill-resource-form")
+      assert html =~ ~s(type="submit")
+      assert html =~ "Add 0 file(s)"
+      assert html =~ "disabled"
+      assert html |> String.split("skill-resource-files-button") |> length() == 2
+    end
+  end
+
+  describe "modal_upload/1 configured for workflow import" do
+    defp workflow_uploads do
+      %{
+        workflow_file: %{
+          uploads().skill_resources
+          | name: :workflow_file,
+            max_entries: 1,
+            max_file_size: 1_000_000
+        }
+      }
+    end
+
+    defp render_workflow_modal(overrides \\ []) do
+      defaults = [
+        id: "import-modal",
+        title: "Import Workflow",
+        cancel_event: "close_import",
+        uploads: workflow_uploads(),
+        upload_name: :workflow_file,
+        id_prefix: "workflow-import",
+        submit_event: "import_workflow",
+        change_event: "validate_import",
+        file_cancel_event: "cancel_workflow_upload",
+        label: "Workflow export file",
+        submit_label: "Import",
+        hint: ".json, .jsonc — max 1 MB",
+        too_large_message: "File exceeds 1 MB limit.",
+        folder_drop?: false,
+        description: "Upload a .json or .jsonc workflow export file."
+      ]
+
+      render_component(
+        &ModalUpload.modal_upload/1,
+        Keyword.merge(defaults, overrides)
+      )
+    end
+
+    test "renders the workflow-scoped dropzone ids and events" do
+      html = render_workflow_modal()
+
+      assert html =~ ~s(id="workflow-import-form")
+      assert html =~ ~s(id="workflow-import-drop-zone")
+      assert html =~ ~s(phx-submit="import_workflow")
+      assert html =~ ~s(phx-change="validate_import")
+      refute html =~ "FolderDrop"
+    end
+
+    test "shows description, hint and server-side error when given" do
+      html =
+        render_workflow_modal(error: "File is not valid JSON or JSONC.")
+
+      assert html =~ "Upload a .json or .jsonc workflow export file."
+      assert html =~ ".json, .jsonc — max 1 MB"
+      assert html =~ "File is not valid JSON or JSONC."
+    end
+
+    test "renders footer Cancel wired to close_import" do
+      html = render_workflow_modal()
+
+      assert html =~ ~s(phx-click="close_import")
+      assert html =~ "Cancel"
+    end
+
+    test "renders Import N file(s) submit in the footer, wired to the dropzone form" do
+      html = render_workflow_modal()
+
+      assert html =~ ~s(form="workflow-import-form")
+      assert html =~ "Import 0 file(s)"
+      assert html =~ "disabled"
+    end
   end
 
   describe "modal_upload/1 defaults (ingestion)" do
@@ -169,6 +259,22 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUploadTest do
 
     test "keeps the ingestion hint" do
       assert render_ingestion_modal() =~ ".docx"
+    end
+
+    test "renders a footer Cancel wired to the default cancel event" do
+      html = render_ingestion_modal()
+
+      assert html =~ ~s(phx-click="close_modal")
+      assert html =~ "Cancel"
+    end
+
+    test "renders Upload N file(s) submit in the footer, disabled with an empty queue" do
+      html = render_ingestion_modal()
+
+      assert html =~ ~s(form="upload-form")
+      assert html =~ ~s(id="upload-files-button")
+      assert html =~ "Upload 0 file(s)"
+      assert html =~ "disabled"
     end
   end
 

--- a/test/zaq_web/live/bo/ai/workflows_live_test.exs
+++ b/test/zaq_web/live/bo/ai/workflows_live_test.exs
@@ -774,7 +774,7 @@ defmodule ZaqWeb.Live.BO.AI.WorkflowsLiveTest do
         ])
 
       assert {:error, _} = render_upload(upload, "big.json")
-      assert render(view) =~ "file exceeds size limit"
+      assert render(view) =~ "File exceeds 1 MB limit."
     end
 
     test "rejects a second file when max_entries is 1", %{conn: conn} do


### PR DESCRIPTION
Unify upload modals via ModalUpload for workflow import:
Replaced the import modal in Workflow and standardised it in ingestion and skills. 
Now one upload component inside a modal is used for all 3 places. 