### PR TITLE
refactor(agent): rename DataSourceTool to Helpers.ChannelTool, add encoding

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,7 +39,8 @@ config :zaq, :channels, %{
     adapter: Zaq.Channels.EmailBridge.ImapAdapter,
     message_format: :html
   },
-  web: %{bridge: Zaq.Channels.WebBridge}
+  web: %{bridge: Zaq.Channels.WebBridge},
+  disk: %{bridge: Zaq.Channels.DiskBridge}
 }
 
 config :zaq,

--- a/lib/zaq/agent/tools/data_source/create_document.ex
+++ b/lib/zaq/agent/tools/data_source/create_document.ex
@@ -5,42 +5,62 @@ defmodule Zaq.Agent.Tools.DataSource.CreateDocument do
   Delegates to Channels through `NodeRouter.dispatch/1`.
   """
 
+  @schema Zoi.object(%{
+            provider: Zoi.string(description: "Datasource provider key"),
+            name: Zoi.string(description: "Document name/title"),
+            content:
+              Zoi.string(description: "Optional textual content to create")
+              |> Zoi.optional(),
+            encoding:
+              Zoi.string(description: "Optional content encoding, e.g. base64 for binary content")
+              |> Zoi.optional(),
+            path:
+              Zoi.string(description: "Optional provider path/parent folder")
+              |> Zoi.optional(),
+            parent_id:
+              Zoi.string(description: "Optional provider parent identifier")
+              |> Zoi.optional(),
+            mime_type:
+              Zoi.string(description: "Optional provider MIME type")
+              |> Zoi.optional(),
+            config_id:
+              Zoi.string(description: "Optional scoped datasource config id")
+              |> Zoi.optional()
+          })
+
+  @output_schema Zoi.object(%{
+                   record:
+                     Zoi.any(description: "Created document metadata record")
+                     |> Zoi.optional()
+                 })
+
   use Zaq.Engine.Workflows.Action,
     name: "create_document",
-    output_schema: [
-      record: [type: :any, required: false, doc: "Created document metadata record"]
-    ],
     description: """
     Create a document on a specific datasource provider.
     Returns provider metadata for the created document.
     """,
-    schema: [
-      provider: [type: :string, required: true, doc: "Datasource provider key"],
-      name: [type: :string, required: true, doc: "Document name/title"],
-      content: [type: :string, required: false, doc: "Optional textual content to create"],
-      path: [type: :string, required: false, doc: "Optional provider path/parent folder"],
-      parent_id: [type: :string, required: false, doc: "Optional provider parent identifier"],
-      mime_type: [type: :string, required: false, doc: "Optional provider MIME type"],
-      config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
-    ]
+    schema: @schema,
+    output_schema: @output_schema
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
   def run(%{provider: provider} = params, context) do
     request =
       %{}
-      |> DataSourceTool.merge_optional(params, [
+      |> ChannelTool.merge_optional(params, [
         :name,
         :content,
+        :encoding,
         :path,
         :parent_id,
         :mime_type,
         :config_id
       ])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_create_file,
       request,
       context,

--- a/lib/zaq/agent/tools/data_source/download_document.ex
+++ b/lib/zaq/agent/tools/data_source/download_document.ex
@@ -2,7 +2,9 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
   @moduledoc """
   ReAct tool: downloads a document by id from a datasource provider.
 
-  Delegates to Channels through `NodeRouter.dispatch/1`.
+  Delegates to Channels through `NodeRouter.dispatch/1`. A bridge that answers with an
+  unmaterialized record — `content: nil` plus a `materializing_event` — takes a second hop
+  through that event, so the tool returns content whichever way the provider works.
   """
 
   use Zaq.Engine.Workflows.Action,
@@ -33,6 +35,8 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
 
   alias Zaq.Agent.Tools.DataSourceTool
 
+  @error_prefix "Data source document download failed"
+
   @impl Jido.Action
 
   def run(%{provider: provider, document_id: document_id} = params, context) do
@@ -49,7 +53,8 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
       :data_source_download_document,
       request,
       context,
-      "Data source document download failed"
+      @error_prefix,
+      &DataSourceTool.materialize(&1, context, @error_prefix)
     )
   end
 end

--- a/lib/zaq/agent/tools/data_source/download_document.ex
+++ b/lib/zaq/agent/tools/data_source/download_document.ex
@@ -7,33 +7,41 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
   through that event, so the tool returns content whichever way the provider works.
   """
 
+  @schema Zoi.object(%{
+            provider: Zoi.string(description: "Datasource provider key"),
+            document_id: Zoi.string(description: "Provider document identifier"),
+            document_mime_type:
+              Zoi.string(
+                description:
+                  "Optional source MIME type of the provider document. Used for automatic export type decision."
+              )
+              |> Zoi.optional(),
+            export_mime_type:
+              Zoi.string(
+                description: "Optional target MIME type to request provider export when supported"
+              )
+              |> Zoi.optional(),
+            config_id:
+              Zoi.string(description: "Optional scoped datasource config id")
+              |> Zoi.optional()
+          })
+
+  @output_schema Zoi.object(%{
+                   record:
+                     Zoi.any(description: "Normalized record including document content")
+                     |> Zoi.optional()
+                 })
+
   use Zaq.Engine.Workflows.Action,
     name: "download_document",
-    output_schema: [
-      record: [type: :any, required: false, doc: "Normalized record including document content"]
-    ],
     description: """
     Download a document by id from a specific datasource provider.
     Returns a normalized record including document content.
     """,
-    schema: [
-      provider: [type: :string, required: true, doc: "Datasource provider key"],
-      document_id: [type: :string, required: true, doc: "Provider document identifier"],
-      document_mime_type: [
-        type: :string,
-        required: false,
-        doc:
-          "Optional source MIME type of the provider document. Used for automatic export type decision."
-      ],
-      export_mime_type: [
-        type: :string,
-        required: false,
-        doc: "Optional target MIME type to request provider export when supported"
-      ],
-      config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
-    ]
+    schema: @schema,
+    output_schema: @output_schema
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @error_prefix "Data source document download failed"
 
@@ -42,19 +50,19 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
   def run(%{provider: provider, document_id: document_id} = params, context) do
     request =
       %{"file_id" => document_id}
-      |> DataSourceTool.merge_optional(params, [
+      |> ChannelTool.merge_optional(params, [
         :document_mime_type,
         :export_mime_type,
         :config_id
       ])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_download_document,
       request,
       context,
       @error_prefix,
-      &DataSourceTool.materialize(&1, context, @error_prefix)
+      &ChannelTool.materialize(&1, context, @error_prefix)
     )
   end
 end

--- a/lib/zaq/agent/tools/data_source/get_document.ex
+++ b/lib/zaq/agent/tools/data_source/get_document.ex
@@ -20,17 +20,17 @@ defmodule Zaq.Agent.Tools.DataSource.GetDocument do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, document_id: document_id} = params, context) do
     request =
       %{"file_id" => document_id}
-      |> DataSourceTool.merge_optional(params, [:config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_get_file,
       request,
       context,

--- a/lib/zaq/agent/tools/data_source/list_documents.ex
+++ b/lib/zaq/agent/tools/data_source/list_documents.ex
@@ -21,17 +21,17 @@ defmodule Zaq.Agent.Tools.DataSource.ListDocuments do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, path: path} = params, context) do
     request =
       %{"path" => path}
-      |> DataSourceTool.merge_optional(params, [:config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_list_files,
       request,
       context,

--- a/lib/zaq/agent/tools/data_source/search_documents.ex
+++ b/lib/zaq/agent/tools/data_source/search_documents.ex
@@ -23,20 +23,20 @@ defmodule Zaq.Agent.Tools.DataSource.SearchDocuments do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, query: query} = params, context) do
     request =
       %{"query" => query}
-      |> DataSourceTool.put_many_if_present([
+      |> ChannelTool.put_many_if_present([
         {"path", Map.get(params, :path)},
         {"config_id", Map.get(params, :config_id)}
       ])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_search_files,
       request,
       context,

--- a/lib/zaq/agent/tools/data_source/update_document.ex
+++ b/lib/zaq/agent/tools/data_source/update_document.ex
@@ -29,14 +29,14 @@ defmodule Zaq.Agent.Tools.DataSource.UpdateDocument do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, document_id: document_id} = params, context) do
     request =
       %{"file_id" => document_id}
-      |> DataSourceTool.merge_optional(params, [
+      |> ChannelTool.merge_optional(params, [
         :name,
         :content,
         :path,
@@ -44,9 +44,9 @@ defmodule Zaq.Agent.Tools.DataSource.UpdateDocument do
         :mime_type,
         :config_id
       ])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_update_file,
       request,
       context,

--- a/lib/zaq/agent/tools/data_source_tool.ex
+++ b/lib/zaq/agent/tools/data_source_tool.ex
@@ -4,6 +4,7 @@ defmodule Zaq.Agent.Tools.DataSourceTool do
   """
 
   alias Zaq.Agent.Tools.Error
+  alias Zaq.Contracts.Record
   alias Zaq.Event
   alias Zaq.NodeRouter
 
@@ -33,6 +34,39 @@ defmodule Zaq.Agent.Tools.DataSourceTool do
   def format_response(other, _error_prefix, _on_ok) do
     {:error, "Unexpected data source response: #{inspect(other)}"}
   end
+
+  @doc """
+  Fills in a record's content when the bridge answered with an unmaterialized one.
+
+  A bridge whose bytes already sit inside ZAQ returns `content: nil` and a
+  `materializing_event` instead of carrying the payload back through the channels node — the
+  disk data source does this, since its files live on an ingestion volume. Dispatching that
+  event is the second hop that actually reads them.
+
+  A payload that already has content, or a record with no event to dispatch, passes through
+  untouched — so a caller can run this over any provider's answer.
+
+  Read `attributes["encoding"]` on the result: `"base64"` means the content is encoded bytes,
+  and its absence means it is already text.
+  """
+  @spec materialize(map(), map(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def materialize(
+        %{record: %Record{content: nil, materializing_event: %Event{} = event}} = payload,
+        context,
+        error_prefix
+      ) do
+    node_router = Map.get(context, :node_router, NodeRouter)
+
+    event
+    |> node_router.dispatch()
+    |> Map.fetch!(:response)
+    |> format_response(error_prefix, fn
+      %{record: %Record{} = record} -> {:ok, %{payload | record: record}}
+      other -> {:error, "#{error_prefix}: unexpected materialize response #{inspect(other)}"}
+    end)
+  end
+
+  def materialize(payload, _context, _error_prefix), do: {:ok, payload}
 
   @spec put_if_present(map(), String.t(), any()) :: map()
   def put_if_present(map, _key, nil), do: map

--- a/lib/zaq/agent/tools/helpers/channel_tool.ex
+++ b/lib/zaq/agent/tools/helpers/channel_tool.ex
@@ -1,6 +1,6 @@
-defmodule Zaq.Agent.Tools.DataSourceTool do
+defmodule Zaq.Agent.Tools.Helpers.ChannelTool do
   @moduledoc """
-  Shared dispatch and response handling for datasource-backed agent tools.
+  Shared dispatch and response handling for agent tools backed by the channels node.
   """
 
   alias Zaq.Agent.Tools.Error
@@ -32,7 +32,7 @@ defmodule Zaq.Agent.Tools.DataSourceTool do
   end
 
   def format_response(other, _error_prefix, _on_ok) do
-    {:error, "Unexpected data source response: #{inspect(other)}"}
+    {:error, "Unexpected channel response: #{inspect(other)}"}
   end
 
   @doc """

--- a/lib/zaq/agent/tools/sheets/add_sheet_tab.ex
+++ b/lib/zaq/agent/tools/sheets/add_sheet_tab.ex
@@ -41,17 +41,17 @@ defmodule Zaq.Agent.Tools.Sheets.AddSheetTab do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, spreadsheet_id: spreadsheet_id, title: title} = params, context) do
     request =
       %{"spreadsheet_id" => spreadsheet_id, "title" => title}
-      |> DataSourceTool.merge_optional(params, [:index, :auto_suffix_on_conflict, :config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:index, :auto_suffix_on_conflict, :config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_add_tab,
       request,
       context,

--- a/lib/zaq/agent/tools/sheets/append_sheet_values.ex
+++ b/lib/zaq/agent/tools/sheets/append_sheet_values.ex
@@ -37,7 +37,7 @@ defmodule Zaq.Agent.Tools.Sheets.AppendSheetValues do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
@@ -48,10 +48,10 @@ defmodule Zaq.Agent.Tools.Sheets.AppendSheetValues do
         "range" => Map.fetch!(params, :range),
         "values" => Map.fetch!(params, :values)
       }
-      |> DataSourceTool.merge_optional(params, [:value_input_option, :config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:value_input_option, :config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_append_values,
       request,
       context,

--- a/lib/zaq/agent/tools/sheets/clear_sheet_values.ex
+++ b/lib/zaq/agent/tools/sheets/clear_sheet_values.ex
@@ -27,17 +27,17 @@ defmodule Zaq.Agent.Tools.Sheets.ClearSheetValues do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, spreadsheet_id: spreadsheet_id, range: range} = params, context) do
     request =
       %{"spreadsheet_id" => spreadsheet_id, "range" => range}
-      |> DataSourceTool.merge_optional(params, [:config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_clear_values,
       request,
       context,

--- a/lib/zaq/agent/tools/sheets/create_sheet.ex
+++ b/lib/zaq/agent/tools/sheets/create_sheet.ex
@@ -29,17 +29,17 @@ defmodule Zaq.Agent.Tools.Sheets.CreateSheet do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, title: title} = params, context) do
     request =
       %{"title" => title}
-      |> DataSourceTool.merge_optional(params, [:config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_create,
       request,
       context,

--- a/lib/zaq/agent/tools/sheets/delete_sheet_tab.ex
+++ b/lib/zaq/agent/tools/sheets/delete_sheet_tab.ex
@@ -27,7 +27,7 @@ defmodule Zaq.Agent.Tools.Sheets.DeleteSheetTab do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
@@ -37,10 +37,10 @@ defmodule Zaq.Agent.Tools.Sheets.DeleteSheetTab do
       ) do
     request =
       %{"spreadsheet_id" => spreadsheet_id, "sheet_id" => sheet_id}
-      |> DataSourceTool.merge_optional(params, [:config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_delete_tab,
       request,
       context,

--- a/lib/zaq/agent/tools/sheets/get_sheet.ex
+++ b/lib/zaq/agent/tools/sheets/get_sheet.ex
@@ -33,7 +33,7 @@ defmodule Zaq.Agent.Tools.Sheets.GetSheet do
       ]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
   alias Zaq.Contracts.Record
 
   @spec run(
@@ -49,10 +49,10 @@ defmodule Zaq.Agent.Tools.Sheets.GetSheet do
   def run(%{provider: provider, spreadsheet_id: spreadsheet_id} = params, context) do
     request =
       %{"spreadsheet_id" => spreadsheet_id}
-      |> DataSourceTool.merge_optional(params, [:range, :config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:range, :config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_get,
       request,
       context,

--- a/lib/zaq/agent/tools/sheets/inspect_sheet.ex
+++ b/lib/zaq/agent/tools/sheets/inspect_sheet.ex
@@ -28,17 +28,17 @@ defmodule Zaq.Agent.Tools.Sheets.InspectSheet do
       config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
 
   @impl Jido.Action
 
   def run(%{provider: provider, spreadsheet_id: spreadsheet_id} = params, context) do
     request =
       %{"spreadsheet_id" => spreadsheet_id}
-      |> DataSourceTool.merge_optional(params, [:config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_inspect,
       request,
       context,

--- a/lib/zaq/agent/tools/sheets/update_sheet_values.ex
+++ b/lib/zaq/agent/tools/sheets/update_sheet_values.ex
@@ -46,7 +46,7 @@ defmodule Zaq.Agent.Tools.Sheets.UpdateSheetValues do
       ]
     ]
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
   alias Zaq.Contracts.Record
 
   @spec run(
@@ -68,10 +68,10 @@ defmodule Zaq.Agent.Tools.Sheets.UpdateSheetValues do
         "range" => Map.fetch!(params, :range),
         "values" => Map.fetch!(params, :values)
       }
-      |> DataSourceTool.merge_optional(params, [:value_input_option, :config_id])
-      |> DataSourceTool.wrap_request(provider)
+      |> ChannelTool.merge_optional(params, [:value_input_option, :config_id])
+      |> ChannelTool.wrap_request(provider)
 
-    DataSourceTool.dispatch(
+    ChannelTool.dispatch(
       :data_source_sheet_update_values,
       request,
       context,

--- a/lib/zaq/channels/channel_config.ex
+++ b/lib/zaq/channels/channel_config.ex
@@ -23,7 +23,7 @@ defmodule Zaq.Channels.ChannelConfig do
   @smtp_provider "email:smtp"
   @imap_provider "email:imap"
   @valid_kinds ~w(data_source retrieval)
-  @valid_providers ~w(mattermost slack teams google_drive sharepoint email:smtp email:imap telegram discord)
+  @valid_providers ~w(mattermost slack teams google_drive sharepoint email:smtp email:imap telegram discord disk)
 
   schema "channel_configs" do
     field :name, :string

--- a/lib/zaq/channels/data_source_bridge.ex
+++ b/lib/zaq/channels/data_source_bridge.ex
@@ -73,6 +73,46 @@ defmodule Zaq.Channels.DataSourceBridge do
   @callback sheet_clear_values(map(), map()) :: {:ok, map()} | {:error, term()}
   @callback sheet_delete_tab(map(), map()) :: {:ok, map()} | {:error, term()}
 
+  # Every callback above is optional. This module already dispatches through
+  # `supports_callback?/3` and answers `{:error, :unsupported}` for anything a bridge does
+  # not export, so partial implementation is the design, not an accident — a provider that
+  # has no spreadsheets should not have to stub twelve sheet functions. Declaring them
+  # optional makes the behaviour say what the dispatcher already does, and lets a narrow
+  # bridge (`Zaq.Channels.DiskBridge`) still get compile-time checking on the callbacks it
+  # does implement.
+  @optional_callbacks auth_handshake: 2,
+                      list_resources: 2,
+                      download_resource: 3,
+                      setup_listener: 2,
+                      teardown_listener: 2,
+                      watch_changes: 2,
+                      unwatch_changes: 2,
+                      watch_item: 2,
+                      unwatch_item: 2,
+                      handle_webhook: 2,
+                      oauth_authorize_url: 2,
+                      oauth_exchange_code: 2,
+                      oauth_refresh_token: 2,
+                      oauth_default_scopes: 1,
+                      list_files: 2,
+                      create_file: 2,
+                      get_file: 2,
+                      update_file: 2,
+                      delete_file: 2,
+                      search_files: 2,
+                      download_document: 2,
+                      list_permissions: 2,
+                      channel_stats: 2,
+                      export_options: 2,
+                      sheet_inspect: 2,
+                      sheet_get: 2,
+                      sheet_create: 2,
+                      sheet_add_tab: 2,
+                      sheet_update_values: 2,
+                      sheet_append_values: 2,
+                      sheet_clear_values: 2,
+                      sheet_delete_tab: 2
+
   @required_capabilities [
     :list_items,
     :count_items,

--- a/lib/zaq/channels/disk_bridge.ex
+++ b/lib/zaq/channels/disk_bridge.ex
@@ -6,10 +6,16 @@ defmodule Zaq.Channels.DiskBridge do
   changes two things.
 
   Nothing is read on the channels node: every callback dispatches a `%Zaq.Event{}` to
-  `:ingestion`, which owns `FileExplorer` and the `documents` table. `download_document/2`
-  goes further and returns the record unmaterialized — `content: nil` plus a
-  `materializing_event` — so a listing does not drag file bytes across a node boundary for a
-  caller that only wanted metadata.
+  `:ingestion`, which owns `FileExplorer` and the `documents` table. Ingestion answers with
+  its own shapes — `Zaq.Ingestion.FileExplorer.Entry` values and flat permission grants — and
+  mapping those onto `Zaq.Contracts.Record` is this module's job, the same way
+  `Zaq.Channels.JidoConnectBridge` maps provider payloads.
+
+  Records come back **unmaterialized**: `content: nil` plus a `materializing_event`, so a
+  listing does not drag file bytes across a node boundary for a caller that only wanted
+  metadata. Dispatching that event goes straight to ingestion, deliberately not back through
+  here — which is why `materialize_record` is the one ingestion action that still answers
+  with a record rather than an entry.
 
   A file is named by its `documents.id`, the same handle `list_files/2` returns and
   `get_file/2`, `update_file/2`, and `delete_file/2` accept. Folders and files with no
@@ -21,8 +27,11 @@ defmodule Zaq.Channels.DiskBridge do
   alias Zaq.Contracts.Record
   alias Zaq.Contracts.RecordPage
   alias Zaq.Event
+  alias Zaq.Ingestion.FileExplorer.Entry
   alias Zaq.NodeRouter
   alias Zaq.Utils
+
+  @provider "disk"
 
   @doc "Reports what the mounted volumes hold — file, folder, and principal counts."
   @impl true
@@ -35,7 +44,9 @@ defmodule Zaq.Channels.DiskBridge do
   @doc "Lists the documents on the mounted volumes as **unmaterialized** records — no content."
   @impl true
   def list_files(config, params) when is_map(config) and is_map(params) do
-    dispatch(:list_records, %{params: params}, config)
+    with {:ok, page} <- dispatch(:list_records, %{params: params}, config) do
+      {:ok, record_page(page)}
+    end
   end
 
   @doc """
@@ -47,7 +58,10 @@ defmodule Zaq.Channels.DiskBridge do
   """
   @impl true
   def create_file(config, params) when is_map(config) and is_map(params) do
-    dispatch(:persist_record, persist_request(params), config)
+    with {:ok, %{entry: entry} = result} <-
+           dispatch(:persist_record, persist_request(params), config) do
+      {:ok, %{status: Map.get(result, :status, "created"), record: map_entry(entry)}}
+    end
   end
 
   @doc "Returns one document as an unmaterialized record — metadata only, no content."
@@ -55,19 +69,8 @@ defmodule Zaq.Channels.DiskBridge do
   def get_file(config, params) when is_map(config) and is_map(params) do
     file_id = to_string(fetch(params, "file_id"))
 
-    case dispatch(:describe_records, %{file_ids: [file_id]}, config) do
-      # The id is re-checked rather than assumed. `describe_records` resolves exactly the ids
-      # it was given, so this holds today — but it holds across a role boundary, and an
-      # unchecked head would turn a future contract drift into the wrong file rather than a
-      # `:not_found`.
-      {:ok, %RecordPage{records: [%Record{id: ^file_id} = record | _]}} ->
-        {:ok, %{record: record}}
-
-      {:ok, %RecordPage{}} ->
-        {:error, :not_found}
-
-      {:error, reason} ->
-        {:error, reason}
+    with {:ok, %Entry{} = entry} <- dispatch(:describe_record, %{file_id: file_id}, config) do
+      {:ok, %{record: map_entry(entry)}}
     end
   end
 
@@ -79,10 +82,18 @@ defmodule Zaq.Channels.DiskBridge do
   """
   @impl true
   def update_file(config, params) when is_map(config) and is_map(params) do
-    dispatch(:update_record, update_request(params), config)
+    with {:ok, %{entry: entry} = result} <-
+           dispatch(:update_record, update_request(params), config) do
+      {:ok, %{status: Map.get(result, :status, "updated"), record: map_entry(entry)}}
+    end
   end
 
-  @doc "Removes the document row and the file behind it, along with its chunks and sidecars."
+  @doc """
+  Removes the document row and the file behind it, along with its chunks and sidecars.
+
+  Answers with the status alone. The file is gone by the time ingestion returns, so there is
+  nothing left to describe — the same answer `JidoConnectBridge.delete_file/2` gives.
+  """
   @impl true
   def delete_file(config, params) when is_map(config) and is_map(params) do
     dispatch(:delete_record, %{file_id: to_string(fetch(params, "file_id"))}, config)
@@ -91,7 +102,9 @@ defmodule Zaq.Channels.DiskBridge do
   @doc "Finds documents whose source or title matches `query`."
   @impl true
   def search_files(config, params) when is_map(config) and is_map(params) do
-    dispatch(:search_records, %{params: params}, config)
+    with {:ok, page} <- dispatch(:search_records, %{params: params}, config) do
+      {:ok, record_page(page)}
+    end
   end
 
   @doc """
@@ -111,11 +124,109 @@ defmodule Zaq.Channels.DiskBridge do
     get_file(config, params)
   end
 
-  @doc "Lists who can read the given document — one record per person or team grant."
+  @doc "Lists who can read the given document — one record per person, team, or public grant."
   @impl true
   def list_permissions(config, params) when is_map(config) and is_map(params) do
-    dispatch(:list_record_permissions, %{file_id: to_string(fetch(params, "file_id"))}, config)
+    file_id = to_string(fetch(params, "file_id"))
+
+    with {:ok, grants} <- dispatch(:list_record_permissions, %{file_id: file_id}, config) do
+      {:ok, permission_page(grants, file_id)}
+    end
   end
+
+  # -- mapping --
+
+  # Ingestion answers with volume entries; the canonical record shape is put on here. The
+  # entry's `:directory` becomes the record's `:folder` — the two vocabularies meet at this
+  # function and nowhere else.
+  defp map_entry(%Entry{} = entry) do
+    kind = kind(entry.type)
+
+    %Record{
+      id: entry.id,
+      kind: kind,
+      name: entry.name,
+      path: entry.relative_path,
+      mime_type: mime_type(kind, entry.name),
+      materializing_event: materializing_event(kind, entry.id),
+      size: entry.size,
+      modified_at: entry.modified_at,
+      attributes: %{
+        "provider" => @provider,
+        "volume" => entry.volume,
+        "relative_path" => entry.relative_path,
+        "source" => entry.source
+      },
+      raw: %{local_entry: entry}
+    }
+  end
+
+  defp record_page(%{entries: entries, scanned: scanned}) do
+    records = Enum.map(entries, &map_entry/1)
+
+    %RecordPage{
+      resource_type: :item,
+      records: records,
+      stats: %{scanned: scanned, returned: length(records)}
+    }
+  end
+
+  # Public access has no `resource_permissions` row, so ingestion reports it as a flag and
+  # the grant is synthesized here. Its id is derived from the document — stable across calls,
+  # and visibly not a permission-row id.
+  defp permission_page(%{permissions: grants, public?: public?}, file_id) do
+    records = public_records(public?, file_id) ++ Enum.map(grants, &map_permission/1)
+
+    %RecordPage{
+      resource_type: :permission,
+      records: records,
+      stats: %{scanned: length(records), returned: length(records)}
+    }
+  end
+
+  defp public_records(false, _file_id), do: []
+
+  defp public_records(true, file_id) do
+    [
+      %Record{
+        id: "public:#{file_id}",
+        kind: :permission,
+        name: "Public",
+        lifecycle_state: :active,
+        attributes: %{"type" => "public", "target_id" => nil, "access_rights" => ["read"]}
+      }
+    ]
+  end
+
+  defp map_permission(grant) when is_map(grant) do
+    %Record{
+      id: to_string(grant.id),
+      kind: :permission,
+      name: grant.name,
+      lifecycle_state: :active,
+      attributes: %{
+        "type" => grant.type,
+        "target_id" => grant.target_id,
+        "access_rights" => grant.access_rights || []
+      }
+    }
+  end
+
+  defp kind(:directory), do: :folder
+  defp kind(_type), do: :file
+
+  # A volume entry carries no declared type, so the extension is all there is to go on.
+  defp mime_type(:file, name) when is_binary(name), do: MIME.from_path(name)
+  defp mime_type(_kind, _name), do: nil
+
+  # A record travels without its bytes — reading every file a listing names would be wasted
+  # work. This is the hop that fetches them when a caller actually wants the content, and it
+  # goes straight to ingestion rather than back through this bridge. A folder has nothing to
+  # materialize.
+  defp materializing_event(:file, id) when is_binary(id),
+    do: Event.new(%{file_id: id}, :ingestion, opts: [action: :materialize_record])
+
+  defp materializing_event(_kind, _id), do: nil
 
   # -- requests --
 

--- a/lib/zaq/channels/disk_bridge.ex
+++ b/lib/zaq/channels/disk_bridge.ex
@@ -1,0 +1,161 @@
+defmodule Zaq.Channels.DiskBridge do
+  @moduledoc """
+  Data-source bridge over the ingestion volumes mounted on this install.
+
+  Unlike a bridge fronting a remote provider, the files here are already inside ZAQ. That
+  changes two things.
+
+  Nothing is read on the channels node: every callback dispatches a `%Zaq.Event{}` to
+  `:ingestion`, which owns `FileExplorer` and the `documents` table. `download_document/2`
+  goes further and returns the record unmaterialized — `content: nil` plus a
+  `materializing_event` — so a listing does not drag file bytes across a node boundary for a
+  caller that only wanted metadata.
+
+  A file is named by its `documents.id`, the same handle `list_files/2` returns and
+  `get_file/2`, `update_file/2`, and `delete_file/2` accept. Folders and files with no
+  document row fall back to a volume-path id, since there is no document to name.
+  """
+
+  @behaviour Zaq.Channels.DataSourceBridge
+
+  alias Zaq.Contracts.Record
+  alias Zaq.Contracts.RecordPage
+  alias Zaq.Event
+  alias Zaq.NodeRouter
+  alias Zaq.Utils
+
+  @doc "Reports what the mounted volumes hold — file, folder, and principal counts."
+  @impl true
+  def channel_stats(config, params) when is_map(config) and is_map(params) do
+    dispatch(:volume_stats, %{params: params}, config)
+  end
+
+  # -- files --
+
+  @doc "Lists the documents on the mounted volumes as **unmaterialized** records — no content."
+  @impl true
+  def list_files(config, params) when is_map(config) and is_map(params) do
+    dispatch(:list_records, %{params: params}, config)
+  end
+
+  @doc """
+  Writes a file onto a volume and registers its document row.
+
+  `path` is the destination directory and carries the volume; `name` is the file. Binary
+  content travels base64-encoded under `encoding`. Ingestion owns which volumes are mounted,
+  so it validates the destination rather than this bridge.
+  """
+  @impl true
+  def create_file(config, params) when is_map(config) and is_map(params) do
+    dispatch(:persist_record, persist_request(params), config)
+  end
+
+  @doc "Returns one document as an unmaterialized record — metadata only, no content."
+  @impl true
+  def get_file(config, params) when is_map(config) and is_map(params) do
+    file_id = to_string(fetch(params, "file_id"))
+
+    case dispatch(:describe_records, %{file_ids: [file_id]}, config) do
+      # The id is re-checked rather than assumed. `describe_records` resolves exactly the ids
+      # it was given, so this holds today — but it holds across a role boundary, and an
+      # unchecked head would turn a future contract drift into the wrong file rather than a
+      # `:not_found`.
+      {:ok, %RecordPage{records: [%Record{id: ^file_id} = record | _]}} ->
+        {:ok, %{record: record}}
+
+      {:ok, %RecordPage{}} ->
+        {:error, :not_found}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Rewrites, renames, or moves an existing document.
+
+  Every field but `file_id` is optional: `name` renames, `path` moves to another directory,
+  `content` (with `encoding` for binary) overwrites the bytes.
+  """
+  @impl true
+  def update_file(config, params) when is_map(config) and is_map(params) do
+    dispatch(:update_record, update_request(params), config)
+  end
+
+  @doc "Removes the document row and the file behind it, along with its chunks and sidecars."
+  @impl true
+  def delete_file(config, params) when is_map(config) and is_map(params) do
+    dispatch(:delete_record, %{file_id: to_string(fetch(params, "file_id"))}, config)
+  end
+
+  @doc "Finds documents whose source or title matches `query`."
+  @impl true
+  def search_files(config, params) when is_map(config) and is_map(params) do
+    dispatch(:search_records, %{params: params}, config)
+  end
+
+  @doc """
+  Returns the document as an **unmaterialized** record: `content: nil` plus the
+  `materializing_event` that fetches the bytes.
+
+  Unlike a bridge fronting a system that holds the file, this one reads nothing. The bytes
+  live on an ingestion volume, so carrying them back through here would route the whole
+  payload across the channels node for no reason. A caller that actually wants the content
+  dispatches `record.materializing_event`, which goes straight to ingestion.
+
+  That makes this the same answer as `get_file/2` — the difference between the two is what
+  the caller does with the record, not what this bridge reads.
+  """
+  @impl true
+  def download_document(config, params) when is_map(config) and is_map(params) do
+    get_file(config, params)
+  end
+
+  @doc "Lists who can read the given document — one record per person or team grant."
+  @impl true
+  def list_permissions(config, params) when is_map(config) and is_map(params) do
+    dispatch(:list_record_permissions, %{file_id: to_string(fetch(params, "file_id"))}, config)
+  end
+
+  # -- requests --
+
+  defp persist_request(params) do
+    %{
+      "name" => fetch(params, "name"),
+      "path" => fetch(params, "path"),
+      "content" => fetch(params, "content") || "",
+      "encoding" => fetch(params, "encoding")
+    }
+  end
+
+  # Only the keys the caller actually sent travel, so ingestion can tell "leave this alone"
+  # from "set this to empty" — an absent `content` must not truncate the file.
+  defp update_request(params) do
+    ["name", "path", "content", "encoding"]
+    |> Enum.reduce(%{"file_id" => to_string(fetch(params, "file_id"))}, fn key, request ->
+      case fetch(params, key) do
+        nil -> request
+        value -> Map.put(request, key, value)
+      end
+    end)
+  end
+
+  # -- dispatch --
+
+  # The bytes and the document rows live on the ingestion node, so every read crosses a role
+  # boundary. The router is read off `config`, never off `params`: `params` is caller-supplied
+  # data that reaches here verbatim from agent tools, and choosing the dispatch target from it
+  # would make what runs a function of what the caller sent.
+  defp dispatch(action, request, config) do
+    node_router = fetch(config, "node_router") || NodeRouter
+
+    request
+    |> Event.new(:ingestion, opts: [action: action])
+    |> node_router.dispatch()
+    |> Map.fetch!(:response)
+  end
+
+  # Params arrive from agent tools with string keys and from internal callers with atom keys;
+  # accept either rather than forcing every caller to normalise first.
+  defp fetch(params, key), do: Utils.Map.present_value(params, key)
+end

--- a/lib/zaq/contracts/record.ex
+++ b/lib/zaq/contracts/record.ex
@@ -1,31 +1,49 @@
 defmodule Zaq.Contracts.Record do
-  @moduledoc "Canonical domain-agnostic record payload."
+  @moduledoc """
+  Canonical domain-agnostic record payload.
 
-  @derive {
-    Jason.Encoder,
-    only: [
-      :id,
-      :kind,
-      :content,
-      :name,
-      :parent_id,
-      :mime_type,
-      :path,
-      :url,
-      :size,
-      :description,
-      :icon,
-      :created_at,
-      :modified_at,
-      :change_type,
-      :lifecycle_state,
-      :deleted_at,
-      :permissions,
-      :parent_ids,
-      :owners,
-      :attributes
-    ]
-  }
+  A pure struct — it never dispatches. A record may travel between nodes
+  **unmaterialized**: full metadata with `content: nil` and a `materializing_event` that
+  fetches the bytes. Dispatching that event is `Zaq.Contracts.Record.Materializer`'s job.
+
+  `materializing_event` is excluded from both the `Jason.Encoder` `only:` list and
+  `to_map/1`, because a dispatchable event inside a serialized payload would let whoever
+  holds the record choose which event fires, on which node, with which params. As a result a
+  record rebuilt from JSON — out of an LLM tool result or persisted workflow state — always
+  comes back with `materializing_event: nil` and cannot be materialized.
+  """
+
+  # The record's public projection: what may leave the struct, whether as JSON or as a plain
+  # map. `raw` and `materializing_event` are deliberately absent — `raw` holds provider
+  # internals, and `materializing_event` is a dispatchable capability that must never travel
+  # to a model or into persisted state.
+  #
+  # One list, used by both the encoder and `to_map/1`, so the two cannot drift apart and
+  # accidentally expose a field through one path but not the other.
+  @public_fields [
+    :id,
+    :kind,
+    :content,
+    :name,
+    :parent_id,
+    :mime_type,
+    :path,
+    :url,
+    :size,
+    :description,
+    :icon,
+    :created_at,
+    :modified_at,
+    :change_type,
+    :lifecycle_state,
+    :deleted_at,
+    :permissions,
+    :parent_ids,
+    :owners,
+    :attributes
+  ]
+
+  @derive {Jason.Encoder, only: @public_fields}
 
   @enforce_keys [:id, :kind]
   defstruct [
@@ -46,6 +64,7 @@ defmodule Zaq.Contracts.Record do
     :lifecycle_state,
     :deleted_at,
     :permissions,
+    :materializing_event,
     parent_ids: [],
     owners: [],
     attributes: %{},
@@ -73,6 +92,17 @@ defmodule Zaq.Contracts.Record do
           deleted_at: DateTime.t() | nil,
           permissions: nil | [t()],
           attributes: map(),
-          raw: map()
+          raw: map(),
+          materializing_event: Zaq.Event.t() | nil
         }
+
+  @doc """
+  The record as a plain map carrying only the fields the `Jason.Encoder` derives from.
+
+  For boundaries that need a map rather than a struct, such as an agent tool's output.
+  Takes only the public fields rather than using `Map.from_struct/1`, so `raw` and
+  `materializing_event` are dropped.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = record), do: Map.take(record, @public_fields)
 end

--- a/lib/zaq/ingestion/api.ex
+++ b/lib/zaq/ingestion/api.ex
@@ -24,6 +24,63 @@ defmodule Zaq.Ingestion.Api do
     %{event | response: Ingestion.process_data_source_changes(request)}
   end
 
+  # -- records --
+
+  def handle_event(%Event{request: %{file_ids: file_ids}} = event, :describe_records, _context)
+      when is_list(file_ids) do
+    %{event | response: Ingestion.describe_records(file_ids)}
+  end
+
+  def handle_event(%Event{request: %{params: params}} = event, :list_records, _context)
+      when is_map(params) do
+    %{event | response: Ingestion.list_records(params)}
+  end
+
+  def handle_event(
+        %Event{request: %{file_id: file_id} = request} = event,
+        :materialize_record,
+        _context
+      )
+      when is_binary(file_id) do
+    %{event | response: Ingestion.materialize_record(request)}
+  end
+
+  def handle_event(%Event{request: request} = event, :persist_record, _context)
+      when is_map(request) do
+    %{event | response: Ingestion.persist_record(request)}
+  end
+
+  def handle_event(%Event{request: request} = event, :update_record, _context)
+      when is_map(request) do
+    %{event | response: Ingestion.update_record(request)}
+  end
+
+  def handle_event(%Event{request: %{file_id: file_id}} = event, :delete_record, _context)
+      when is_binary(file_id) do
+    %{event | response: Ingestion.delete_record(file_id)}
+  end
+
+  def handle_event(
+        %Event{request: %{file_id: file_id}} = event,
+        :list_record_permissions,
+        _context
+      )
+      when is_binary(file_id) do
+    %{event | response: Ingestion.list_record_permissions(file_id)}
+  end
+
+  # -- volumes --
+
+  def handle_event(%Event{request: %{params: params}} = event, :search_records, _context)
+      when is_map(params) do
+    %{event | response: Ingestion.search_records(params)}
+  end
+
+  def handle_event(%Event{request: request} = event, :volume_stats, _context)
+      when is_map(request) do
+    %{event | response: Ingestion.volume_stats()}
+  end
+
   def handle_event(%Event{} = event, action, _context),
     do: InternalBoundaries.default_handle_event(event, action)
 end

--- a/lib/zaq/ingestion/api.ex
+++ b/lib/zaq/ingestion/api.ex
@@ -26,9 +26,9 @@ defmodule Zaq.Ingestion.Api do
 
   # -- records --
 
-  def handle_event(%Event{request: %{file_ids: file_ids}} = event, :describe_records, _context)
-      when is_list(file_ids) do
-    %{event | response: Ingestion.describe_records(file_ids)}
+  def handle_event(%Event{request: %{file_id: file_id}} = event, :describe_record, _context)
+      when is_binary(file_id) do
+    %{event | response: Ingestion.describe_record(file_id)}
   end
 
   def handle_event(%Event{request: %{params: params}} = event, :list_records, _context)

--- a/lib/zaq/ingestion/file_explorer.ex
+++ b/lib/zaq/ingestion/file_explorer.ex
@@ -10,6 +10,8 @@ defmodule Zaq.Ingestion.FileExplorer do
 
   require Logger
 
+  alias Zaq.Ingestion.FileExplorer.Entry
+
   @doc """
   Returns the configured base path for ingestion files.
   """
@@ -115,12 +117,12 @@ defmodule Zaq.Ingestion.FileExplorer do
 
   @doc """
   Lists files and folders in the given directory relative to base path.
-  Returns `{:ok, [%{name, type, size, modified_at}]}`.
+  Returns `{:ok, [%Zaq.Ingestion.FileExplorer.Entry{}]}`.
   """
   def list(relative_path \\ ".") do
     with {:ok, full_path} <- resolve_path(relative_path),
          true <- File.dir?(full_path) do
-      {:ok, list_entries(full_path)}
+      {:ok, list_entries(full_path, nil, relative_path)}
     else
       false -> {:error, :not_a_directory}
       error -> error
@@ -133,7 +135,7 @@ defmodule Zaq.Ingestion.FileExplorer do
   def list(volume_name, relative_path) when is_binary(volume_name) do
     with {:ok, full_path} <- resolve_path(volume_name, relative_path),
          true <- File.dir?(full_path) do
-      {:ok, list_entries(full_path)}
+      {:ok, list_entries(full_path, volume_name, relative_path)}
     else
       false -> {:error, :not_a_directory}
       error -> error
@@ -146,7 +148,7 @@ defmodule Zaq.Ingestion.FileExplorer do
   def file_info(relative_path) do
     with {:ok, full_path} <- resolve_path(relative_path),
          {:ok, stat} <- File.stat(full_path, time: :posix) do
-      {:ok, build_entry(full_path, stat)}
+      {:ok, build_entry(Path.basename(full_path), stat, nil, relative_path)}
     end
   end
 
@@ -156,7 +158,7 @@ defmodule Zaq.Ingestion.FileExplorer do
   def file_info(volume_name, relative_path) when is_binary(volume_name) do
     with {:ok, full_path} <- resolve_path(volume_name, relative_path),
          {:ok, stat} <- File.stat(full_path, time: :posix) do
-      {:ok, build_entry(full_path, stat)}
+      {:ok, build_entry(Path.basename(full_path), stat, volume_name, relative_path)}
     end
   end
 
@@ -343,7 +345,7 @@ defmodule Zaq.Ingestion.FileExplorer do
     end
   end
 
-  defp list_entries(full_path) do
+  defp list_entries(full_path, volume_name, relative_path) do
     full_path
     |> File.ls!()
     |> Enum.sort()
@@ -352,12 +354,7 @@ defmodule Zaq.Ingestion.FileExplorer do
         entry_path = Path.join(full_path, name)
         stat = File.stat!(entry_path, time: :posix)
 
-        %{
-          name: name,
-          type: if(stat.type == :directory, do: :directory, else: :file),
-          size: stat.size,
-          modified_at: stat.mtime |> DateTime.from_unix!()
-        }
+        build_entry(name, stat, volume_name, child_path(relative_path, name))
       end,
       max_concurrency: file_stats_concurrency(),
       ordered: true,
@@ -399,12 +396,19 @@ defmodule Zaq.Ingestion.FileExplorer do
   defp normalize_concurrency(value, _default) when is_integer(value) and value > 0, do: value
   defp normalize_concurrency(_value, default), do: default
 
-  defp build_entry(full_path, stat) do
-    %{
-      name: Path.basename(full_path),
+  defp build_entry(name, stat, volume_name, relative_path) do
+    %Entry{
+      name: name,
       type: if(stat.type == :directory, do: :directory, else: :file),
       size: stat.size,
-      modified_at: stat.mtime |> DateTime.from_unix!()
+      modified_at: stat.mtime |> DateTime.from_unix!(),
+      volume: volume_name,
+      relative_path: relative_path
     }
   end
+
+  # Matches how the rest of ingestion joins a listing directory to an entry name — a "."
+  # directory contributes nothing, so entries under the root are named bare.
+  defp child_path(dir, name) when dir in [".", "", nil], do: name
+  defp child_path(dir, name), do: Path.join(dir, name)
 end

--- a/lib/zaq/ingestion/file_explorer/entry.ex
+++ b/lib/zaq/ingestion/file_explorer/entry.ex
@@ -1,0 +1,43 @@
+defmodule Zaq.Ingestion.FileExplorer.Entry do
+  @moduledoc """
+  One file or folder on a mounted ingestion volume, as read from disk.
+
+  `Zaq.Ingestion.FileExplorer` builds these from `File.stat/2`, so it fills only filesystem
+  state. `id`, `source`, and `document_id` need a database lookup and are filled by
+  `Zaq.Ingestion.VolumeEntries.resolve/1` — on an entry straight out of `FileExplorer` they
+  are `nil`.
+
+  `type` is `:directory`, not `:folder`. Callers pattern-match `%{type: :directory}` to
+  branch on it; `Zaq.Contracts.Record`'s `:folder` naming is applied by the data-source
+  bridge when it maps an entry into a record.
+
+  `relative_path` out of `FileExplorer` is as-given by the caller, joined with the entry
+  name — it is not passed through `Zaq.Ingestion.SourcePath.normalize_relative/1`, which
+  aliases `FileExplorer` and cannot be called from here. `resolve/1` normalizes it.
+  """
+
+  @enforce_keys [:name, :type]
+  defstruct [
+    :id,
+    :name,
+    :type,
+    :size,
+    :modified_at,
+    :volume,
+    :relative_path,
+    :source,
+    :document_id
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t() | nil,
+          name: String.t(),
+          type: :file | :directory,
+          size: non_neg_integer() | nil,
+          modified_at: DateTime.t() | nil,
+          volume: String.t() | nil,
+          relative_path: String.t() | nil,
+          source: String.t() | nil,
+          document_id: integer() | nil
+        }
+end

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -30,6 +30,7 @@ defmodule Zaq.Ingestion do
   }
 
   alias Zaq.Contracts.Record
+  alias Zaq.Contracts.RecordPage
   alias Zaq.Permissions.DocumentPermission, as: Permission
 
   alias Zaq.Repo
@@ -346,6 +347,7 @@ defmodule Zaq.Ingestion do
   """
   def volumes_configured?, do: FileExplorer.volumes_configured?()
 
+  def list_entries(nil, path), do: FileExplorer.list(path)
   def list_entries(volume_name, path), do: FileExplorer.list(volume_name, path)
 
   def create_directory(volume_name, path), do: FileExplorer.create_directory(volume_name, path)
@@ -360,6 +362,477 @@ defmodule Zaq.Ingestion do
     do: FileExplorer.upload(volume_name, path, content)
 
   def file_info(volume_name, path), do: FileExplorer.file_info(volume_name, path)
+
+  @doc """
+  Returns canonical records for the given document ids.
+
+  Ids with no document row, or whose file is gone from its volume, are dropped rather than
+  failing the page — one missing document does not hide the rest. Callers that need to know
+  an id was missing compare the returned ids against the ones they asked for.
+  """
+  @spec describe_records([String.t() | integer()]) :: {:ok, RecordPage.t()}
+  def describe_records(file_ids) when is_list(file_ids) do
+    records =
+      Enum.flat_map(file_ids, fn file_id ->
+        case describe_record(file_id) do
+          {:ok, record} -> [record]
+          {:error, _reason} -> []
+        end
+      end)
+
+    {:ok, record_page(records, length(file_ids))}
+  end
+
+  @doc """
+  Returns a page of canonical records.
+
+  With no `filters["parent"]`, answers every file the deployment holds across all mounted
+  volumes. With one, answers that directory's entries — folders alongside files, so a caller
+  can walk the tree the way `RecordSource.list_children/1` does for a folder record. A parent
+  is a volume-prefixed source, the same form `Document.source` carries.
+
+  Ingested files answer with their `documents.id`, so an id read off this page is the one
+  `describe_records/1` accepts.
+  """
+  @spec list_records(map()) :: {:ok, RecordPage.t()} | {:error, term()}
+  def list_records(params \\ %{}) when is_map(params) do
+    case parent_source(params) do
+      nil -> list_all_records()
+      parent -> list_directory_records(split_parent(parent))
+    end
+  end
+
+  # Document rows already span every volume, so listing them needs no walk across the mounts.
+  defp list_all_records do
+    documents = Document.list()
+    {:ok, record_page(records_for(documents), length(documents))}
+  end
+
+  defp list_directory_records({volume_name, path}) do
+    with {:ok, entries} <- list_entries(volume_name, path) do
+      {:ok,
+       entries |> VolumeRecords.from_entries(volume_name, path) |> record_page(length(entries))}
+    end
+  end
+
+  defp record_page(records, scanned) do
+    %RecordPage{
+      resource_type: :item,
+      records: records,
+      stats: %{scanned: scanned, returned: length(records)}
+    }
+  end
+
+  @doc """
+  Writes a file onto a mounted volume and registers its document row.
+
+  `path` is the destination directory and must name a volume — a bare relative path has no
+  volume to write to and is refused rather than silently landing on the default one. The
+  file is deduplicated the way a BO upload is, so a name already taken yields
+  `notes (1).md`; the returned record carries the name that was actually written.
+
+  Creating is not ingesting: the document row exists immediately, but chunking and
+  embedding still happen through the normal ingest flow.
+  """
+  @spec persist_record(map()) :: {:ok, map()} | {:error, term()}
+  def persist_record(request) when is_map(request) do
+    with {:ok, {volume_name, dir}} <- destination(request),
+         {:ok, name} <- required(request, "name", :name_required),
+         {:ok, content} <- decode_content(request),
+         dest = dir |> Path.join(name) |> SourcePath.normalize_relative(),
+         {:ok, absolute_path} <- upload_file(volume_name, dest, content),
+         {:ok, %Document{} = document} <- track_upload(volume_name, absolute_path),
+         {:ok, record} <- describe_document(document) do
+      {:ok, %{status: "created", record: record}}
+    end
+  end
+
+  @doc """
+  Reads a document's bytes and returns it as a materialized record.
+
+  This is the far end of the `materializing_event` every file record carries: the record
+  travels without content so a listing does not read every file it names, and a caller that
+  wants the bytes dispatches the event to land here.
+
+  A textual document comes back as text, so a caller reading markdown does not have to
+  decode it first. Anything else is base64 with `attributes["encoding"]` saying so — the
+  convention `RecordSource.store_download/2` already reads. Send `encoding: "base64"` in the
+  request to force it, which is how a caller asks for the raw bytes of a text file.
+  """
+  @spec materialize_record(map()) :: {:ok, map()} | {:error, term()}
+  def materialize_record(request) when is_map(request) do
+    with {:ok, file_id} <- required(request, "file_id", :file_id_required) do
+      case Document.get(file_id) do
+        %Document{} = document -> materialize_document(document, request)
+        nil -> {:error, :not_found}
+      end
+    end
+  end
+
+  defp materialize_document(%Document{} = document, request) do
+    with {:ok, record} <- describe_document(document),
+         {:ok, absolute_path} <- RecordSource.resolve_path(record),
+         {:ok, binary} <- File.read(absolute_path) do
+      {:ok, %{record: put_content(record, binary, request)}}
+    end
+  end
+
+  defp put_content(%Record{} = record, binary, request) do
+    if base64?(record, binary, request) do
+      %{
+        record
+        | content: Base.encode64(binary),
+          attributes: Map.put(record.attributes, "encoding", "base64")
+      }
+    else
+      %{record | content: binary}
+    end
+  end
+
+  # `String.valid?/1` is not redundant with the mime check: an extension says what a file is
+  # meant to be, not what it holds. A `.md` carrying invalid UTF-8 would otherwise come back
+  # as a broken string, so it falls to base64 instead.
+  defp base64?(%Record{} = record, binary, request) do
+    MapUtils.present_value(request, "encoding") == "base64" or
+      not (textual_mime?(record.mime_type) and String.valid?(binary))
+  end
+
+  @textual_mime_types ~w(
+    application/json application/xml application/javascript
+    application/yaml application/x-yaml application/x-sh
+  )
+
+  defp textual_mime?(mime) when is_binary(mime),
+    do: String.starts_with?(mime, "text/") or mime in @textual_mime_types
+
+  defp textual_mime?(_mime), do: false
+
+  @doc """
+  Returns records for documents whose source or title matches `query`.
+
+  Matching is a case-insensitive substring over the stored source and title — there is no
+  index behind it, so the page is capped. Chunk and sidecar rows are excluded; they are not
+  files a caller can act on.
+  """
+  @spec search_records(map()) :: {:ok, RecordPage.t()} | {:error, term()}
+  def search_records(params) when is_map(params) do
+    with {:ok, query} <- required(params, "query", :query_required) do
+      documents = search_documents(query)
+      {:ok, record_page(records_for(documents), length(documents))}
+    end
+  end
+
+  # A document whose file is gone from its volume is dropped rather than failing the page —
+  # one missing file does not hide the rest.
+  defp records_for(documents) do
+    Enum.flat_map(documents, fn document ->
+      case describe_document(document) do
+        {:ok, record} -> [record]
+        {:error, _reason} -> []
+      end
+    end)
+  end
+
+  defp search_documents(query) do
+    pattern = "%#{query}%"
+
+    from(d in Document,
+      where: fragment("(? ->> 'source_document_source') IS NULL", d.metadata),
+      where: ilike(d.source, ^pattern) or ilike(d.title, ^pattern),
+      order_by: [asc: d.source],
+      limit: 100
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Reports what the mounted volumes hold.
+
+  `root_folders` are the mounted volume names — a volume is the root a caller browses from.
+  `folders_count` is derived from document sources rather than walked on disk, so it counts
+  directories that hold at least one document.
+  """
+  @spec volume_stats() :: {:ok, map()}
+  def volume_stats do
+    sources =
+      from(d in Document,
+        where: fragment("(? ->> 'source_document_source') IS NULL", d.metadata),
+        select: d.source
+      )
+      |> Repo.all()
+
+    folders =
+      sources
+      |> Enum.map(&Path.dirname/1)
+      |> Enum.reject(&(&1 in [".", "", "/"]))
+      |> Enum.uniq()
+
+    {:ok,
+     %{
+       files_count: length(sources),
+       folders_count: length(folders),
+       principals_count: count_principals(),
+       root_folders: FileExplorer.list_volumes() |> Map.keys() |> Enum.sort()
+     }}
+  end
+
+  # A principal is whoever a grant names, counted once no matter how many documents it
+  # covers. Public access names nobody, so it is not a principal.
+  defp count_principals do
+    from(p in Permission,
+      where: p.resource_type == "document",
+      distinct: true,
+      select: {p.person_id, p.team_id}
+    )
+    |> Repo.all()
+    |> Enum.reject(&(&1 == {nil, nil}))
+    |> length()
+  end
+
+  @doc """
+  Returns who can read a document, one record per grant.
+
+  A grant names a person, a team, or everyone. Person and team grants are rows in
+  `resource_permissions`; public access is the `"public"` tag on the document itself, and is
+  reported here as a grant too — a caller asking who can read a file should not have to know
+  ZAQ stores the two differently. `attributes["type"]` says which kind it is, and
+  `attributes["access_rights"]` what was granted.
+  """
+  @spec list_record_permissions(String.t() | integer()) ::
+          {:ok, RecordPage.t()} | {:error, term()}
+  def list_record_permissions(file_id) do
+    case Document.get(file_id) do
+      %Document{} = document ->
+        records =
+          public_records(document) ++
+            Enum.map(list_document_permissions(document.id), &permission_record/1)
+
+        {:ok,
+         %RecordPage{
+           resource_type: :permission,
+           records: records,
+           stats: %{scanned: length(records), returned: length(records)}
+         }}
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+
+  # Public access has no permission row to name, so the id is derived from the document —
+  # stable across calls, and visibly not a `resource_permissions` id.
+  defp public_records(%Document{} = document) do
+    if "public" in (document.tags || []) do
+      [
+        %Record{
+          id: "public:#{document.id}",
+          kind: :permission,
+          name: "Public",
+          lifecycle_state: :active,
+          attributes: %{"type" => "public", "target_id" => nil, "access_rights" => ["read"]}
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp permission_record(%Permission{} = permission) do
+    {type, target_id, name} = permission_target(permission)
+
+    %Record{
+      id: to_string(permission.id),
+      kind: :permission,
+      name: name,
+      lifecycle_state: :active,
+      attributes: %{
+        "type" => type,
+        "target_id" => target_id,
+        "access_rights" => permission.access_rights || []
+      }
+    }
+  end
+
+  defp permission_target(%Permission{person: %{} = person}),
+    do: {"person", to_string(person.id), person.full_name || person.email}
+
+  defp permission_target(%Permission{team: %{} = team}),
+    do: {"team", to_string(team.id), team.name}
+
+  defp permission_target(%Permission{}), do: {"unknown", nil, nil}
+
+  @doc """
+  Updates a file in place: rewrites its content, renames it, or moves it within its volume.
+
+  Every field is optional and applied to whatever the document already is — `name` renames,
+  `path` moves to another directory, `content` overwrites the bytes. Moves go through the
+  same `rename_entry/3` a BO rename runs, so the document source and any linked sidecar move
+  with the file in one transaction and the id stays stable.
+  """
+  @spec update_record(map()) :: {:ok, map()} | {:error, term()}
+  def update_record(request) when is_map(request) do
+    with {:ok, file_id} <- required(request, "file_id", :file_id_required) do
+      case Document.get(file_id) do
+        %Document{} = document -> update_document(document, request)
+        nil -> {:error, :not_found}
+      end
+    end
+  end
+
+  defp update_document(%Document{} = document, request) do
+    {volume_name, path} = SourcePath.split_source(document.source, nil)
+
+    # Content is written at the current location before any move, so a request that both
+    # rewrites and renames lands the new bytes under the new name.
+    with :ok <- write_content(volume_name, path, request),
+         {:ok, target} <- move_target(volume_name, path, request),
+         :ok <- move(volume_name, path, target),
+         %Document{} = updated <- Document.get(document.id),
+         {:ok, record} <- describe_document(updated) do
+      {:ok, %{status: "updated", record: record}}
+    end
+  end
+
+  defp write_content(volume_name, path, request) do
+    case MapUtils.present_value(request, "content") do
+      nil ->
+        :ok
+
+      _content ->
+        with {:ok, content} <- decode_content(request),
+             {:ok, _absolute_path} <- save_file(volume_name, path, content) do
+          :ok
+        end
+    end
+  end
+
+  defp move_target(volume_name, path, request) do
+    name = MapUtils.present_value(request, "name") || Path.basename(path)
+
+    case MapUtils.present_value(request, "path") do
+      nil ->
+        {:ok, path |> Path.dirname() |> Path.join(name) |> SourcePath.normalize_relative()}
+
+      new_path ->
+        case split_parent(new_path) do
+          # A move names its volume the way a create does. Crossing volumes is refused rather
+          # than half-done: `rename_entry/3` renames within one volume, so a cross-volume move
+          # would leave the file moved and the sidecar behind.
+          {^volume_name, dir} ->
+            {:ok, dir |> Path.join(name) |> SourcePath.normalize_relative()}
+
+          {nil, _dir} ->
+            {:error, :volume_required}
+
+          {_other_volume, _dir} ->
+            {:error, :cross_volume_move_unsupported}
+        end
+    end
+  end
+
+  defp move(_volume_name, path, path), do: :ok
+  defp move(volume_name, path, target), do: rename_entry(volume_name, path, target)
+
+  @doc """
+  Removes a document row and the file behind it.
+
+  Delegates to the same `delete_path/4` a BO delete runs, so chunks and linked sidecars go
+  with it. The record is captured before the delete so the caller learns what was removed.
+  """
+  @spec delete_record(String.t() | integer()) :: {:ok, map()} | {:error, term()}
+  def delete_record(file_id) do
+    case Document.get(file_id) do
+      %Document{} = document -> delete_document(document)
+      nil -> {:error, :not_found}
+    end
+  end
+
+  defp delete_document(%Document{} = document) do
+    record =
+      case describe_document(document) do
+        {:ok, record} -> record
+        {:error, _reason} -> nil
+      end
+
+    {volume_name, path} = SourcePath.split_source(document.source, nil)
+
+    case delete_path(volume_name, path, "file") do
+      :ok -> {:ok, %{status: "deleted", record: record}}
+      error -> error
+    end
+  end
+
+  defp destination(request) do
+    with {:ok, path} <- required(request, "path", :path_required) do
+      case split_parent(path) do
+        {nil, _dir} -> {:error, :volume_required}
+        {volume_name, dir} -> {:ok, {volume_name, dir}}
+      end
+    end
+  end
+
+  # Binary uploads arrive base64-encoded because the request travels as JSON from agent
+  # tools; anything else is written through as the text it already is.
+  defp decode_content(request) do
+    content = MapUtils.present_value(request, "content") || ""
+
+    case MapUtils.present_value(request, "encoding") do
+      "base64" ->
+        case Base.decode64(content) do
+          {:ok, binary} -> {:ok, binary}
+          :error -> {:error, :invalid_base64}
+        end
+
+      _ ->
+        {:ok, content}
+    end
+  end
+
+  defp required(request, key, error) do
+    case MapUtils.present_value(request, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, error}
+    end
+  end
+
+  # `split_source/2` splits a file source, so it needs a "volume/rest" shape and leaves a bare
+  # volume name untouched — which would then resolve against the default volume and answer
+  # `:not_a_directory`. A parent naming a whole volume is that volume's root.
+  defp split_parent(parent) do
+    volumes = FileExplorer.list_volumes()
+
+    if Map.has_key?(volumes, parent) do
+      {parent, "."}
+    else
+      SourcePath.split_source(parent, nil, volumes)
+    end
+  end
+
+  defp parent_source(params) do
+    filters = MapUtils.present_value(params, "filters") || %{}
+
+    case MapUtils.present_value(filters, "parent") do
+      parent when is_binary(parent) and parent != "" -> parent
+      _ -> nil
+    end
+  end
+
+  defp describe_record(file_id) do
+    case Document.get(file_id) do
+      %Document{} = document -> describe_document(document)
+      nil -> {:error, :not_found}
+    end
+  end
+
+  defp describe_document(%Document{} = document) do
+    {volume_name, path} = SourcePath.split_source(document.source, nil)
+
+    with {:ok, %Record{} = record} <- VolumeRecords.from_path(volume_name, path) do
+      # The document id is the identity the caller holds, so the record answers with it
+      # rather than the volume-entry id `from_path/2` derives for browsing.
+      {:ok, %{record | id: to_string(document.id)}}
+    end
+  end
 
   def directory_snapshot(volume_name, current_dir, current_user) do
     with {:ok, entries} <- list_entries(volume_name, current_dir) do

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -8,6 +8,23 @@ defmodule Zaq.Ingestion do
   decides which watched records should be re-ingested, which removed records
   should delete existing documents and sidecars, and how folder watch inheritance
   is reflected in the BO UI.
+
+  ## Records are not produced here
+
+  The data-source read path answers with ingestion's own shapes —
+  `Zaq.Ingestion.FileExplorer.Entry` values and flat permission grants. Mapping those onto
+  `Zaq.Contracts.Record` belongs to `Zaq.Channels.DiskBridge`, the same way every other
+  provider's bridge maps that provider's payloads. Ingestion still *consumes* records, since
+  `ingest_records/2` takes them from any bridge.
+
+  `materialize_record/1` is the one exception. It is the far end of the `materializing_event`
+  every file record carries, and a caller holding that event dispatches straight to this node
+  — deliberately not through channels, so a listing never drags file bytes across the
+  channels node. The record therefore has to be built on this side.
+
+  `directory_snapshot/3` also still returns records, for BO's local browse branch. That is
+  temporary: BO moves to `Zaq.Channels.DiskBridge` in a follow-up, and
+  `Zaq.Ingestion.VolumeRecords` goes with it.
   """
 
   alias Zaq.Ingestion.{
@@ -26,11 +43,12 @@ defmodule Zaq.Ingestion do
     RenameService,
     Sidecar,
     SourcePath,
+    VolumeEntries,
     VolumeRecords
   }
 
   alias Zaq.Contracts.Record
-  alias Zaq.Contracts.RecordPage
+  alias Zaq.Ingestion.FileExplorer.Entry
   alias Zaq.Permissions.DocumentPermission, as: Permission
 
   alias Zaq.Repo
@@ -42,6 +60,14 @@ defmodule Zaq.Ingestion do
 
   @pubsub Zaq.PubSub
   @topic "ingestion:jobs"
+
+  @typedoc """
+  A page of volume entries.
+
+  `scanned` is what the underlying listing held before entries whose file is gone were
+  dropped, so a caller can tell a short page from a complete one.
+  """
+  @type entry_page :: %{entries: [Entry.t()], scanned: non_neg_integer()}
 
   # --- Ingestion triggers ---
 
@@ -364,27 +390,21 @@ defmodule Zaq.Ingestion do
   def file_info(volume_name, path), do: FileExplorer.file_info(volume_name, path)
 
   @doc """
-  Returns canonical records for the given document ids.
+  Returns the volume entry for a document id.
 
-  Ids with no document row, or whose file is gone from its volume, are dropped rather than
-  failing the page — one missing document does not hide the rest. Callers that need to know
-  an id was missing compare the returned ids against the ones they asked for.
+  Answers `{:error, :not_found}` for an id with no document row, and the filesystem error
+  when the row exists but its file is gone from the volume.
   """
-  @spec describe_records([String.t() | integer()]) :: {:ok, RecordPage.t()}
-  def describe_records(file_ids) when is_list(file_ids) do
-    records =
-      Enum.flat_map(file_ids, fn file_id ->
-        case describe_record(file_id) do
-          {:ok, record} -> [record]
-          {:error, _reason} -> []
-        end
-      end)
-
-    {:ok, record_page(records, length(file_ids))}
+  @spec describe_record(String.t() | integer()) :: {:ok, Entry.t()} | {:error, term()}
+  def describe_record(file_id) do
+    case Document.get(file_id) do
+      %Document{} = document -> describe_document(document)
+      nil -> {:error, :not_found}
+    end
   end
 
   @doc """
-  Returns a page of canonical records.
+  Returns a page of volume entries.
 
   With no `filters["parent"]`, answers every file the deployment holds across all mounted
   volumes. With one, answers that directory's entries — folders alongside files, so a caller
@@ -392,35 +412,30 @@ defmodule Zaq.Ingestion do
   is a volume-prefixed source, the same form `Document.source` carries.
 
   Ingested files answer with their `documents.id`, so an id read off this page is the one
-  `describe_records/1` accepts.
+  `describe_record/1` accepts.
   """
-  @spec list_records(map()) :: {:ok, RecordPage.t()} | {:error, term()}
+  @spec list_records(map()) :: {:ok, entry_page()} | {:error, term()}
   def list_records(params \\ %{}) when is_map(params) do
     case parent_source(params) do
-      nil -> list_all_records()
-      parent -> list_directory_records(split_parent(parent))
+      nil -> list_all_entries()
+      parent -> list_directory_entries(split_parent(parent))
     end
   end
 
   # Document rows already span every volume, so listing them needs no walk across the mounts.
-  defp list_all_records do
+  defp list_all_entries do
     documents = Document.list()
-    {:ok, record_page(records_for(documents), length(documents))}
+    {:ok, entry_page(entries_for(documents), length(documents))}
   end
 
-  defp list_directory_records({volume_name, path}) do
+  defp list_directory_entries({volume_name, path}) do
     with {:ok, entries} <- list_entries(volume_name, path) do
-      {:ok,
-       entries |> VolumeRecords.from_entries(volume_name, path) |> record_page(length(entries))}
+      {:ok, entries |> VolumeEntries.resolve() |> entry_page(length(entries))}
     end
   end
 
-  defp record_page(records, scanned) do
-    %RecordPage{
-      resource_type: :item,
-      records: records,
-      stats: %{scanned: scanned, returned: length(records)}
-    }
+  defp entry_page(entries, scanned) do
+    %{entries: entries, scanned: scanned}
   end
 
   @doc """
@@ -429,7 +444,7 @@ defmodule Zaq.Ingestion do
   `path` is the destination directory and must name a volume — a bare relative path has no
   volume to write to and is refused rather than silently landing on the default one. The
   file is deduplicated the way a BO upload is, so a name already taken yields
-  `notes (1).md`; the returned record carries the name that was actually written.
+  `notes (1).md`; the returned entry carries the name that was actually written.
 
   Creating is not ingesting: the document row exists immediately, but chunking and
   embedding still happen through the normal ingest flow.
@@ -442,8 +457,8 @@ defmodule Zaq.Ingestion do
          dest = dir |> Path.join(name) |> SourcePath.normalize_relative(),
          {:ok, absolute_path} <- upload_file(volume_name, dest, content),
          {:ok, %Document{} = document} <- track_upload(volume_name, absolute_path),
-         {:ok, record} <- describe_document(document) do
-      {:ok, %{status: "created", record: record}}
+         {:ok, entry} <- describe_document(document) do
+      {:ok, %{status: "created", entry: entry}}
     end
   end
 
@@ -469,8 +484,13 @@ defmodule Zaq.Ingestion do
     end
   end
 
+  # The one place ingestion still produces a `Zaq.Contracts.Record`. Everything else answers
+  # with volume entries and leaves the record shape to `Zaq.Channels.DiskBridge`, but this is
+  # the far end of `materializing_event`: a caller on any node dispatches straight here,
+  # deliberately not through the channels node, so the record has to be built on this side.
   defp materialize_document(%Document{} = document, request) do
-    with {:ok, record} <- describe_document(document),
+    with {:ok, entry} <- describe_document(document),
+         record = VolumeRecords.to_record(entry),
          {:ok, absolute_path} <- RecordSource.resolve_path(record),
          {:ok, binary} <- File.read(absolute_path) do
       {:ok, %{record: put_content(record, binary, request)}}
@@ -508,26 +528,26 @@ defmodule Zaq.Ingestion do
   defp textual_mime?(_mime), do: false
 
   @doc """
-  Returns records for documents whose source or title matches `query`.
+  Returns volume entries for documents whose source or title matches `query`.
 
   Matching is a case-insensitive substring over the stored source and title — there is no
   index behind it, so the page is capped. Chunk and sidecar rows are excluded; they are not
   files a caller can act on.
   """
-  @spec search_records(map()) :: {:ok, RecordPage.t()} | {:error, term()}
+  @spec search_records(map()) :: {:ok, entry_page()} | {:error, term()}
   def search_records(params) when is_map(params) do
     with {:ok, query} <- required(params, "query", :query_required) do
       documents = search_documents(query)
-      {:ok, record_page(records_for(documents), length(documents))}
+      {:ok, entry_page(entries_for(documents), length(documents))}
     end
   end
 
   # A document whose file is gone from its volume is dropped rather than failing the page —
   # one missing file does not hide the rest.
-  defp records_for(documents) do
+  defp entries_for(documents) do
     Enum.flat_map(documents, fn document ->
       case describe_document(document) do
-        {:ok, record} -> [record]
+        {:ok, entry} -> [entry]
         {:error, _reason} -> []
       end
     end)
@@ -590,28 +610,26 @@ defmodule Zaq.Ingestion do
   end
 
   @doc """
-  Returns who can read a document, one record per grant.
+  Returns who can read a document, one flat map per grant.
 
-  A grant names a person, a team, or everyone. Person and team grants are rows in
-  `resource_permissions`; public access is the `"public"` tag on the document itself, and is
-  reported here as a grant too — a caller asking who can read a file should not have to know
-  ZAQ stores the two differently. `attributes["type"]` says which kind it is, and
-  `attributes["access_rights"]` what was granted.
+  A grant names a person or a team; `public?` reports the `"public"` tag on the document
+  itself, which grants read access to everyone and has no `resource_permissions` row to
+  name. Both are grants — the caller shaping them into a page is `Zaq.Channels.DiskBridge`,
+  which does not have to know ZAQ stores the two differently.
+
+  Grants are flattened rather than returned as `Zaq.Permissions.DocumentPermission` structs
+  so the bridge never reaches into an Ecto schema or depends on which associations were
+  preloaded.
   """
   @spec list_record_permissions(String.t() | integer()) ::
-          {:ok, RecordPage.t()} | {:error, term()}
+          {:ok, %{permissions: [map()], public?: boolean()}} | {:error, term()}
   def list_record_permissions(file_id) do
     case Document.get(file_id) do
       %Document{} = document ->
-        records =
-          public_records(document) ++
-            Enum.map(list_document_permissions(document.id), &permission_record/1)
-
         {:ok,
-         %RecordPage{
-           resource_type: :permission,
-           records: records,
-           stats: %{scanned: length(records), returned: length(records)}
+         %{
+           permissions: Enum.map(list_document_permissions(document.id), &permission_grant/1),
+           public?: "public" in (document.tags || [])
          }}
 
       nil ->
@@ -619,37 +637,15 @@ defmodule Zaq.Ingestion do
     end
   end
 
-  # Public access has no permission row to name, so the id is derived from the document —
-  # stable across calls, and visibly not a `resource_permissions` id.
-  defp public_records(%Document{} = document) do
-    if "public" in (document.tags || []) do
-      [
-        %Record{
-          id: "public:#{document.id}",
-          kind: :permission,
-          name: "Public",
-          lifecycle_state: :active,
-          attributes: %{"type" => "public", "target_id" => nil, "access_rights" => ["read"]}
-        }
-      ]
-    else
-      []
-    end
-  end
-
-  defp permission_record(%Permission{} = permission) do
+  defp permission_grant(%Permission{} = permission) do
     {type, target_id, name} = permission_target(permission)
 
-    %Record{
+    %{
       id: to_string(permission.id),
-      kind: :permission,
+      type: type,
+      target_id: target_id,
       name: name,
-      lifecycle_state: :active,
-      attributes: %{
-        "type" => type,
-        "target_id" => target_id,
-        "access_rights" => permission.access_rights || []
-      }
+      access_rights: permission.access_rights || []
     }
   end
 
@@ -688,8 +684,8 @@ defmodule Zaq.Ingestion do
          {:ok, target} <- move_target(volume_name, path, request),
          :ok <- move(volume_name, path, target),
          %Document{} = updated <- Document.get(document.id),
-         {:ok, record} <- describe_document(updated) do
-      {:ok, %{status: "updated", record: record}}
+         {:ok, entry} <- describe_document(updated) do
+      {:ok, %{status: "updated", entry: entry}}
     end
   end
 
@@ -737,7 +733,8 @@ defmodule Zaq.Ingestion do
   Removes a document row and the file behind it.
 
   Delegates to the same `delete_path/4` a BO delete runs, so chunks and linked sidecars go
-  with it. The record is captured before the delete so the caller learns what was removed.
+  with it. Answers with the status alone: the file is gone by the time this returns, so
+  there is nothing left on the volume to describe.
   """
   @spec delete_record(String.t() | integer()) :: {:ok, map()} | {:error, term()}
   def delete_record(file_id) do
@@ -748,16 +745,10 @@ defmodule Zaq.Ingestion do
   end
 
   defp delete_document(%Document{} = document) do
-    record =
-      case describe_document(document) do
-        {:ok, record} -> record
-        {:error, _reason} -> nil
-      end
-
     {volume_name, path} = SourcePath.split_source(document.source, nil)
 
     case delete_path(volume_name, path, "file") do
-      :ok -> {:ok, %{status: "deleted", record: record}}
+      :ok -> {:ok, %{status: "deleted"}}
       error -> error
     end
   end
@@ -817,20 +808,13 @@ defmodule Zaq.Ingestion do
     end
   end
 
-  defp describe_record(file_id) do
-    case Document.get(file_id) do
-      %Document{} = document -> describe_document(document)
-      nil -> {:error, :not_found}
-    end
-  end
-
   defp describe_document(%Document{} = document) do
     {volume_name, path} = SourcePath.split_source(document.source, nil)
 
-    with {:ok, %Record{} = record} <- VolumeRecords.from_path(volume_name, path) do
-      # The document id is the identity the caller holds, so the record answers with it
-      # rather than the volume-entry id `from_path/2` derives for browsing.
-      {:ok, %{record | id: to_string(document.id)}}
+    with {:ok, %Entry{} = entry} <- VolumeEntries.from_path(volume_name, path) do
+      # The document id is the identity the caller holds, so the entry answers with it
+      # rather than the volume-path id `from_path/2` derives for browsing.
+      {:ok, %{entry | id: to_string(document.id), document_id: document.id}}
     end
   end
 
@@ -839,7 +823,7 @@ defmodule Zaq.Ingestion do
       sorted =
         entries
         |> Enum.sort_by(fn e -> {if(e.type == :directory, do: 0, else: 1), e.name} end)
-        |> VolumeRecords.from_entries(volume_name, current_dir)
+        |> VolumeRecords.from_entries()
 
       {:ok, DirectorySnapshot.build(sorted, volume_name, current_dir, current_user)}
     end

--- a/lib/zaq/ingestion/record_source.ex
+++ b/lib/zaq/ingestion/record_source.ex
@@ -78,7 +78,7 @@ defmodule Zaq.Ingestion.RecordSource do
 
       with path when is_binary(path) <- relative_path(record),
            {:ok, entries} <- list_entries(volume, path) do
-        {:ok, VolumeRecords.from_entries(entries, volume, path)}
+        {:ok, VolumeRecords.from_entries(entries)}
       end
     end
   end

--- a/lib/zaq/ingestion/volume_entries.ex
+++ b/lib/zaq/ingestion/volume_entries.ex
@@ -1,0 +1,111 @@
+defmodule Zaq.Ingestion.VolumeEntries do
+  @moduledoc """
+  Fills document identity onto `Zaq.Ingestion.FileExplorer.Entry` values.
+
+  `FileExplorer` reads the filesystem and knows nothing about the `documents` table, so the
+  entries it returns carry no `id`. This module resolves that half: an ingested file answers
+  with its `documents.id`, so the id on a listed entry is the one a caller hands back to
+  fetch, download, or delete that file. Folders and files with no document row fall back to
+  a stable volume-path id — there is no document to name.
+
+  Resolving also normalizes `relative_path`, which `FileExplorer` stores as the caller gave
+  it.
+  """
+
+  alias Zaq.Ingestion.Document
+  alias Zaq.Ingestion.FileExplorer
+  alias Zaq.Ingestion.FileExplorer.Entry
+  alias Zaq.Ingestion.SourcePath
+
+  @local_provider "disk"
+
+  @doc """
+  Resolves one entry, or a whole listing.
+
+  A listing takes one document query for the page rather than a query per file: every
+  candidate source is read at once and each entry takes its id from the result.
+  """
+  @spec resolve([Entry.t()] | Entry.t()) :: [Entry.t()] | Entry.t()
+  def resolve(entries) when is_list(entries) do
+    document_ids = document_ids_by_source(entries)
+    Enum.map(entries, &put_identity(&1, document_ids))
+  end
+
+  def resolve(%Entry{} = entry), do: put_identity(entry, nil)
+
+  @doc "Reads one path off a volume and resolves the entry it names."
+  @spec from_path(String.t() | nil, String.t()) :: {:ok, Entry.t()} | {:error, term()}
+  def from_path(volume_name, path) do
+    with {:ok, %Entry{} = entry} <- file_info(volume_name, SourcePath.normalize_relative(path)) do
+      {:ok, resolve(entry)}
+    end
+  end
+
+  @doc "Returns the provider name local volume entries answer with."
+  @spec local_provider() :: String.t()
+  def local_provider, do: @local_provider
+
+  defp put_identity(%Entry{} = entry, document_ids) do
+    relative_path = SourcePath.normalize_relative(entry.relative_path || entry.name)
+    document_id = document_id(entry.volume, relative_path, document_ids)
+
+    %Entry{
+      entry
+      | id: entry_id_for(entry.volume, relative_path, document_id),
+        relative_path: relative_path,
+        source: source_for(entry.volume, relative_path),
+        document_id: document_id
+    }
+  end
+
+  defp entry_id_for(_volume_name, _relative_path, document_id) when not is_nil(document_id),
+    do: to_string(document_id)
+
+  defp entry_id_for(volume_name, relative_path, _document_id),
+    do: Enum.join([@local_provider, volume_name || "default", relative_path], ":")
+
+  defp document_ids_by_source(entries) do
+    entries
+    |> Enum.flat_map(fn %Entry{} = entry ->
+      entry.volume
+      |> source_candidates(SourcePath.normalize_relative(entry.relative_path || entry.name))
+    end)
+    |> Document.list_by_sources()
+    |> Map.new(&{&1.source, &1.id})
+  end
+
+  defp document_id(volume_name, relative_path, nil) do
+    volume_name
+    |> source_candidates(relative_path)
+    |> Enum.find_value(fn source ->
+      case Document.get_by_source(source) do
+        %Document{id: id} -> id
+        _ -> nil
+      end
+    end)
+  end
+
+  defp document_id(volume_name, relative_path, document_ids) when is_map(document_ids) do
+    volume_name
+    |> source_candidates(relative_path)
+    |> Enum.find_value(&Map.get(document_ids, &1))
+  end
+
+  # A volume-prefixed candidate has no meaning without a volume — single-volume deployments
+  # store the bare relative path.
+  defp source_candidates(nil, relative_path), do: [SourcePath.normalize_relative(relative_path)]
+
+  defp source_candidates(volume_name, relative_path),
+    do: SourcePath.source_candidates(volume_name, relative_path)
+
+  defp source_for(nil, relative_path), do: relative_path
+
+  defp source_for(volume_name, relative_path) do
+    volume_name
+    |> SourcePath.source_candidates(relative_path)
+    |> List.first()
+  end
+
+  defp file_info(nil, path), do: FileExplorer.file_info(path)
+  defp file_info(volume_name, path), do: FileExplorer.file_info(volume_name, path)
+end

--- a/lib/zaq/ingestion/volume_records.ex
+++ b/lib/zaq/ingestion/volume_records.ex
@@ -1,123 +1,62 @@
 defmodule Zaq.Ingestion.VolumeRecords do
   @moduledoc """
-  Converts local ingestion volume entries into canonical `Zaq.Contracts.Record` values.
+  Converts resolved volume entries into canonical `Zaq.Contracts.Record` values.
 
-  The local volume remains the source of truth for browsing. This module only adapts
-  filesystem entries into the same record shape that future external data sources
-  will pass to the BO ingestion UI.
+  Identity and path resolution live in `Zaq.Ingestion.VolumeEntries`; this module only puts
+  the `Zaq.Contracts.Record` shape on top of what that returns.
+
+  Producing records is the data-source bridge's concern, not ingestion's — the remaining
+  callers here are the ingest pipeline, which takes records as input, and BO's
+  `Zaq.Ingestion.directory_snapshot/3`, which is moving to `Zaq.Channels.DiskBridge`.
   """
 
   alias Zaq.Contracts.Record
   alias Zaq.Event
-  alias Zaq.Ingestion.{Document, FileExplorer, SourcePath}
+  alias Zaq.Ingestion.FileExplorer.Entry
+  alias Zaq.Ingestion.VolumeEntries
 
-  @local_provider "disk"
-
-  @doc "Converts local volume directory entries into canonical records."
-  @spec from_entries([map()], String.t() | nil, String.t()) :: [Record.t()]
-  def from_entries(entries, volume_name, current_dir) when is_list(entries) do
-    document_ids = document_ids_by_source(entries, volume_name, current_dir)
-    Enum.map(entries, &from_entry(&1, volume_name, current_dir, document_ids))
+  @doc "Resolves local volume entries and converts them into canonical records."
+  @spec from_entries([Entry.t()]) :: [Record.t()]
+  def from_entries(entries) when is_list(entries) do
+    entries
+    |> VolumeEntries.resolve()
+    |> Enum.map(&to_record/1)
   end
 
   @doc "Builds a canonical record for a path inside a local volume."
   @spec from_path(String.t() | nil, String.t()) :: {:ok, Record.t()} | {:error, term()}
   def from_path(volume_name, path) do
-    normalized_path = SourcePath.normalize_relative(path)
-
-    with {:ok, entry} <- file_info(volume_name, normalized_path) do
-      {:ok, from_entry(entry, volume_name, Path.dirname(normalized_path))}
+    with {:ok, %Entry{} = entry} <- VolumeEntries.from_path(volume_name, path) do
+      {:ok, to_record(entry)}
     end
   end
 
-  @doc "Converts one local volume entry into a canonical record."
-  @spec from_entry(map(), String.t() | nil, String.t(), map() | nil) :: Record.t()
-  def from_entry(entry, volume_name, current_dir, document_ids \\ nil) do
-    relative_path = current_dir |> Path.join(entry.name) |> SourcePath.normalize_relative()
-    kind = entry_kind(entry)
-    source = relative_path |> SourcePath.normalize_relative() |> source_for(volume_name)
-    id = record_id(volume_name, relative_path, document_ids)
+  @doc "Converts one resolved volume entry into a canonical record."
+  @spec to_record(Entry.t()) :: Record.t()
+  def to_record(%Entry{} = entry) do
+    kind = kind(entry.type)
 
     %Record{
-      id: id,
+      id: entry.id,
       kind: kind,
       name: entry.name,
-      path: relative_path,
+      path: entry.relative_path,
       mime_type: mime_type(kind, entry.name),
-      materializing_event: materializing_event(kind, id),
-      size: Map.get(entry, :size),
-      modified_at: Map.get(entry, :modified_at),
+      materializing_event: materializing_event(kind, entry.id),
+      size: entry.size,
+      modified_at: entry.modified_at,
       attributes: %{
-        "provider" => @local_provider,
-        "volume" => volume_name,
-        "relative_path" => relative_path,
-        "source" => source
+        "provider" => VolumeEntries.local_provider(),
+        "volume" => entry.volume,
+        "relative_path" => entry.relative_path,
+        "source" => entry.source
       },
       raw: %{local_entry: entry}
     }
   end
 
-  @doc """
-  Returns the identifier for an entry on a local volume.
-
-  An ingested file answers with its `documents.id`, so the id on a listed record is the one
-  a caller hands back to fetch, download, or delete that file. Folders and files with no
-  document row fall back to a stable volume-path identifier — there is no document to name.
-
-  Pass `document_ids` (a source-to-id map) to resolve a whole listing without a query per
-  entry; `from_entries/3` builds it.
-  """
-  @spec record_id(String.t() | nil, String.t(), map() | nil) :: String.t()
-  def record_id(volume_name, relative_path, document_ids \\ nil) do
-    case document_id(volume_name, relative_path, document_ids) do
-      nil -> Enum.join([@local_provider, volume_name || "default", relative_path], ":")
-      id -> to_string(id)
-    end
-  end
-
-  # One query per listing rather than one per entry — `from_entries/3` resolves the page up
-  # front and every entry reads its id out of the result.
-  defp document_ids_by_source(entries, volume_name, current_dir) do
-    entries
-    |> Enum.flat_map(fn entry ->
-      current_dir
-      |> Path.join(entry.name)
-      |> SourcePath.normalize_relative()
-      |> then(&source_candidates(volume_name, &1))
-    end)
-    |> Document.list_by_sources()
-    |> Map.new(&{&1.source, &1.id})
-  end
-
-  defp document_id(volume_name, relative_path, nil) do
-    volume_name
-    |> source_candidates(relative_path)
-    |> Enum.find_value(fn source ->
-      case Document.get_by_source(source) do
-        %Document{id: id} -> id
-        _ -> nil
-      end
-    end)
-  end
-
-  defp document_id(volume_name, relative_path, document_ids) when is_map(document_ids) do
-    volume_name
-    |> source_candidates(relative_path)
-    |> Enum.find_value(&Map.get(document_ids, &1))
-  end
-
-  # A volume-prefixed candidate has no meaning without a volume — single-volume deployments
-  # store the bare relative path.
-  defp source_candidates(nil, relative_path), do: [SourcePath.normalize_relative(relative_path)]
-
-  defp source_candidates(volume_name, relative_path),
-    do: SourcePath.source_candidates(volume_name, relative_path)
-
-  defp file_info(nil, path), do: FileExplorer.file_info(path)
-  defp file_info(volume_name, path), do: FileExplorer.file_info(volume_name, path)
-
-  defp entry_kind(%{type: :directory}), do: :folder
-  defp entry_kind(_entry), do: :file
+  defp kind(:directory), do: :folder
+  defp kind(_type), do: :file
 
   # A volume entry carries no declared type, so the extension is all there is to go on.
   defp mime_type(:file, name), do: MIME.from_path(name)
@@ -130,12 +69,4 @@ defmodule Zaq.Ingestion.VolumeRecords do
     do: Event.new(%{file_id: id}, :ingestion, opts: [action: :materialize_record])
 
   defp materializing_event(_kind, _id), do: nil
-
-  defp source_for(relative_path, nil), do: relative_path
-
-  defp source_for(relative_path, volume_name) do
-    volume_name
-    |> SourcePath.source_candidates(relative_path)
-    |> List.first()
-  end
 end

--- a/lib/zaq/ingestion/volume_records.ex
+++ b/lib/zaq/ingestion/volume_records.ex
@@ -8,14 +8,16 @@ defmodule Zaq.Ingestion.VolumeRecords do
   """
 
   alias Zaq.Contracts.Record
-  alias Zaq.Ingestion.{FileExplorer, SourcePath}
+  alias Zaq.Event
+  alias Zaq.Ingestion.{Document, FileExplorer, SourcePath}
 
-  @local_provider "zaq_local"
+  @local_provider "disk"
 
   @doc "Converts local volume directory entries into canonical records."
   @spec from_entries([map()], String.t() | nil, String.t()) :: [Record.t()]
   def from_entries(entries, volume_name, current_dir) when is_list(entries) do
-    Enum.map(entries, &from_entry(&1, volume_name, current_dir))
+    document_ids = document_ids_by_source(entries, volume_name, current_dir)
+    Enum.map(entries, &from_entry(&1, volume_name, current_dir, document_ids))
   end
 
   @doc "Builds a canonical record for a path inside a local volume."
@@ -29,17 +31,20 @@ defmodule Zaq.Ingestion.VolumeRecords do
   end
 
   @doc "Converts one local volume entry into a canonical record."
-  @spec from_entry(map(), String.t() | nil, String.t()) :: Record.t()
-  def from_entry(entry, volume_name, current_dir) do
+  @spec from_entry(map(), String.t() | nil, String.t(), map() | nil) :: Record.t()
+  def from_entry(entry, volume_name, current_dir, document_ids \\ nil) do
     relative_path = current_dir |> Path.join(entry.name) |> SourcePath.normalize_relative()
     kind = entry_kind(entry)
     source = relative_path |> SourcePath.normalize_relative() |> source_for(volume_name)
+    id = record_id(volume_name, relative_path, document_ids)
 
     %Record{
-      id: record_id(volume_name, relative_path),
+      id: id,
       kind: kind,
       name: entry.name,
       path: relative_path,
+      mime_type: mime_type(kind, entry.name),
+      materializing_event: materializing_event(kind, id),
       size: Map.get(entry, :size),
       modified_at: Map.get(entry, :modified_at),
       attributes: %{
@@ -52,16 +57,79 @@ defmodule Zaq.Ingestion.VolumeRecords do
     }
   end
 
-  @doc "Builds a stable local-volume record identifier."
-  @spec record_id(String.t() | nil, String.t()) :: String.t()
-  def record_id(volume_name, relative_path),
-    do: Enum.join([@local_provider, volume_name || "default", relative_path], ":")
+  @doc """
+  Returns the identifier for an entry on a local volume.
+
+  An ingested file answers with its `documents.id`, so the id on a listed record is the one
+  a caller hands back to fetch, download, or delete that file. Folders and files with no
+  document row fall back to a stable volume-path identifier — there is no document to name.
+
+  Pass `document_ids` (a source-to-id map) to resolve a whole listing without a query per
+  entry; `from_entries/3` builds it.
+  """
+  @spec record_id(String.t() | nil, String.t(), map() | nil) :: String.t()
+  def record_id(volume_name, relative_path, document_ids \\ nil) do
+    case document_id(volume_name, relative_path, document_ids) do
+      nil -> Enum.join([@local_provider, volume_name || "default", relative_path], ":")
+      id -> to_string(id)
+    end
+  end
+
+  # One query per listing rather than one per entry — `from_entries/3` resolves the page up
+  # front and every entry reads its id out of the result.
+  defp document_ids_by_source(entries, volume_name, current_dir) do
+    entries
+    |> Enum.flat_map(fn entry ->
+      current_dir
+      |> Path.join(entry.name)
+      |> SourcePath.normalize_relative()
+      |> then(&source_candidates(volume_name, &1))
+    end)
+    |> Document.list_by_sources()
+    |> Map.new(&{&1.source, &1.id})
+  end
+
+  defp document_id(volume_name, relative_path, nil) do
+    volume_name
+    |> source_candidates(relative_path)
+    |> Enum.find_value(fn source ->
+      case Document.get_by_source(source) do
+        %Document{id: id} -> id
+        _ -> nil
+      end
+    end)
+  end
+
+  defp document_id(volume_name, relative_path, document_ids) when is_map(document_ids) do
+    volume_name
+    |> source_candidates(relative_path)
+    |> Enum.find_value(&Map.get(document_ids, &1))
+  end
+
+  # A volume-prefixed candidate has no meaning without a volume — single-volume deployments
+  # store the bare relative path.
+  defp source_candidates(nil, relative_path), do: [SourcePath.normalize_relative(relative_path)]
+
+  defp source_candidates(volume_name, relative_path),
+    do: SourcePath.source_candidates(volume_name, relative_path)
 
   defp file_info(nil, path), do: FileExplorer.file_info(path)
   defp file_info(volume_name, path), do: FileExplorer.file_info(volume_name, path)
 
   defp entry_kind(%{type: :directory}), do: :folder
   defp entry_kind(_entry), do: :file
+
+  # A volume entry carries no declared type, so the extension is all there is to go on.
+  defp mime_type(:file, name), do: MIME.from_path(name)
+  defp mime_type(_kind, _name), do: nil
+
+  # A record travels without its bytes — reading every file a listing names would be wasted
+  # work. This is the hop that fetches them when a caller actually wants the content. A
+  # folder has nothing to materialize.
+  defp materializing_event(:file, id),
+    do: Event.new(%{file_id: id}, :ingestion, opts: [action: :materialize_record])
+
+  defp materializing_event(_kind, _id), do: nil
 
   defp source_for(relative_path, nil), do: relative_path
 

--- a/lib/zaq/utils/map.ex
+++ b/lib/zaq/utils/map.ex
@@ -48,6 +48,23 @@ defmodule Zaq.Utils.Map do
 
   def metadata_value(_metadata, _key), do: nil
 
+  @doc """
+  Like `metadata_value/2`, but a key holding `nil` does not shadow the other spelling.
+
+  For payloads assembled by more than one writer, where the same field may be present as a
+  string key with no value and as an atom key with one.
+  """
+  @spec present_value(map(), atom() | String.t()) :: term() | nil
+  def present_value(map, key) when is_map(map) and is_binary(key) do
+    read_present(map, [key, existing_atom_key(key)])
+  end
+
+  def present_value(map, key) when is_map(map) and is_atom(key) do
+    read_present(map, [key, Atom.to_string(key)])
+  end
+
+  def present_value(_map, _key), do: nil
+
   @spec stringify_keys(map()) :: map()
   def stringify_keys(map) when is_map(map) do
     Map.new(map, fn {key, value} -> {to_string(key), value} end)

--- a/priv/repo/migrations/20260803000000_add_disk_data_source_channel_config.exs
+++ b/priv/repo/migrations/20260803000000_add_disk_data_source_channel_config.exs
@@ -1,0 +1,21 @@
+defmodule Zaq.Repo.Migrations.AddDiskDataSourceChannelConfig do
+  use Ecto.Migration
+
+  # The disk data source fronts ingestion volumes ZAQ already owns, so unlike a connected
+  # provider it has nothing for an operator to enter — no URL, no token, no OAuth grant. It
+  # still needs a `channel_configs` row, because that row is how `Bridge.fetch_channel_config/1`
+  # finds the provider at dispatch time. `url` and `token` are empty strings rather than NULL
+  # to match what the `data_source` branch of `ChannelConfig.changeset/2` writes for every
+  # other datasource.
+  def up do
+    execute("""
+    INSERT INTO channel_configs (name, provider, kind, url, token, enabled, settings, inserted_at, updated_at)
+    VALUES ('Disk', 'disk', 'data_source', '', '', true, '{}'::jsonb, now(), now())
+    ON CONFLICT (provider) DO NOTHING
+    """)
+  end
+
+  def down do
+    execute("DELETE FROM channel_configs WHERE provider = 'disk'")
+  end
+end

--- a/test/zaq/agent/tools/data_source/create_document_test.exs
+++ b/test/zaq/agent/tools/data_source/create_document_test.exs
@@ -39,6 +39,7 @@ defmodule Zaq.Agent.Tools.DataSource.CreateDocumentTest do
                  provider: "google_drive",
                  name: "Doc",
                  content: "hello",
+                 encoding: "base64",
                  path: "/docs",
                  parent_id: "p1",
                  mime_type: "text/plain",
@@ -51,11 +52,23 @@ defmodule Zaq.Agent.Tools.DataSource.CreateDocumentTest do
                      %{
                        "name" => "Doc",
                        "content" => "hello",
+                       "encoding" => "base64",
                        "path" => "/docs",
                        "parent_id" => "p1",
                        "mime_type" => "text/plain",
                        "config_id" => "12"
                      }}
+  end
+
+  test "omits encoding entirely when absent" do
+    assert {:ok, _} =
+             CreateDocument.run(
+               %{provider: "google_drive", name: "Doc", content: "hello"},
+               %{node_router: StubNodeRouter}
+             )
+
+    assert_received {:dispatch, :data_source_create_file, params}
+    assert params == %{"name" => "Doc", "content" => "hello"}
   end
 
   test "formats datasource error reason" do

--- a/test/zaq/agent/tools/data_source/create_document_test.exs
+++ b/test/zaq/agent/tools/data_source/create_document_test.exs
@@ -82,6 +82,6 @@ defmodule Zaq.Agent.Tools.DataSource.CreateDocumentTest do
     assert {:error, message} =
              CreateDocument.run(%{provider: "google_drive"}, %{node_router: UnexpectedNodeRouter})
 
-    assert message == "Unexpected data source response: :ok"
+    assert message == "Unexpected channel response: :ok"
   end
 end

--- a/test/zaq/agent/tools/data_source/download_document_test.exs
+++ b/test/zaq/agent/tools/data_source/download_document_test.exs
@@ -102,7 +102,7 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
     end
 
     test "returns formatted errors for unexpected responses" do
-      assert {:error, "Unexpected data source response: :weird_response"} =
+      assert {:error, "Unexpected channel response: :weird_response"} =
                DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
                  node_router: StubNodeRouterUnexpected
                })

--- a/test/zaq/agent/tools/data_source/download_document_test.exs
+++ b/test/zaq/agent/tools/data_source/download_document_test.exs
@@ -2,6 +2,7 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
   use Zaq.DataCase, async: true
 
   alias Zaq.Agent.Tools.DataSource.DownloadDocument
+  alias Zaq.Contracts.Record
   alias Zaq.Event
 
   defmodule StubNodeRouter do
@@ -105,6 +106,150 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
                DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
                  node_router: StubNodeRouterUnexpected
                })
+    end
+  end
+
+  # ── unmaterialized bridges (disk) ───────────────────────────────────────────
+
+  describe "run/2 against a bridge answering unmaterialized" do
+    # Stands in for the disk data source: the channels hop answers with metadata only, and
+    # the bytes come back through a second hop straight to ingestion.
+    defmodule DiskNodeRouter do
+      @moduledoc false
+
+      @files %{
+        "guide.md" => {"text/markdown", "# guide", %{}},
+        "deck.pdf" => {"application/pdf", "JVBERi0=", %{"encoding" => "base64"}}
+      }
+
+      def dispatch(%Event{request: %{provider: "disk", params: params}, opts: opts} = event) do
+        file_id = params["file_id"]
+        send(self(), {:first_hop, event.next_hop.destination, opts[:action], params})
+        {mime_type, _content, _attributes} = Map.fetch!(@files, file_id)
+
+        %{
+          event
+          | response:
+              {:ok,
+               %{
+                 record: %Record{
+                   id: file_id,
+                   kind: :file,
+                   name: file_id,
+                   mime_type: mime_type,
+                   content: nil,
+                   attributes: %{"provider" => "disk"},
+                   materializing_event:
+                     Event.new(%{file_id: file_id}, :ingestion,
+                       opts: [action: :materialize_record]
+                     )
+                 }
+               }}
+        }
+      end
+
+      def dispatch(%Event{request: %{file_id: file_id}, opts: opts} = event) do
+        send(self(), {:second_hop, event.next_hop.destination, opts[:action], file_id})
+        {mime_type, content, attributes} = Map.fetch!(@files, file_id)
+
+        %{
+          event
+          | response:
+              {:ok,
+               %{
+                 record: %Record{
+                   id: file_id,
+                   kind: :file,
+                   name: file_id,
+                   mime_type: mime_type,
+                   content: content,
+                   attributes: Map.merge(%{"provider" => "disk"}, attributes)
+                 }
+               }}
+        }
+      end
+    end
+
+    defmodule DiskFirstHopErrorRouter do
+      @moduledoc false
+
+      def dispatch(%Event{request: %{provider: "disk"}} = event) do
+        send(self(), :first_hop)
+        %{event | response: {:error, :not_found}}
+      end
+
+      def dispatch(%Event{} = event) do
+        send(self(), :second_hop)
+        %{event | response: {:ok, %{}}}
+      end
+    end
+
+    test "takes the second hop and returns text content for a text file" do
+      assert {:ok, %{record: %Record{} = record}} =
+               DownloadDocument.run(%{provider: "disk", document_id: "guide.md"}, %{
+                 node_router: DiskNodeRouter
+               })
+
+      assert record.content == "# guide"
+      refute Map.has_key?(record.attributes, "encoding")
+
+      assert_received {:first_hop, :channels, :data_source_download_document,
+                       %{"file_id" => "guide.md"}}
+
+      assert_received {:second_hop, :ingestion, :materialize_record, "guide.md"}
+    end
+
+    test "returns base64 content for a binary file, flagged in attributes" do
+      assert {:ok, %{record: %Record{} = record}} =
+               DownloadDocument.run(%{provider: "disk", document_id: "deck.pdf"}, %{
+                 node_router: DiskNodeRouter
+               })
+
+      assert record.attributes["encoding"] == "base64"
+      assert Base.decode64!(record.content) == "%PDF-"
+    end
+
+    test "a provider answering with content directly takes exactly one hop" do
+      assert {:ok, %{record: %{"id" => "f1", "content" => "abc"}}} =
+               DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
+                 node_router: StubNodeRouter
+               })
+
+      assert_received {:dispatch, :data_source_download_document, %{"file_id" => "f1"}}
+      refute_received {:dispatch, _action, _params}
+    end
+
+    test "an error on the first hop is prefixed and no second hop is attempted" do
+      assert {:error, "Data source document download failed: :not_found"} =
+               DownloadDocument.run(%{provider: "disk", document_id: "guide.md"}, %{
+                 node_router: DiskFirstHopErrorRouter
+               })
+
+      assert_received :first_hop
+      refute_received :second_hop
+    end
+
+    test "still merges the optional mime type and config keys into the first request" do
+      assert {:ok, _} =
+               DownloadDocument.run(
+                 %{
+                   provider: "disk",
+                   document_id: "guide.md",
+                   document_mime_type: "text/markdown",
+                   export_mime_type: "text/plain",
+                   config_id: "12"
+                 },
+                 %{node_router: DiskNodeRouter}
+               )
+
+      assert_received {:first_hop, :channels, :data_source_download_document, params}
+
+      assert params == %{
+               "file_id" => "guide.md",
+               "document_mime_type" => "text/markdown",
+               "export_mime_type" => "text/plain",
+               "config_id" => "12"
+             }
     end
   end
 end

--- a/test/zaq/agent/tools/data_source/get_document_test.exs
+++ b/test/zaq/agent/tools/data_source/get_document_test.exs
@@ -68,6 +68,6 @@ defmodule Zaq.Agent.Tools.DataSource.GetDocumentTest do
                node_router: UnexpectedNodeRouter
              })
 
-    assert message == "Unexpected data source response: :ok"
+    assert message == "Unexpected channel response: :ok"
   end
 end

--- a/test/zaq/agent/tools/data_source/list_documents_test.exs
+++ b/test/zaq/agent/tools/data_source/list_documents_test.exs
@@ -80,6 +80,6 @@ defmodule Zaq.Agent.Tools.DataSource.ListDocumentsTest do
                node_router: StubNodeRouterTimeout
              })
 
-    assert message == "Unexpected data source response: :timeout"
+    assert message == "Unexpected channel response: :timeout"
   end
 end

--- a/test/zaq/agent/tools/data_source/search_documents_test.exs
+++ b/test/zaq/agent/tools/data_source/search_documents_test.exs
@@ -69,6 +69,6 @@ defmodule Zaq.Agent.Tools.DataSource.SearchDocumentsTest do
                node_router: UnexpectedResponseNodeRouter
              })
 
-    assert message == "Unexpected data source response: :not_a_tuple"
+    assert message == "Unexpected channel response: :not_a_tuple"
   end
 end

--- a/test/zaq/agent/tools/data_source/update_document_test.exs
+++ b/test/zaq/agent/tools/data_source/update_document_test.exs
@@ -77,6 +77,6 @@ defmodule Zaq.Agent.Tools.DataSource.UpdateDocumentTest do
                node_router: UnexpectedNodeRouter
              })
 
-    assert message == "Unexpected data source response: :ok"
+    assert message == "Unexpected channel response: :ok"
   end
 end

--- a/test/zaq/agent/tools/data_source_tool_test.exs
+++ b/test/zaq/agent/tools/data_source_tool_test.exs
@@ -2,6 +2,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
   use Zaq.DataCase, async: true
 
   alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Contracts.Record
   alias Zaq.Event
 
   defmodule OkNodeRouter do
@@ -81,5 +82,137 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
                {"range", "Sheet1!A1"},
                {"path", nil}
              ])
+  end
+
+  test "merge_optional/3 only merges keys the params carry" do
+    params = %{document_mime_type: "application/pdf", export_mime_type: nil}
+
+    assert DataSourceTool.merge_optional(%{"file_id" => "f1"}, params, [
+             :document_mime_type,
+             :export_mime_type,
+             :config_id
+           ]) == %{"file_id" => "f1", "document_mime_type" => "application/pdf"}
+  end
+
+  test "wrap_request/2 nests the params under the provider" do
+    assert DataSourceTool.wrap_request(%{"file_id" => "f1"}, "disk") ==
+             %{provider: "disk", params: %{"file_id" => "f1"}}
+  end
+
+  # ── the second hop ──────────────────────────────────────────────────────────
+
+  describe "materialize/2" do
+    defmodule MaterializingRouter do
+      @moduledoc false
+
+      def dispatch(%Event{request: request, opts: opts} = event) do
+        send(self(), {:materialize, event.next_hop.destination, opts[:action], request})
+
+        %{
+          event
+          | response:
+              {:ok,
+               %{
+                 record: %Record{
+                   id: request.file_id,
+                   kind: :file,
+                   content: "# materialized",
+                   attributes: %{"encoding" => "base64"}
+                 }
+               }}
+        }
+      end
+    end
+
+    defmodule MaterializeErrorRouter do
+      @moduledoc false
+
+      def dispatch(%Event{} = event), do: %{event | response: {:error, :enoent}}
+    end
+
+    defmodule MaterializeShapeRouter do
+      @moduledoc false
+
+      def dispatch(%Event{} = event), do: %{event | response: {:ok, %{status: "ok"}}}
+    end
+
+    defp unmaterialized(id \\ "42") do
+      %Record{
+        id: id,
+        kind: :file,
+        content: nil,
+        materializing_event:
+          Event.new(%{file_id: id}, :ingestion, opts: [action: :materialize_record])
+      }
+    end
+
+    test "dispatches the event and returns the record with content" do
+      payload = %{record: unmaterialized(), extra: :kept}
+
+      assert {:ok, %{record: %Record{content: "# materialized"} = record, extra: :kept}} =
+               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+
+      assert record.attributes["encoding"] == "base64"
+      assert_received {:materialize, :ingestion, :materialize_record, %{file_id: "42"}}
+    end
+
+    test "passes a record that already has content through untouched" do
+      payload = %{record: %{unmaterialized() | content: "already here"}}
+
+      assert {:ok, ^payload} =
+               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+
+      refute_received {:materialize, _destination, _action, _request}
+    end
+
+    test "passes a record with no event through untouched" do
+      payload = %{record: %{unmaterialized() | materializing_event: nil}}
+
+      assert {:ok, ^payload} =
+               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+
+      refute_received {:materialize, _destination, _action, _request}
+    end
+
+    test "passes a payload that is not a record through untouched" do
+      payload = %{status: "ok", bytes: 12}
+
+      assert {:ok, ^payload} =
+               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+
+      refute_received {:materialize, _destination, _action, _request}
+    end
+
+    test "passes a plain-map record through untouched" do
+      payload = %{record: %{"id" => "42", "content" => nil}}
+
+      assert {:ok, ^payload} =
+               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+    end
+
+    test "formats a second-hop error with the same prefix as the first" do
+      payload = %{record: unmaterialized()}
+
+      assert {:error, "Download failed: :enoent"} =
+               DataSourceTool.materialize(
+                 payload,
+                 %{node_router: MaterializeErrorRouter},
+                 "Download failed"
+               )
+    end
+
+    test "reports an unexpected second-hop shape rather than crashing" do
+      payload = %{record: unmaterialized()}
+
+      assert {:error, message} =
+               DataSourceTool.materialize(
+                 payload,
+                 %{node_router: MaterializeShapeRouter},
+                 "Download failed"
+               )
+
+      assert message =~ "Download failed: unexpected materialize response"
+      assert message =~ ~s(%{status: "ok"})
+    end
   end
 end

--- a/test/zaq/agent/tools/helpers/channel_tool_test.exs
+++ b/test/zaq/agent/tools/helpers/channel_tool_test.exs
@@ -58,7 +58,7 @@ defmodule Zaq.Agent.Tools.Helpers.ChannelToolTest do
   end
 
   test "dispatch/5 formats unexpected responses" do
-    assert {:error, "Unexpected data source response: :weird_response"} =
+    assert {:error, "Unexpected channel response: :weird_response"} =
              ChannelTool.dispatch(
                :data_source_get_file,
                %{provider: "google_drive", params: %{"file_id" => "f1"}},

--- a/test/zaq/agent/tools/helpers/channel_tool_test.exs
+++ b/test/zaq/agent/tools/helpers/channel_tool_test.exs
@@ -1,7 +1,7 @@
-defmodule Zaq.Agent.Tools.DataSourceToolTest do
+defmodule Zaq.Agent.Tools.Helpers.ChannelToolTest do
   use Zaq.DataCase, async: true
 
-  alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Agent.Tools.Helpers.ChannelTool
   alias Zaq.Contracts.Record
   alias Zaq.Event
 
@@ -24,7 +24,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
     request = %{provider: "google_drive", params: %{"file_id" => "f1"}}
 
     assert {:ok, %{record: %{"id" => "f1"}}} =
-             DataSourceTool.dispatch(
+             ChannelTool.dispatch(
                :data_source_get_file,
                request,
                %{node_router: OkNodeRouter},
@@ -38,7 +38,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
     request = %{provider: "google_drive", params: %{"query" => "invoice"}}
 
     assert {:ok, %{record: %{"id" => "f1"}, count: 1}} =
-             DataSourceTool.dispatch(
+             ChannelTool.dispatch(
                :data_source_search_files,
                request,
                %{node_router: OkNodeRouter},
@@ -49,7 +49,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
 
   test "dispatch/5 formats error tuples" do
     assert {:error, "Data source document request failed: :timeout"} =
-             DataSourceTool.dispatch(
+             ChannelTool.dispatch(
                :data_source_get_file,
                %{provider: "google_drive", params: %{"file_id" => "f1"}},
                %{node_router: ErrorNodeRouter},
@@ -59,7 +59,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
 
   test "dispatch/5 formats unexpected responses" do
     assert {:error, "Unexpected data source response: :weird_response"} =
-             DataSourceTool.dispatch(
+             ChannelTool.dispatch(
                :data_source_get_file,
                %{provider: "google_drive", params: %{"file_id" => "f1"}},
                %{node_router: UnexpectedNodeRouter},
@@ -70,14 +70,14 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
   test "put_if_present/3 only adds non-nil values" do
     assert %{"file_id" => "f1", "config_id" => "7"} =
              %{"file_id" => "f1"}
-             |> DataSourceTool.put_if_present("config_id", "7")
-             |> DataSourceTool.put_if_present("path", nil)
+             |> ChannelTool.put_if_present("config_id", "7")
+             |> ChannelTool.put_if_present("path", nil)
   end
 
   test "put_many_if_present/2 adds only present values" do
     assert %{"file_id" => "f1", "config_id" => "7", "range" => "Sheet1!A1"} =
              %{"file_id" => "f1"}
-             |> DataSourceTool.put_many_if_present([
+             |> ChannelTool.put_many_if_present([
                {"config_id", "7"},
                {"range", "Sheet1!A1"},
                {"path", nil}
@@ -87,7 +87,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
   test "merge_optional/3 only merges keys the params carry" do
     params = %{document_mime_type: "application/pdf", export_mime_type: nil}
 
-    assert DataSourceTool.merge_optional(%{"file_id" => "f1"}, params, [
+    assert ChannelTool.merge_optional(%{"file_id" => "f1"}, params, [
              :document_mime_type,
              :export_mime_type,
              :config_id
@@ -95,7 +95,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
   end
 
   test "wrap_request/2 nests the params under the provider" do
-    assert DataSourceTool.wrap_request(%{"file_id" => "f1"}, "disk") ==
+    assert ChannelTool.wrap_request(%{"file_id" => "f1"}, "disk") ==
              %{provider: "disk", params: %{"file_id" => "f1"}}
   end
 
@@ -150,7 +150,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
       payload = %{record: unmaterialized(), extra: :kept}
 
       assert {:ok, %{record: %Record{content: "# materialized"} = record, extra: :kept}} =
-               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+               ChannelTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
 
       assert record.attributes["encoding"] == "base64"
       assert_received {:materialize, :ingestion, :materialize_record, %{file_id: "42"}}
@@ -160,7 +160,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
       payload = %{record: %{unmaterialized() | content: "already here"}}
 
       assert {:ok, ^payload} =
-               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+               ChannelTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
 
       refute_received {:materialize, _destination, _action, _request}
     end
@@ -169,7 +169,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
       payload = %{record: %{unmaterialized() | materializing_event: nil}}
 
       assert {:ok, ^payload} =
-               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+               ChannelTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
 
       refute_received {:materialize, _destination, _action, _request}
     end
@@ -178,7 +178,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
       payload = %{status: "ok", bytes: 12}
 
       assert {:ok, ^payload} =
-               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+               ChannelTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
 
       refute_received {:materialize, _destination, _action, _request}
     end
@@ -187,14 +187,14 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
       payload = %{record: %{"id" => "42", "content" => nil}}
 
       assert {:ok, ^payload} =
-               DataSourceTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
+               ChannelTool.materialize(payload, %{node_router: MaterializingRouter}, "Failed")
     end
 
     test "formats a second-hop error with the same prefix as the first" do
       payload = %{record: unmaterialized()}
 
       assert {:error, "Download failed: :enoent"} =
-               DataSourceTool.materialize(
+               ChannelTool.materialize(
                  payload,
                  %{node_router: MaterializeErrorRouter},
                  "Download failed"
@@ -205,7 +205,7 @@ defmodule Zaq.Agent.Tools.DataSourceToolTest do
       payload = %{record: unmaterialized()}
 
       assert {:error, message} =
-               DataSourceTool.materialize(
+               ChannelTool.materialize(
                  payload,
                  %{node_router: MaterializeShapeRouter},
                  "Download failed"

--- a/test/zaq/agent/tools/sheets/create_sheet_test.exs
+++ b/test/zaq/agent/tools/sheets/create_sheet_test.exs
@@ -58,6 +58,6 @@ defmodule Zaq.Agent.Tools.Sheets.CreateSheetTest do
                node_router: UnexpectedNodeRouter
              })
 
-    assert message == "Unexpected data source response: :ok"
+    assert message == "Unexpected channel response: :ok"
   end
 end

--- a/test/zaq/channels/channel_config_test.exs
+++ b/test/zaq/channels/channel_config_test.exs
@@ -1,7 +1,7 @@
 defmodule Zaq.Channels.ChannelConfigTest do
   use Zaq.DataCase, async: false
 
-  alias Zaq.Channels.{AgentRouting, ChannelConfig, RetrievalChannel}
+  alias Zaq.Channels.{AgentRouting, Bridge, ChannelConfig, DiskBridge, RetrievalChannel}
   alias Zaq.Engine.IncomingMessageRouting
   alias Zaq.Repo
   alias Zaq.System.SecretConfig
@@ -178,6 +178,65 @@ defmodule Zaq.Channels.ChannelConfigTest do
 
     assert changeset.valid?
     assert {:ok, _config} = Repo.insert(changeset)
+  end
+
+  # ── disk data source ────────────────────────────────────────────────────────
+
+  describe "disk provider" do
+    test "is an accepted provider" do
+      changeset =
+        ChannelConfig.changeset(%ChannelConfig{}, %{
+          name: "Disk",
+          provider: "disk",
+          kind: "data_source",
+          enabled: true
+        })
+
+      assert changeset.valid?
+      refute Elixir.Map.has_key?(errors_on(changeset), :provider)
+    end
+
+    test "gets url and token placeholders rather than being required to supply them" do
+      # The disk data source fronts volumes ZAQ already owns — there is nothing for an
+      # operator to enter, but the row still has to exist for the bridge to be resolved.
+      # The migration already seeded one, so this starts from a clean slate.
+      Repo.get_by!(ChannelConfig, provider: "disk") |> Repo.delete!()
+
+      assert {:ok, config} =
+               %ChannelConfig{}
+               |> ChannelConfig.changeset(%{
+                 name: "Disk",
+                 provider: "disk",
+                 kind: "data_source",
+                 enabled: true
+               })
+               |> Repo.insert()
+
+      assert config.url == ""
+      assert config.token == ""
+    end
+
+    test "keeps a url and token the caller did supply" do
+      assert {:ok, config} =
+               ChannelConfig
+               |> Repo.get_by!(provider: "disk")
+               |> ChannelConfig.changeset(%{url: "https://example.test", token: "supplied"})
+               |> Repo.update()
+
+      assert config.url == "https://example.test"
+      assert Repo.get!(ChannelConfig, config.id).token == "supplied"
+    end
+
+    test "the migration's row is what Bridge.fetch_channel_config/1 finds" do
+      assert {:ok, config} = Bridge.fetch_channel_config("disk")
+      assert config.provider == "disk"
+      assert config.kind == "data_source"
+      assert config.enabled
+    end
+
+    test "resolves to the disk bridge" do
+      assert {:ok, DiskBridge} = Bridge.resolve_bridge("disk")
+    end
   end
 
   test "email:imap requires selected_mailboxes in settings" do

--- a/test/zaq/channels/data_source_bridge_test.exs
+++ b/test/zaq/channels/data_source_bridge_test.exs
@@ -1,7 +1,7 @@
 defmodule Zaq.Channels.DataSourceBridgeTest do
   use Zaq.DataCase, async: false
 
-  alias Zaq.Channels.{ChannelConfig, DataSourceBridge}
+  alias Zaq.Channels.{Bridge, ChannelConfig, DataSourceBridge, DiskBridge}
   alias Zaq.Repo
 
   defmodule StubDataSourceBridge do
@@ -1017,5 +1017,87 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
 
     assert {:error, {:channel_not_configured, :google_drive}} =
              DataSourceBridge.list_files(:google_drive, %{"config_id" => non_existent_id})
+  end
+
+  # ── partial implementation ──────────────────────────────────────────────────
+
+  describe "@optional_callbacks" do
+    test "every declared callback is optional" do
+      # The dispatcher already answers {:error, :unsupported} for anything a bridge does not
+      # export, so partial implementation is the design. The behaviour has to say so, or a
+      # narrow bridge cannot get compile-time checking on the callbacks it does implement.
+      callbacks = DataSourceBridge.behaviour_info(:callbacks)
+      optional = DataSourceBridge.behaviour_info(:optional_callbacks)
+
+      assert callbacks -- optional == []
+    end
+  end
+
+  describe "a bridge implementing only a subset" do
+    setup do
+      original_channels = Application.get_env(:zaq, :channels)
+
+      Application.put_env(:zaq, :channels, %{
+        disk: %{bridge: DiskBridge}
+      })
+
+      on_exit(fn ->
+        if original_channels do
+          Application.put_env(:zaq, :channels, original_channels)
+        else
+          Application.delete_env(:zaq, :channels)
+        end
+      end)
+
+      :ok
+    end
+
+    test ":disk resolves to the disk bridge through the registry" do
+      assert {:ok, DiskBridge} = Bridge.resolve_bridge(:disk)
+      assert {:ok, DiskBridge} = Bridge.resolve_bridge("disk")
+    end
+
+    test "exports the file callbacks it implements" do
+      for {callback, arity} <- [
+            list_files: 2,
+            create_file: 2,
+            get_file: 2,
+            update_file: 2,
+            delete_file: 2,
+            search_files: 2,
+            download_document: 2,
+            list_permissions: 2,
+            channel_stats: 2
+          ] do
+        assert function_exported?(DiskBridge, callback, arity),
+               "expected DiskBridge to export #{callback}/#{arity}"
+      end
+    end
+
+    test "answers :unsupported for the callbacks it omits" do
+      assert {:error, :unsupported} = DataSourceBridge.auth_handshake(:disk, %{})
+      assert {:error, :unsupported} = DataSourceBridge.list_resources(:disk, %{})
+      assert {:error, :unsupported} = DataSourceBridge.oauth_authorize_url(:disk, %{})
+      assert {:error, :unsupported} = DataSourceBridge.oauth_default_scopes(:disk)
+      assert {:error, :unsupported} = DataSourceBridge.watch_changes(:disk, %{})
+      assert {:error, :unsupported} = DataSourceBridge.handle_webhook(:disk, %{})
+      assert {:error, :unsupported} = DataSourceBridge.sheet_get(:disk, %{})
+      assert {:error, :unsupported} = DataSourceBridge.sheet_create(:disk, %{})
+      assert {:error, :unsupported} = DataSourceBridge.sheet_delete_tab(:disk, %{})
+    end
+
+    test "export_options falls back to an empty answer rather than :unsupported" do
+      # `export_options/2` has its own fallback in the dispatcher: a bridge that exports
+      # nothing answers with empty lists, not an error.
+      assert {:ok, %{native_types: [], export_formats_by_native_type: %{}}} =
+               DataSourceBridge.export_options(:disk, %{})
+    end
+
+    test "a provider with no channel_configs row errors rather than getting a synthetic one" do
+      Repo.get_by!(ChannelConfig, provider: "disk") |> Repo.delete!()
+
+      assert {:error, {:channel_not_configured, :disk}} =
+               DataSourceBridge.list_files(:disk, %{})
+    end
   end
 end

--- a/test/zaq/channels/disk_bridge_test.exs
+++ b/test/zaq/channels/disk_bridge_test.exs
@@ -1,0 +1,322 @@
+defmodule Zaq.Channels.DiskBridgeTest do
+  # Unit-level: the router is stubbed through `config["node_router"]`, so these assert what
+  # the bridge asks ingestion for and what it does with the answer — never ingestion itself.
+  use ExUnit.Case, async: true
+
+  alias Zaq.Channels.DiskBridge
+  alias Zaq.Contracts.Record
+  alias Zaq.Contracts.RecordPage
+  alias Zaq.Event
+
+  defmodule StubRouter do
+    @moduledoc false
+
+    def dispatch(%Event{} = event) do
+      send(self(), {:dispatch, event.next_hop.destination, event.opts[:action], event.request})
+      %{event | response: Process.get(:stub_response, {:ok, %{}})}
+    end
+  end
+
+  defmodule ExplodingRouter do
+    @moduledoc false
+
+    def dispatch(%Event{}), do: raise("the bridge must not take its router from params")
+  end
+
+  defp config(overrides \\ %{}) do
+    Map.merge(%{"provider" => "disk", "node_router" => StubRouter}, overrides)
+  end
+
+  defp stub_response(response), do: Process.put(:stub_response, response)
+
+  defp record(id, attrs \\ %{}) do
+    struct!(%Record{id: id, kind: :file, name: "guide.md"}, attrs)
+  end
+
+  defp page(records) do
+    %RecordPage{
+      resource_type: :item,
+      records: records,
+      stats: %{scanned: length(records), returned: length(records)}
+    }
+  end
+
+  # ── request shapes, one per callback ────────────────────────────────────────
+
+  describe "list_files/2" do
+    test "dispatches :list_records to ingestion, passing filters through untouched" do
+      params = %{"filters" => %{"parent" => "archives/manuals"}, "page_size" => 50}
+      stub_response({:ok, page([])})
+
+      assert {:ok, %RecordPage{}} = DiskBridge.list_files(config(), params)
+      assert_received {:dispatch, :ingestion, :list_records, %{params: ^params}}
+    end
+  end
+
+  describe "get_file/2" do
+    test "dispatches :describe_records with the single id" do
+      stub_response({:ok, page([record("42")])})
+
+      assert {:ok, %{record: %Record{id: "42"}}} =
+               DiskBridge.get_file(config(), %{"file_id" => "42"})
+
+      assert_received {:dispatch, :ingestion, :describe_records, %{file_ids: ["42"]}}
+    end
+
+    test "stringifies an integer file_id" do
+      stub_response({:ok, page([record("42")])})
+
+      assert {:ok, %{record: %Record{id: "42"}}} = DiskBridge.get_file(config(), %{file_id: 42})
+      assert_received {:dispatch, :ingestion, :describe_records, %{file_ids: ["42"]}}
+    end
+
+    test "refuses a record whose id is not the one that was asked for" do
+      # The id is re-checked across the role boundary: contract drift must surface as
+      # :not_found, never as the wrong file.
+      stub_response({:ok, page([record("99")])})
+
+      assert {:error, :not_found} = DiskBridge.get_file(config(), %{"file_id" => "42"})
+    end
+
+    test "answers :not_found for an empty page" do
+      stub_response({:ok, page([])})
+
+      assert {:error, :not_found} = DiskBridge.get_file(config(), %{"file_id" => "42"})
+    end
+
+    test "takes the matching record when it heads a multi-record page" do
+      stub_response({:ok, page([record("42"), record("43")])})
+
+      assert {:ok, %{record: %Record{id: "42"}}} =
+               DiskBridge.get_file(config(), %{"file_id" => "42"})
+    end
+
+    test "passes an ingestion error back unchanged" do
+      stub_response({:error, :whatever})
+
+      assert {:error, :whatever} = DiskBridge.get_file(config(), %{"file_id" => "42"})
+    end
+
+    test "returns the record unmaterialized, event intact" do
+      event = Event.new(%{file_id: "42"}, :ingestion, opts: [action: :materialize_record])
+      stub_response({:ok, page([record("42", %{content: nil, materializing_event: event})])})
+
+      assert {:ok, %{record: %Record{content: nil, materializing_event: ^event}}} =
+               DiskBridge.get_file(config(), %{"file_id" => "42"})
+    end
+  end
+
+  describe "create_file/2" do
+    test "dispatches :persist_record carrying name, path, content, and encoding" do
+      stub_response({:ok, %{status: "created"}})
+
+      assert {:ok, %{status: "created"}} =
+               DiskBridge.create_file(config(), %{
+                 "name" => "notes.md",
+                 "path" => "archives",
+                 "content" => "# notes",
+                 "encoding" => "base64"
+               })
+
+      assert_received {:dispatch, :ingestion, :persist_record, request}
+
+      assert request == %{
+               "name" => "notes.md",
+               "path" => "archives",
+               "content" => "# notes",
+               "encoding" => "base64"
+             }
+    end
+
+    test "defaults absent content to an empty string and leaves encoding nil" do
+      stub_response({:ok, %{status: "created"}})
+
+      DiskBridge.create_file(config(), %{"name" => "notes.md", "path" => "archives"})
+
+      assert_received {:dispatch, :ingestion, :persist_record, request}
+      assert request["content"] == ""
+      assert request["encoding"] == nil
+    end
+
+    test "passes an ingestion error back unchanged" do
+      stub_response({:error, :volume_required})
+
+      assert {:error, :volume_required} =
+               DiskBridge.create_file(config(), %{"name" => "notes.md", "path" => "nowhere"})
+    end
+  end
+
+  describe "update_file/2" do
+    test "dispatches :update_record with every key the caller sent" do
+      stub_response({:ok, %{status: "updated"}})
+
+      DiskBridge.update_file(config(), %{
+        "file_id" => "42",
+        "name" => "renamed.md",
+        "path" => "archives/manuals",
+        "content" => "new",
+        "encoding" => "base64"
+      })
+
+      assert_received {:dispatch, :ingestion, :update_record, request}
+
+      assert request == %{
+               "file_id" => "42",
+               "name" => "renamed.md",
+               "path" => "archives/manuals",
+               "content" => "new",
+               "encoding" => "base64"
+             }
+    end
+
+    test "omits keys the caller did not send" do
+      # An absent `content` must not reach ingestion as an empty one — that would truncate
+      # the file on every rename.
+      stub_response({:ok, %{status: "updated"}})
+
+      DiskBridge.update_file(config(), %{"file_id" => "42", "name" => "renamed.md"})
+
+      assert_received {:dispatch, :ingestion, :update_record, request}
+      assert request == %{"file_id" => "42", "name" => "renamed.md"}
+      refute Map.has_key?(request, "content")
+      refute Map.has_key?(request, "path")
+      refute Map.has_key?(request, "encoding")
+    end
+
+    test "treats a key holding nil as absent" do
+      stub_response({:ok, %{status: "updated"}})
+
+      DiskBridge.update_file(config(), %{"file_id" => "42", "content" => nil})
+
+      assert_received {:dispatch, :ingestion, :update_record, request}
+      assert request == %{"file_id" => "42"}
+    end
+
+    test "carries atom-keyed params through under string keys" do
+      stub_response({:ok, %{status: "updated"}})
+
+      DiskBridge.update_file(config(), %{file_id: "42", content: "new"})
+
+      assert_received {:dispatch, :ingestion, :update_record, request}
+      assert request == %{"file_id" => "42", "content" => "new"}
+    end
+  end
+
+  describe "delete_file/2" do
+    test "dispatches :delete_record with the id" do
+      stub_response({:ok, %{status: "deleted"}})
+
+      assert {:ok, %{status: "deleted"}} =
+               DiskBridge.delete_file(config(), %{"file_id" => "42"})
+
+      assert_received {:dispatch, :ingestion, :delete_record, %{file_id: "42"}}
+    end
+
+    test "passes an ingestion error back unchanged" do
+      stub_response({:error, :not_found})
+
+      assert {:error, :not_found} = DiskBridge.delete_file(config(), %{"file_id" => "42"})
+    end
+  end
+
+  describe "search_files/2" do
+    test "dispatches :search_records with the params untouched" do
+      params = %{"query" => "invoice", "page_size" => 10}
+      stub_response({:ok, page([])})
+
+      assert {:ok, %RecordPage{}} = DiskBridge.search_files(config(), params)
+      assert_received {:dispatch, :ingestion, :search_records, %{params: ^params}}
+    end
+  end
+
+  describe "download_document/2" do
+    test "answers exactly as get_file/2 does — one read, not two" do
+      stub_response({:ok, page([record("42", %{content: nil})])})
+
+      assert {:ok, %{record: %Record{id: "42", content: nil}}} =
+               DiskBridge.download_document(config(), %{"file_id" => "42"})
+
+      assert_received {:dispatch, :ingestion, :describe_records, %{file_ids: ["42"]}}
+      refute_received {:dispatch, :ingestion, _action, _request}
+    end
+
+    test "answers :not_found on an id mismatch, like get_file/2" do
+      stub_response({:ok, page([record("99")])})
+
+      assert {:error, :not_found} = DiskBridge.download_document(config(), %{"file_id" => "42"})
+    end
+  end
+
+  describe "list_permissions/2" do
+    test "dispatches :list_record_permissions with the id" do
+      stub_response({:ok, %RecordPage{resource_type: :permission, records: []}})
+
+      assert {:ok, %RecordPage{resource_type: :permission}} =
+               DiskBridge.list_permissions(config(), %{"file_id" => "42"})
+
+      assert_received {:dispatch, :ingestion, :list_record_permissions, %{file_id: "42"}}
+    end
+  end
+
+  describe "channel_stats/2" do
+    test "dispatches :volume_stats" do
+      stub_response({:ok, %{files_count: 3}})
+
+      assert {:ok, %{files_count: 3}} = DiskBridge.channel_stats(config(), %{})
+      assert_received {:dispatch, :ingestion, :volume_stats, %{params: %{}}}
+    end
+  end
+
+  # ── cross-cutting behaviour ─────────────────────────────────────────────────
+
+  describe "params key flexibility" do
+    test "string and atom file_id spellings behave identically" do
+      stub_response({:ok, %{status: "deleted"}})
+
+      DiskBridge.delete_file(config(), %{"file_id" => "42"})
+      assert_received {:dispatch, :ingestion, :delete_record, string_request}
+
+      DiskBridge.delete_file(config(), %{file_id: "42"})
+      assert_received {:dispatch, :ingestion, :delete_record, atom_request}
+
+      assert string_request == atom_request
+    end
+
+    test "a string key holding nil does not shadow the atom spelling" do
+      stub_response({:ok, %{status: "created"}})
+
+      DiskBridge.create_file(config(), %{"name" => nil, :name => "notes.md", "path" => "archives"})
+
+      assert_received {:dispatch, :ingestion, :persist_record, request}
+      assert request["name"] == "notes.md"
+    end
+  end
+
+  describe "router resolution" do
+    test "reads the router off config, never off params" do
+      # `params` reaches this bridge verbatim from agent tools. Taking the dispatch target
+      # from it would let the caller choose which code runs.
+      stub_response({:ok, page([])})
+
+      assert {:ok, %RecordPage{}} =
+               DiskBridge.list_files(config(), %{"node_router" => ExplodingRouter})
+
+      assert_received {:dispatch, :ingestion, :list_records, _request}
+    end
+
+    test "accepts an atom-keyed router on config" do
+      stub_response({:ok, page([])})
+
+      assert {:ok, %RecordPage{}} =
+               DiskBridge.list_files(%{node_router: StubRouter}, %{})
+
+      assert_received {:dispatch, :ingestion, :list_records, _request}
+    end
+  end
+
+  test "implements the DataSourceBridge behaviour" do
+    assert Zaq.Channels.DataSourceBridge in (DiskBridge.module_info(:attributes)
+                                             |> Keyword.get_values(:behaviour)
+                                             |> List.flatten())
+  end
+end

--- a/test/zaq/channels/disk_bridge_test.exs
+++ b/test/zaq/channels/disk_bridge_test.exs
@@ -1,12 +1,13 @@
 defmodule Zaq.Channels.DiskBridgeTest do
   # Unit-level: the router is stubbed through `config["node_router"]`, so these assert what
-  # the bridge asks ingestion for and what it does with the answer — never ingestion itself.
+  # the bridge asks ingestion for and what it maps the answer into — never ingestion itself.
   use ExUnit.Case, async: true
 
   alias Zaq.Channels.DiskBridge
   alias Zaq.Contracts.Record
   alias Zaq.Contracts.RecordPage
   alias Zaq.Event
+  alias Zaq.Ingestion.FileExplorer.Entry
 
   defmodule StubRouter do
     @moduledoc false
@@ -29,16 +30,115 @@ defmodule Zaq.Channels.DiskBridgeTest do
 
   defp stub_response(response), do: Process.put(:stub_response, response)
 
-  defp record(id, attrs \\ %{}) do
-    struct!(%Record{id: id, kind: :file, name: "guide.md"}, attrs)
+  defp entry(id, attrs \\ %{}) do
+    struct!(
+      %Entry{
+        id: id,
+        name: "guide.md",
+        type: :file,
+        size: 12,
+        modified_at: ~U[2026-01-01 00:00:00Z],
+        volume: "archives",
+        relative_path: "guide.md",
+        source: "guide.md"
+      },
+      attrs
+    )
   end
 
-  defp page(records) do
-    %RecordPage{
-      resource_type: :item,
-      records: records,
-      stats: %{scanned: length(records), returned: length(records)}
-    }
+  defp entry_page(entries), do: %{entries: entries, scanned: length(entries)}
+
+  defp grant(id, attrs \\ %{}) do
+    Map.merge(
+      %{id: id, type: "person", target_id: "7", name: "Ada", access_rights: ["read"]},
+      attrs
+    )
+  end
+
+  # ── mapping: entries to records ─────────────────────────────────────────────
+
+  describe "entry mapping" do
+    test "maps a file entry onto a record, carrying provider attributes" do
+      stub_response({:ok, entry_page([entry("42")])})
+
+      assert {:ok, %RecordPage{records: [record]}} = DiskBridge.list_files(config(), %{})
+
+      assert %Record{id: "42", kind: :file, name: "guide.md", path: "guide.md"} = record
+      assert record.mime_type == "text/markdown"
+      assert record.size == 12
+      assert record.modified_at == ~U[2026-01-01 00:00:00Z]
+
+      assert record.attributes == %{
+               "provider" => "disk",
+               "volume" => "archives",
+               "relative_path" => "guide.md",
+               "source" => "guide.md"
+             }
+    end
+
+    test "translates the entry's :directory into the record's :folder, with no mime type" do
+      # The two vocabularies meet here: ingestion says :directory, the record contract says
+      # :folder.
+      stub_response({:ok, entry_page([entry("d1", %{type: :directory, name: "manuals"})])})
+
+      assert {:ok, %RecordPage{records: [record]}} = DiskBridge.list_files(config(), %{})
+      assert record.kind == :folder
+      assert record.mime_type == nil
+    end
+
+    test "keeps the entry on the record's raw field" do
+      volume_entry = entry("42")
+      stub_response({:ok, entry_page([volume_entry])})
+
+      assert {:ok, %RecordPage{records: [record]}} = DiskBridge.list_files(config(), %{})
+      assert record.raw == %{local_entry: volume_entry}
+    end
+
+    test "reports the scanned count ingestion gave alongside what was returned" do
+      # `scanned` differs from `returned` when ingestion dropped rows whose file is gone.
+      stub_response({:ok, %{entries: [entry("42")], scanned: 5}})
+
+      assert {:ok, %RecordPage{stats: stats, resource_type: :item}} =
+               DiskBridge.list_files(config(), %{})
+
+      assert stats == %{scanned: 5, returned: 1}
+    end
+
+    test "answers with an empty page for an empty listing" do
+      stub_response({:ok, entry_page([])})
+
+      assert {:ok, %RecordPage{records: [], stats: %{scanned: 0, returned: 0}}} =
+               DiskBridge.list_files(config(), %{})
+    end
+  end
+
+  describe "materializing events" do
+    test "attaches an event addressed to ingestion, naming the record id" do
+      stub_response({:ok, entry_page([entry("42")])})
+
+      assert {:ok, %RecordPage{records: [record]}} = DiskBridge.list_files(config(), %{})
+
+      assert %Event{request: %{file_id: "42"}, opts: opts, next_hop: next_hop} =
+               record.materializing_event
+
+      assert opts[:action] == :materialize_record
+      assert next_hop.destination == :ingestion
+      assert record.content == nil
+    end
+
+    test "attaches one to a file with no document row, using its volume-path id" do
+      stub_response({:ok, entry_page([entry("disk:archives:loose.md")])})
+
+      assert {:ok, %RecordPage{records: [record]}} = DiskBridge.list_files(config(), %{})
+      assert %Event{request: %{file_id: "disk:archives:loose.md"}} = record.materializing_event
+    end
+
+    test "leaves folders with no materializing event" do
+      stub_response({:ok, entry_page([entry("d1", %{type: :directory})])})
+
+      assert {:ok, %RecordPage{records: [record]}} = DiskBridge.list_files(config(), %{})
+      assert record.materializing_event == nil
+    end
   end
 
   # ── request shapes, one per callback ────────────────────────────────────────
@@ -46,71 +146,55 @@ defmodule Zaq.Channels.DiskBridgeTest do
   describe "list_files/2" do
     test "dispatches :list_records to ingestion, passing filters through untouched" do
       params = %{"filters" => %{"parent" => "archives/manuals"}, "page_size" => 50}
-      stub_response({:ok, page([])})
+      stub_response({:ok, entry_page([])})
 
       assert {:ok, %RecordPage{}} = DiskBridge.list_files(config(), params)
       assert_received {:dispatch, :ingestion, :list_records, %{params: ^params}}
     end
+
+    test "passes an ingestion error back unchanged" do
+      stub_response({:error, :unknown_volume})
+
+      assert {:error, :unknown_volume} = DiskBridge.list_files(config(), %{})
+    end
   end
 
   describe "get_file/2" do
-    test "dispatches :describe_records with the single id" do
-      stub_response({:ok, page([record("42")])})
+    test "dispatches :describe_record with the single id" do
+      stub_response({:ok, entry("42")})
 
       assert {:ok, %{record: %Record{id: "42"}}} =
                DiskBridge.get_file(config(), %{"file_id" => "42"})
 
-      assert_received {:dispatch, :ingestion, :describe_records, %{file_ids: ["42"]}}
+      assert_received {:dispatch, :ingestion, :describe_record, %{file_id: "42"}}
     end
 
     test "stringifies an integer file_id" do
-      stub_response({:ok, page([record("42")])})
+      stub_response({:ok, entry("42")})
 
       assert {:ok, %{record: %Record{id: "42"}}} = DiskBridge.get_file(config(), %{file_id: 42})
-      assert_received {:dispatch, :ingestion, :describe_records, %{file_ids: ["42"]}}
-    end
-
-    test "refuses a record whose id is not the one that was asked for" do
-      # The id is re-checked across the role boundary: contract drift must surface as
-      # :not_found, never as the wrong file.
-      stub_response({:ok, page([record("99")])})
-
-      assert {:error, :not_found} = DiskBridge.get_file(config(), %{"file_id" => "42"})
-    end
-
-    test "answers :not_found for an empty page" do
-      stub_response({:ok, page([])})
-
-      assert {:error, :not_found} = DiskBridge.get_file(config(), %{"file_id" => "42"})
-    end
-
-    test "takes the matching record when it heads a multi-record page" do
-      stub_response({:ok, page([record("42"), record("43")])})
-
-      assert {:ok, %{record: %Record{id: "42"}}} =
-               DiskBridge.get_file(config(), %{"file_id" => "42"})
+      assert_received {:dispatch, :ingestion, :describe_record, %{file_id: "42"}}
     end
 
     test "passes an ingestion error back unchanged" do
-      stub_response({:error, :whatever})
+      stub_response({:error, :not_found})
 
-      assert {:error, :whatever} = DiskBridge.get_file(config(), %{"file_id" => "42"})
+      assert {:error, :not_found} = DiskBridge.get_file(config(), %{"file_id" => "42"})
     end
 
-    test "returns the record unmaterialized, event intact" do
-      event = Event.new(%{file_id: "42"}, :ingestion, opts: [action: :materialize_record])
-      stub_response({:ok, page([record("42", %{content: nil, materializing_event: event})])})
+    test "returns the record unmaterialized" do
+      stub_response({:ok, entry("42")})
 
-      assert {:ok, %{record: %Record{content: nil, materializing_event: ^event}}} =
+      assert {:ok, %{record: %Record{content: nil, materializing_event: %Event{}}}} =
                DiskBridge.get_file(config(), %{"file_id" => "42"})
     end
   end
 
   describe "create_file/2" do
     test "dispatches :persist_record carrying name, path, content, and encoding" do
-      stub_response({:ok, %{status: "created"}})
+      stub_response({:ok, %{status: "created", entry: entry("42")}})
 
-      assert {:ok, %{status: "created"}} =
+      assert {:ok, %{status: "created", record: %Record{id: "42"}}} =
                DiskBridge.create_file(config(), %{
                  "name" => "notes.md",
                  "path" => "archives",
@@ -129,7 +213,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
     end
 
     test "defaults absent content to an empty string and leaves encoding nil" do
-      stub_response({:ok, %{status: "created"}})
+      stub_response({:ok, %{status: "created", entry: entry("42")}})
 
       DiskBridge.create_file(config(), %{"name" => "notes.md", "path" => "archives"})
 
@@ -148,15 +232,16 @@ defmodule Zaq.Channels.DiskBridgeTest do
 
   describe "update_file/2" do
     test "dispatches :update_record with every key the caller sent" do
-      stub_response({:ok, %{status: "updated"}})
+      stub_response({:ok, %{status: "updated", entry: entry("42")}})
 
-      DiskBridge.update_file(config(), %{
-        "file_id" => "42",
-        "name" => "renamed.md",
-        "path" => "archives/manuals",
-        "content" => "new",
-        "encoding" => "base64"
-      })
+      assert {:ok, %{status: "updated", record: %Record{id: "42"}}} =
+               DiskBridge.update_file(config(), %{
+                 "file_id" => "42",
+                 "name" => "renamed.md",
+                 "path" => "archives/manuals",
+                 "content" => "new",
+                 "encoding" => "base64"
+               })
 
       assert_received {:dispatch, :ingestion, :update_record, request}
 
@@ -172,7 +257,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
     test "omits keys the caller did not send" do
       # An absent `content` must not reach ingestion as an empty one — that would truncate
       # the file on every rename.
-      stub_response({:ok, %{status: "updated"}})
+      stub_response({:ok, %{status: "updated", entry: entry("42")}})
 
       DiskBridge.update_file(config(), %{"file_id" => "42", "name" => "renamed.md"})
 
@@ -184,7 +269,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
     end
 
     test "treats a key holding nil as absent" do
-      stub_response({:ok, %{status: "updated"}})
+      stub_response({:ok, %{status: "updated", entry: entry("42")}})
 
       DiskBridge.update_file(config(), %{"file_id" => "42", "content" => nil})
 
@@ -193,7 +278,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
     end
 
     test "carries atom-keyed params through under string keys" do
-      stub_response({:ok, %{status: "updated"}})
+      stub_response({:ok, %{status: "updated", entry: entry("42")}})
 
       DiskBridge.update_file(config(), %{file_id: "42", content: "new"})
 
@@ -203,11 +288,12 @@ defmodule Zaq.Channels.DiskBridgeTest do
   end
 
   describe "delete_file/2" do
-    test "dispatches :delete_record with the id" do
+    test "dispatches :delete_record and answers with the status alone" do
+      # No record comes back: the file is gone by the time ingestion returns, so there is
+      # nothing left to describe. Same answer JidoConnectBridge.delete_file/2 gives.
       stub_response({:ok, %{status: "deleted"}})
 
-      assert {:ok, %{status: "deleted"}} =
-               DiskBridge.delete_file(config(), %{"file_id" => "42"})
+      assert {:ok, %{status: "deleted"}} = DiskBridge.delete_file(config(), %{"file_id" => "42"})
 
       assert_received {:dispatch, :ingestion, :delete_record, %{file_id: "42"}}
     end
@@ -222,39 +308,100 @@ defmodule Zaq.Channels.DiskBridgeTest do
   describe "search_files/2" do
     test "dispatches :search_records with the params untouched" do
       params = %{"query" => "invoice", "page_size" => 10}
-      stub_response({:ok, page([])})
+      stub_response({:ok, entry_page([entry("42")])})
 
-      assert {:ok, %RecordPage{}} = DiskBridge.search_files(config(), params)
+      assert {:ok, %RecordPage{records: [%Record{id: "42"}]}} =
+               DiskBridge.search_files(config(), params)
+
       assert_received {:dispatch, :ingestion, :search_records, %{params: ^params}}
+    end
+
+    test "passes an ingestion error back unchanged" do
+      stub_response({:error, :query_required})
+
+      assert {:error, :query_required} = DiskBridge.search_files(config(), %{})
     end
   end
 
   describe "download_document/2" do
     test "answers exactly as get_file/2 does — one read, not two" do
-      stub_response({:ok, page([record("42", %{content: nil})])})
+      stub_response({:ok, entry("42")})
 
       assert {:ok, %{record: %Record{id: "42", content: nil}}} =
                DiskBridge.download_document(config(), %{"file_id" => "42"})
 
-      assert_received {:dispatch, :ingestion, :describe_records, %{file_ids: ["42"]}}
+      assert_received {:dispatch, :ingestion, :describe_record, %{file_id: "42"}}
       refute_received {:dispatch, :ingestion, _action, _request}
     end
 
-    test "answers :not_found on an id mismatch, like get_file/2" do
-      stub_response({:ok, page([record("99")])})
+    test "passes an ingestion error back, like get_file/2" do
+      stub_response({:error, :not_found})
 
       assert {:error, :not_found} = DiskBridge.download_document(config(), %{"file_id" => "42"})
     end
   end
 
   describe "list_permissions/2" do
-    test "dispatches :list_record_permissions with the id" do
-      stub_response({:ok, %RecordPage{resource_type: :permission, records: []}})
+    test "dispatches :list_record_permissions and maps each grant onto a record" do
+      stub_response({:ok, %{permissions: [grant("7")], public?: false}})
 
-      assert {:ok, %RecordPage{resource_type: :permission}} =
+      assert {:ok, %RecordPage{resource_type: :permission, records: [record]}} =
                DiskBridge.list_permissions(config(), %{"file_id" => "42"})
 
+      assert %Record{id: "7", kind: :permission, name: "Ada", lifecycle_state: :active} = record
+
+      assert record.attributes == %{
+               "type" => "person",
+               "target_id" => "7",
+               "access_rights" => ["read"]
+             }
+
       assert_received {:dispatch, :ingestion, :list_record_permissions, %{file_id: "42"}}
+    end
+
+    test "synthesizes the public grant, since it has no permission row to name" do
+      stub_response({:ok, %{permissions: [], public?: true}})
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               DiskBridge.list_permissions(config(), %{"file_id" => "42"})
+
+      assert record.id == "public:42"
+      assert record.name == "Public"
+      assert record.attributes["type"] == "public"
+      assert record.attributes["target_id"] == nil
+      assert record.attributes["access_rights"] == ["read"]
+    end
+
+    test "lists the public grant ahead of explicit ones" do
+      stub_response({:ok, %{permissions: [grant("7")], public?: true}})
+
+      assert {:ok, %RecordPage{records: records, stats: stats}} =
+               DiskBridge.list_permissions(config(), %{"file_id" => "42"})
+
+      assert Enum.map(records, & &1.id) == ["public:42", "7"]
+      assert stats == %{scanned: 2, returned: 2}
+    end
+
+    test "answers with an empty page when nobody has access" do
+      stub_response({:ok, %{permissions: [], public?: false}})
+
+      assert {:ok, %RecordPage{resource_type: :permission, records: []}} =
+               DiskBridge.list_permissions(config(), %{"file_id" => "42"})
+    end
+
+    test "defaults missing access rights to an empty list" do
+      stub_response({:ok, %{permissions: [grant("7", %{access_rights: nil})], public?: false}})
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               DiskBridge.list_permissions(config(), %{"file_id" => "42"})
+
+      assert record.attributes["access_rights"] == []
+    end
+
+    test "passes an ingestion error back unchanged" do
+      stub_response({:error, :not_found})
+
+      assert {:error, :not_found} = DiskBridge.list_permissions(config(), %{"file_id" => "42"})
     end
   end
 
@@ -283,7 +430,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
     end
 
     test "a string key holding nil does not shadow the atom spelling" do
-      stub_response({:ok, %{status: "created"}})
+      stub_response({:ok, %{status: "created", entry: entry("42")}})
 
       DiskBridge.create_file(config(), %{"name" => nil, :name => "notes.md", "path" => "archives"})
 
@@ -296,7 +443,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
     test "reads the router off config, never off params" do
       # `params` reaches this bridge verbatim from agent tools. Taking the dispatch target
       # from it would let the caller choose which code runs.
-      stub_response({:ok, page([])})
+      stub_response({:ok, entry_page([])})
 
       assert {:ok, %RecordPage{}} =
                DiskBridge.list_files(config(), %{"node_router" => ExplodingRouter})
@@ -305,10 +452,9 @@ defmodule Zaq.Channels.DiskBridgeTest do
     end
 
     test "accepts an atom-keyed router on config" do
-      stub_response({:ok, page([])})
+      stub_response({:ok, entry_page([])})
 
-      assert {:ok, %RecordPage{}} =
-               DiskBridge.list_files(%{node_router: StubRouter}, %{})
+      assert {:ok, %RecordPage{}} = DiskBridge.list_files(%{node_router: StubRouter}, %{})
 
       assert_received {:dispatch, :ingestion, :list_records, _request}
     end

--- a/test/zaq/contracts/record_test.exs
+++ b/test/zaq/contracts/record_test.exs
@@ -1,0 +1,112 @@
+defmodule Zaq.Contracts.RecordTest do
+  use ExUnit.Case, async: true
+
+  alias Zaq.Contracts.Record
+  alias Zaq.Event
+
+  # Every field that must never leave the struct. Kept as a literal here on purpose: if the
+  # struct grows a field carrying provider internals or a dispatchable capability, one of
+  # these tests should fail rather than the field quietly appearing in a tool result.
+  @private_fields [:materializing_event, :raw]
+
+  defp record(attrs \\ %{}) do
+    struct!(
+      %Record{
+        id: "42",
+        kind: :file,
+        name: "guide.md",
+        mime_type: "text/markdown",
+        content: "# guide",
+        path: "manuals/guide.md",
+        attributes: %{"provider" => "disk"},
+        raw: %{local_entry: %{name: "guide.md"}},
+        materializing_event:
+          Event.new(%{file_id: "42"}, :ingestion, opts: [action: :materialize_record])
+      },
+      attrs
+    )
+  end
+
+  describe "to_map/1" do
+    test "returns every struct field except the private ones" do
+      expected =
+        record()
+        |> Map.from_struct()
+        |> Map.keys()
+        |> Kernel.--(@private_fields)
+        |> Enum.sort()
+
+      assert record() |> Record.to_map() |> Map.keys() |> Enum.sort() == expected
+    end
+
+    test "drops raw and materializing_event" do
+      map = Record.to_map(record())
+
+      for field <- @private_fields do
+        refute Map.has_key?(map, field), "#{field} must not travel in to_map/1"
+      end
+    end
+
+    test "keeps the public values intact" do
+      map = Record.to_map(record())
+
+      assert map.id == "42"
+      assert map.kind == :file
+      assert map.content == "# guide"
+      assert map.attributes == %{"provider" => "disk"}
+      assert map.parent_ids == []
+      assert map.owners == []
+    end
+
+    test "returns a plain map, not a struct" do
+      refute is_struct(Record.to_map(record()))
+    end
+  end
+
+  describe "Jason encoding" do
+    test "encodes exactly the fields to_map/1 returns" do
+      # The encoder and `to_map/1` read one list precisely so they cannot drift apart and
+      # expose a field through one path but not the other.
+      encoded_keys = record() |> Jason.encode!() |> Jason.decode!() |> Map.keys() |> Enum.sort()
+
+      to_map_keys =
+        record() |> Record.to_map() |> Map.keys() |> Enum.map(&Atom.to_string/1) |> Enum.sort()
+
+      assert encoded_keys == to_map_keys
+    end
+
+    test "omits raw and materializing_event" do
+      decoded = record() |> Jason.encode!() |> Jason.decode!()
+
+      for field <- @private_fields do
+        refute Map.has_key?(decoded, Atom.to_string(field)),
+               "#{field} must not travel in the JSON projection"
+      end
+    end
+
+    test "a record encodes even when it carries an event" do
+      # A `%Zaq.Event{}` has no encoder — the record only encodes because the event is
+      # excluded from the derived field list.
+      assert is_binary(Jason.encode!(record()))
+    end
+  end
+
+  describe "round trip through JSON" do
+    test "comes back without the event, and therefore cannot be materialized" do
+      rebuilt =
+        record()
+        |> Jason.encode!()
+        |> Jason.decode!()
+        |> Enum.map(fn {key, value} -> {String.to_existing_atom(key), value} end)
+        |> then(&struct(Record, &1))
+
+      assert rebuilt.id == "42"
+      assert rebuilt.materializing_event == nil
+      assert rebuilt.raw == %{}
+    end
+  end
+
+  test "id and kind are enforced" do
+    assert_raise ArgumentError, fn -> struct!(Record, name: "guide.md") end
+  end
+end

--- a/test/zaq/engine/connect/grant_refresh_worker_test.exs
+++ b/test/zaq/engine/connect/grant_refresh_worker_test.exs
@@ -38,6 +38,13 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
     |> Repo.insert!()
   end
 
+  # `Connect.issue_grant/1` rejects a data_source grant whose channel config names another
+  # provider, so a test that wants the "no config" path needs an id no row holds. Migrations
+  # seed channel_configs rows, so that id cannot be a literal.
+  defp unused_config_id do
+    to_string((Repo.aggregate(ChannelConfig, :max, :id) || 0) + 1)
+  end
+
   test "perform/1 returns ok when grant does not exist" do
     assert :ok = GrantRefreshWorker.perform(%Job{args: %{"grant_id" => -1}})
   end
@@ -112,7 +119,7 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
       Connect.issue_grant(%{
         credential_id: credential.id,
         resource_type: "data_source",
-        resource_id: "2",
+        resource_id: unused_config_id(),
         owner_type: "org",
         metadata: %{},
         status: "active",
@@ -125,7 +132,7 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
   end
 
   test "perform/1 returns ok when oauth2 refresh succeeds" do
-    insert_config(:google_drive, kind: "data_source")
+    config = insert_config(:google_drive, kind: "data_source")
 
     original_channels = Application.get_env(:zaq, :channels)
 
@@ -157,7 +164,7 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
       Connect.issue_grant(%{
         credential_id: credential.id,
         resource_type: "data_source",
-        resource_id: "2",
+        resource_id: to_string(config.id),
         owner_type: "org",
         metadata: %{},
         status: "active",
@@ -169,7 +176,7 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
   end
 
   test "perform/1 returns ok when bridge does not support oauth2 refresh" do
-    insert_config(:slack, kind: "data_source")
+    config = insert_config(:slack, kind: "data_source")
 
     original_channels = Application.get_env(:zaq, :channels)
 
@@ -201,7 +208,7 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
       Connect.issue_grant(%{
         credential_id: credential.id,
         resource_type: "data_source",
-        resource_id: "2",
+        resource_id: to_string(config.id),
         owner_type: "org",
         metadata: %{},
         status: "active",
@@ -213,7 +220,7 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
   end
 
   test "perform/1 keeps existing refresh_token when refresh payload omits it" do
-    insert_config(:google_drive, kind: "data_source")
+    config = insert_config(:google_drive, kind: "data_source")
 
     original_channels = Application.get_env(:zaq, :channels)
 
@@ -245,7 +252,7 @@ defmodule Zaq.Engine.Connect.GrantRefreshWorkerTest do
       Connect.issue_grant(%{
         credential_id: credential.id,
         resource_type: "data_source",
-        resource_id: "2",
+        resource_id: to_string(config.id),
         owner_type: "org",
         metadata: %{},
         status: "active",

--- a/test/zaq/ingestion/api_test.exs
+++ b/test/zaq/ingestion/api_test.exs
@@ -3,7 +3,6 @@ defmodule Zaq.Ingestion.ApiTest do
   # Application.put_env.
   use Zaq.DataCase, async: false
 
-  alias Zaq.Contracts.RecordPage
   alias Zaq.Event
   alias Zaq.Ingestion.Api
   alias Zaq.Ingestion.Document
@@ -68,20 +67,19 @@ defmodule Zaq.Ingestion.ApiTest do
   end
 
   describe "record actions" do
-    test "describe_records delegates and puts the page on the response", %{root: root} do
+    test "describe_record delegates and puts the entry on the response", %{root: root} do
       document = seed_file(root, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: [record]}} =
-               handle(%{file_ids: [to_string(document.id)]}, :describe_records)
+      assert {:ok, entry} = handle(%{file_id: to_string(document.id)}, :describe_record)
 
-      assert record.id == to_string(document.id)
+      assert entry.id == to_string(document.id)
     end
 
     test "list_records delegates", %{root: root} do
       document = seed_file(root, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: records}} = handle(%{params: %{}}, :list_records)
-      assert to_string(document.id) in Enum.map(records, & &1.id)
+      assert {:ok, %{entries: entries}} = handle(%{params: %{}}, :list_records)
+      assert to_string(document.id) in Enum.map(entries, & &1.id)
     end
 
     test "materialize_record delegates and passes the whole request through", %{root: root} do
@@ -97,13 +95,13 @@ defmodule Zaq.Ingestion.ApiTest do
     end
 
     test "persist_record delegates", %{root: root} do
-      assert {:ok, %{status: "created", record: record}} =
+      assert {:ok, %{status: "created", entry: entry}} =
                handle(
                  %{"name" => "notes.md", "path" => @volume, "content" => "# notes"},
                  :persist_record
                )
 
-      assert record.name == "notes.md"
+      assert entry.name == "notes.md"
       assert File.read!(Path.join(root, "notes.md")) == "# notes"
     end
 
@@ -128,17 +126,17 @@ defmodule Zaq.Ingestion.ApiTest do
     test "list_record_permissions delegates", %{root: root} do
       document = seed_file(root, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{resource_type: :permission}} =
+      assert {:ok, %{permissions: [], public?: false}} =
                handle(%{file_id: to_string(document.id)}, :list_record_permissions)
     end
 
     test "search_records delegates", %{root: root} do
       document = seed_file(root, "quarterly.md", "# report")
 
-      assert {:ok, %RecordPage{records: [record]}} =
+      assert {:ok, %{entries: [entry]}} =
                handle(%{params: %{"query" => "quarterly"}}, :search_records)
 
-      assert record.id == to_string(document.id)
+      assert entry.id == to_string(document.id)
     end
 
     test "volume_stats delegates", %{root: root} do
@@ -149,9 +147,9 @@ defmodule Zaq.Ingestion.ApiTest do
   end
 
   describe "clause guards" do
-    test "describe_records with a non-list falls through to the catch-all" do
-      assert handle(%{file_ids: "not-a-list"}, :describe_records) ==
-               {:error, {:unsupported_action, :describe_records}}
+    test "describe_record with a non-binary file_id falls through to the catch-all" do
+      assert handle(%{file_id: 123}, :describe_record) ==
+               {:error, {:unsupported_action, :describe_record}}
     end
 
     test "materialize_record with a non-binary file_id falls through to the catch-all" do
@@ -194,7 +192,7 @@ defmodule Zaq.Ingestion.ApiTest do
       # Clause order is load-bearing and silent when wrong: a catch-all placed above these
       # would swallow them all, and this assertion is what notices.
       actions = [
-        {%{file_ids: []}, :describe_records},
+        {%{file_id: "1"}, :describe_record},
         {%{params: %{}}, :list_records},
         {%{file_id: "99999999"}, :materialize_record},
         {%{}, :persist_record},

--- a/test/zaq/ingestion/api_test.exs
+++ b/test/zaq/ingestion/api_test.exs
@@ -1,8 +1,57 @@
 defmodule Zaq.Ingestion.ApiTest do
-  use ExUnit.Case, async: true
+  # async: false — the record actions read the mounted volumes, which are set through
+  # Application.put_env.
+  use Zaq.DataCase, async: false
 
+  alias Zaq.Contracts.RecordPage
   alias Zaq.Event
   alias Zaq.Ingestion.Api
+  alias Zaq.Ingestion.Document
+
+  @volume "archives"
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "zaq_ingestion_api_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+
+    original = Application.get_env(:zaq, Zaq.Ingestion)
+
+    Application.put_env(
+      :zaq,
+      Zaq.Ingestion,
+      Keyword.merge(original || [], volumes: %{@volume => root})
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root)
+
+      if is_nil(original) do
+        Application.delete_env(:zaq, Zaq.Ingestion)
+      else
+        Application.put_env(:zaq, Zaq.Ingestion, original)
+      end
+    end)
+
+    %{root: root}
+  end
+
+  defp handle(request, action) do
+    request
+    |> Event.new(:ingestion, opts: [action: action])
+    |> Api.handle_event(action, nil)
+    |> Map.fetch!(:response)
+  end
+
+  defp seed_file(root, relative_path, content) do
+    absolute = Path.join(root, relative_path)
+    absolute |> Path.dirname() |> File.mkdir_p!()
+    File.write!(absolute, content)
+
+    {:ok, document} =
+      Document.create(%{source: Path.join(@volume, relative_path), content: content})
+
+    document
+  end
 
   test "delegates invoke to shared helper" do
     event = Event.new(%{module: String, function: :upcase, args: ["hi"]}, :ingestion)
@@ -16,5 +65,150 @@ defmodule Zaq.Ingestion.ApiTest do
     result = Api.handle_event(event, :unknown, nil)
 
     assert result.response == {:error, {:unsupported_action, :unknown}}
+  end
+
+  describe "record actions" do
+    test "describe_records delegates and puts the page on the response", %{root: root} do
+      document = seed_file(root, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               handle(%{file_ids: [to_string(document.id)]}, :describe_records)
+
+      assert record.id == to_string(document.id)
+    end
+
+    test "list_records delegates", %{root: root} do
+      document = seed_file(root, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: records}} = handle(%{params: %{}}, :list_records)
+      assert to_string(document.id) in Enum.map(records, & &1.id)
+    end
+
+    test "materialize_record delegates and passes the whole request through", %{root: root} do
+      document = seed_file(root, "guide.md", "# guide")
+
+      assert {:ok, %{record: record}} =
+               handle(
+                 %{"encoding" => "base64", file_id: to_string(document.id)},
+                 :materialize_record
+               )
+
+      assert record.attributes["encoding"] == "base64"
+    end
+
+    test "persist_record delegates", %{root: root} do
+      assert {:ok, %{status: "created", record: record}} =
+               handle(
+                 %{"name" => "notes.md", "path" => @volume, "content" => "# notes"},
+                 :persist_record
+               )
+
+      assert record.name == "notes.md"
+      assert File.read!(Path.join(root, "notes.md")) == "# notes"
+    end
+
+    test "update_record delegates", %{root: root} do
+      document = seed_file(root, "guide.md", "old")
+
+      assert {:ok, %{status: "updated"}} =
+               handle(%{"file_id" => to_string(document.id), "content" => "new"}, :update_record)
+
+      assert File.read!(Path.join(root, "guide.md")) == "new"
+    end
+
+    test "delete_record delegates", %{root: root} do
+      document = seed_file(root, "guide.md", "# guide")
+
+      assert {:ok, %{status: "deleted"}} =
+               handle(%{file_id: to_string(document.id)}, :delete_record)
+
+      refute File.exists?(Path.join(root, "guide.md"))
+    end
+
+    test "list_record_permissions delegates", %{root: root} do
+      document = seed_file(root, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{resource_type: :permission}} =
+               handle(%{file_id: to_string(document.id)}, :list_record_permissions)
+    end
+
+    test "search_records delegates", %{root: root} do
+      document = seed_file(root, "quarterly.md", "# report")
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               handle(%{params: %{"query" => "quarterly"}}, :search_records)
+
+      assert record.id == to_string(document.id)
+    end
+
+    test "volume_stats delegates", %{root: root} do
+      seed_file(root, "guide.md", "# guide")
+
+      assert {:ok, %{files_count: 1, root_folders: [@volume]}} = handle(%{}, :volume_stats)
+    end
+  end
+
+  describe "clause guards" do
+    test "describe_records with a non-list falls through to the catch-all" do
+      assert handle(%{file_ids: "not-a-list"}, :describe_records) ==
+               {:error, {:unsupported_action, :describe_records}}
+    end
+
+    test "materialize_record with a non-binary file_id falls through to the catch-all" do
+      assert handle(%{file_id: 123}, :materialize_record) ==
+               {:error, {:unsupported_action, :materialize_record}}
+    end
+
+    test "delete_record with a non-binary file_id falls through to the catch-all" do
+      assert handle(%{file_id: 123}, :delete_record) ==
+               {:error, {:unsupported_action, :delete_record}}
+    end
+
+    test "list_record_permissions with a non-binary file_id falls through to the catch-all" do
+      assert handle(%{file_id: 123}, :list_record_permissions) ==
+               {:error, {:unsupported_action, :list_record_permissions}}
+    end
+
+    test "list_records with non-map params falls through to the catch-all" do
+      assert handle(%{params: "nope"}, :list_records) ==
+               {:error, {:unsupported_action, :list_records}}
+    end
+
+    test "search_records with non-map params falls through to the catch-all" do
+      assert handle(%{params: "nope"}, :search_records) ==
+               {:error, {:unsupported_action, :search_records}}
+    end
+
+    test "a record action with a non-map request falls through to the catch-all" do
+      assert handle(:not_a_map, :persist_record) ==
+               {:error, {:unsupported_action, :persist_record}}
+
+      assert handle(:not_a_map, :update_record) ==
+               {:error, {:unsupported_action, :update_record}}
+
+      assert handle(:not_a_map, :volume_stats) ==
+               {:error, {:unsupported_action, :volume_stats}}
+    end
+
+    test "the catch-all stays last — every known action still resolves to its own clause" do
+      # Clause order is load-bearing and silent when wrong: a catch-all placed above these
+      # would swallow them all, and this assertion is what notices.
+      actions = [
+        {%{file_ids: []}, :describe_records},
+        {%{params: %{}}, :list_records},
+        {%{file_id: "99999999"}, :materialize_record},
+        {%{}, :persist_record},
+        {%{}, :update_record},
+        {%{file_id: "99999999"}, :delete_record},
+        {%{file_id: "99999999"}, :list_record_permissions},
+        {%{params: %{}}, :search_records},
+        {%{}, :volume_stats}
+      ]
+
+      for {request, action} <- actions do
+        refute handle(request, action) == {:error, {:unsupported_action, action}},
+               "#{action} fell through to the catch-all"
+      end
+    end
   end
 end

--- a/test/zaq/ingestion/file_explorer_test.exs
+++ b/test/zaq/ingestion/file_explorer_test.exs
@@ -2,6 +2,7 @@ defmodule Zaq.Ingestion.FileExplorerTest do
   use ExUnit.Case, async: false
 
   alias Zaq.Ingestion.FileExplorer
+  alias Zaq.Ingestion.FileExplorer.Entry
 
   @test_base "test/tmp/file_explorer"
 
@@ -19,6 +20,73 @@ defmodule Zaq.Ingestion.FileExplorerTest do
     end)
 
     :ok
+  end
+
+  describe "entries" do
+    test "list/1 answers with entry structs carrying the path each entry was listed under" do
+      File.mkdir_p!(Path.join(@test_base, "docs/nested"))
+      File.write!(Path.join(@test_base, "docs/file.txt"), "hello")
+
+      assert {:ok, [file, nested]} = FileExplorer.list("docs")
+
+      assert %Entry{name: "nested", type: :directory, relative_path: "docs/nested"} = nested
+      assert %Entry{name: "file.txt", type: :file, relative_path: "docs/file.txt"} = file
+      assert file.size == 5
+      assert %DateTime{} = file.modified_at
+    end
+
+    # A "." listing directory contributes nothing to the path, matching how the rest of
+    # ingestion joins a directory to an entry name.
+    test "list/1 names entries under the root bare rather than prefixed with \".\"" do
+      File.write!(Path.join(@test_base, "root.txt"), "x")
+
+      assert {:ok, entries} = FileExplorer.list(".")
+      assert Enum.any?(entries, &(&1.relative_path == "root.txt"))
+    end
+
+    # Without a volume there is nothing to name, so single-volume deployments answer nil
+    # rather than inventing a default.
+    test "list/1 leaves volume unset" do
+      File.write!(Path.join(@test_base, "root.txt"), "x")
+
+      assert {:ok, [entry]} = FileExplorer.list(".")
+      assert entry.volume == nil
+    end
+
+    test "file_info/1 answers with an entry struct for the path it was given" do
+      File.write!(Path.join(@test_base, "doc.md"), "# Title")
+
+      assert {:ok, %Entry{} = entry} = FileExplorer.file_info("doc.md")
+      assert entry.name == "doc.md"
+      assert entry.type == :file
+      assert entry.relative_path == "doc.md"
+      assert entry.volume == nil
+    end
+  end
+
+  describe "entries in a named volume" do
+    setup do
+      vol = Path.join(@test_base, "vol_docs")
+      File.mkdir_p!(Path.join(vol, "sub"))
+      File.write!(Path.join(vol, "sub/note.md"), "note")
+      original = Application.get_env(:zaq, Zaq.Ingestion)
+      Application.put_env(:zaq, Zaq.Ingestion, volumes: %{"docs" => vol})
+      on_exit(fn -> Application.put_env(:zaq, Zaq.Ingestion, original || []) end)
+      :ok
+    end
+
+    test "list/2 stamps the volume and the path relative to it" do
+      assert {:ok, [entry]} = FileExplorer.list("docs", "sub")
+
+      assert %Entry{name: "note.md", volume: "docs", relative_path: "sub/note.md"} = entry
+    end
+
+    test "file_info/2 stamps the volume and the path it was given" do
+      assert {:ok, %Entry{} = entry} = FileExplorer.file_info("docs", "sub/note.md")
+
+      assert entry.volume == "docs"
+      assert entry.relative_path == "sub/note.md"
+    end
   end
 
   describe "resolve_path/1" do

--- a/test/zaq/ingestion/ingestion_disk_records_test.exs
+++ b/test/zaq/ingestion/ingestion_disk_records_test.exs
@@ -1,0 +1,892 @@
+defmodule Zaq.Ingestion.DiskRecordsTest do
+  # async: false — these tests mount volumes through Application.put_env; concurrent runs
+  # would read each other's configuration.
+  use Zaq.DataCase, async: false
+
+  alias Zaq.Accounts.People
+  alias Zaq.Contracts.Record
+  alias Zaq.Contracts.RecordPage
+  alias Zaq.Ingestion
+  alias Zaq.Ingestion.Chunk
+  alias Zaq.Ingestion.Document
+  alias Zaq.Repo
+
+  @volume "archives"
+  @other_volume "vault"
+
+  setup do
+    unique = System.unique_integer([:positive])
+    root = Path.join(System.tmp_dir!(), "zaq_disk_records_#{unique}")
+    other_root = Path.join(System.tmp_dir!(), "zaq_disk_records_other_#{unique}")
+    File.mkdir_p!(root)
+    File.mkdir_p!(other_root)
+
+    original = Application.get_env(:zaq, Zaq.Ingestion)
+
+    Application.put_env(
+      :zaq,
+      Zaq.Ingestion,
+      Keyword.merge(original || [], volumes: %{@volume => root, @other_volume => other_root})
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      File.rm_rf(other_root)
+
+      if is_nil(original) do
+        Application.delete_env(:zaq, Zaq.Ingestion)
+      else
+        Application.put_env(:zaq, Zaq.Ingestion, original)
+      end
+    end)
+
+    %{root: root, other_root: other_root}
+  end
+
+  # Writes a file onto a volume and registers the document row the way an ingest would, so
+  # tests start from the state the bridge actually reads.
+  # The bytes on disk and `documents.content` are kept separate: a document row holds the
+  # extracted text, and a test seeding raw binary must not push it through a UTF-8 column.
+  defp seed_file(root, volume, relative_path, bytes, attrs \\ %{}) do
+    absolute = Path.join(root, relative_path)
+    absolute |> Path.dirname() |> File.mkdir_p!()
+    File.write!(absolute, bytes)
+
+    source = Path.join(volume, relative_path)
+    {:ok, document} = Document.create(Map.merge(%{source: source, content: "seeded"}, attrs))
+
+    document
+  end
+
+  # A row pointing at a file that is not on the volume — the state most rows in a long-lived
+  # install end up in.
+  defp seed_stale_row(volume, relative_path) do
+    {:ok, document} =
+      Document.create(%{source: Path.join(volume, relative_path), content: "orphaned"})
+
+    document
+  end
+
+  defp create_person do
+    unique = System.unique_integer([:positive])
+
+    {:ok, person} =
+      People.create_person(%{
+        "full_name" => "Disk Person #{unique}",
+        "email" => "disk#{unique}@test.com"
+      })
+
+    person
+  end
+
+  defp create_team do
+    {:ok, team} = People.create_team(%{name: "Disk Team #{System.unique_integer([:positive])}"})
+    team
+  end
+
+  # ── describe_records/1 ──────────────────────────────────────────────────────
+
+  describe "describe_records/1" do
+    test "answers with one record per known document id", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: [record], stats: stats}} =
+               Ingestion.describe_records([to_string(document.id)])
+
+      assert record.id == to_string(document.id)
+      assert record.name == "guide.md"
+      assert record.kind == :file
+      assert stats == %{scanned: 1, returned: 1}
+    end
+
+    test "drops unknown ids rather than failing the page", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+      missing = to_string(document.id + 9_999)
+
+      assert {:ok, %RecordPage{records: records, stats: stats}} =
+               Ingestion.describe_records([to_string(document.id), missing])
+
+      assert Enum.map(records, & &1.id) == [to_string(document.id)]
+      assert stats == %{scanned: 2, returned: 1}
+    end
+
+    test "drops a stale row whose file is gone from the volume", %{root: root} do
+      live = seed_file(root, @volume, "guide.md", "# guide")
+      stale = seed_stale_row(@volume, "deleted.md")
+
+      assert {:ok, %RecordPage{records: records, stats: stats}} =
+               Ingestion.describe_records([to_string(live.id), to_string(stale.id)])
+
+      assert Enum.map(records, & &1.id) == [to_string(live.id)]
+      assert stats == %{scanned: 2, returned: 1}
+    end
+
+    test "returns an empty page for no ids" do
+      assert {:ok, %RecordPage{records: [], stats: %{scanned: 0, returned: 0}}} =
+               Ingestion.describe_records([])
+    end
+
+    test "records travel unmaterialized with an event that names the same id", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               Ingestion.describe_records([to_string(document.id)])
+
+      assert record.content == nil
+      assert record.materializing_event.request == %{file_id: to_string(document.id)}
+      assert record.materializing_event.opts[:action] == :materialize_record
+    end
+  end
+
+  # ── list_records/1 ──────────────────────────────────────────────────────────
+
+  describe "list_records/1 without a parent filter" do
+    test "answers with documents from every mounted volume", %{root: root, other_root: other} do
+      archived = seed_file(root, @volume, "guide.md", "# guide")
+      vaulted = seed_file(other, @other_volume, "secret.md", "# secret")
+
+      assert {:ok, %RecordPage{records: records}} = Ingestion.list_records(%{})
+
+      ids = Enum.map(records, & &1.id)
+      assert to_string(archived.id) in ids
+      assert to_string(vaulted.id) in ids
+    end
+
+    test "treats an empty parent filter as no filter", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: records}} =
+               Ingestion.list_records(%{"filters" => %{"parent" => ""}})
+
+      assert to_string(document.id) in Enum.map(records, & &1.id)
+    end
+
+    test "drops stale rows and reports the gap in stats", %{root: root} do
+      _live = seed_file(root, @volume, "guide.md", "# guide")
+      _stale = seed_stale_row(@volume, "deleted.md")
+
+      assert {:ok, %RecordPage{stats: %{scanned: scanned, returned: returned}}} =
+               Ingestion.list_records(%{})
+
+      assert scanned == returned + 1
+    end
+
+    test "defaults params to an empty map", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: records}} = Ingestion.list_records()
+      assert to_string(document.id) in Enum.map(records, & &1.id)
+    end
+  end
+
+  describe "list_records/1 with a parent filter" do
+    test "a bare volume name lists that volume's root", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+      File.mkdir_p!(Path.join(root, "manuals"))
+
+      assert {:ok, %RecordPage{records: records}} =
+               Ingestion.list_records(%{"filters" => %{"parent" => @volume}})
+
+      by_name = Map.new(records, &{&1.name, &1})
+      assert by_name["guide.md"].id == to_string(document.id)
+      assert by_name["manuals"].kind == :folder
+    end
+
+    test "a subdirectory lists that directory", %{root: root} do
+      document = seed_file(root, @volume, "manuals/nested.md", "# nested")
+
+      assert {:ok, %RecordPage{records: [record], stats: %{scanned: 1, returned: 1}}} =
+               Ingestion.list_records(%{"filters" => %{"parent" => "#{@volume}/manuals"}})
+
+      assert record.id == to_string(document.id)
+      assert record.path == "manuals/nested.md"
+    end
+
+    test "returns folders alongside files, with folders carrying a path id", %{root: root} do
+      File.mkdir_p!(Path.join(root, "manuals"))
+      _document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: records}} =
+               Ingestion.list_records(%{"filters" => %{"parent" => @volume}})
+
+      folder = Enum.find(records, &(&1.kind == :folder))
+      assert folder.id == "disk:#{@volume}:manuals"
+      assert folder.materializing_event == nil
+    end
+
+    test "a file with no document row carries the path-form id", %{root: root} do
+      File.write!(Path.join(root, "unindexed.md"), "# unindexed")
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               Ingestion.list_records(%{"filters" => %{"parent" => @volume}})
+
+      assert record.id == "disk:#{@volume}:unindexed.md"
+    end
+
+    test "an unknown volume answers with FileExplorer's error rather than crashing" do
+      assert {:error, _reason} =
+               Ingestion.list_records(%{"filters" => %{"parent" => "nosuchvolume/sub"}})
+    end
+
+    test "accepts atom-keyed filters", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: records}} =
+               Ingestion.list_records(%{filters: %{parent: @volume}})
+
+      assert to_string(document.id) in Enum.map(records, & &1.id)
+    end
+  end
+
+  # ── persist_record/1 ────────────────────────────────────────────────────────
+
+  describe "persist_record/1" do
+    test "writes the file, registers the row, and names the record by the row", %{root: root} do
+      assert {:ok, %{status: "created", record: %Record{} = record}} =
+               Ingestion.persist_record(%{
+                 "name" => "notes.md",
+                 "path" => @volume,
+                 "content" => "# notes"
+               })
+
+      assert File.read!(Path.join(root, "notes.md")) == "# notes"
+      document = Document.get_by_source("#{@volume}/notes.md")
+      assert record.id == to_string(document.id)
+      assert record.name == "notes.md"
+    end
+
+    test "writes into a subdirectory of the volume", %{root: root} do
+      File.mkdir_p!(Path.join(root, "manuals"))
+
+      assert {:ok, %{record: record}} =
+               Ingestion.persist_record(%{
+                 "name" => "nested.md",
+                 "path" => "#{@volume}/manuals",
+                 "content" => "# nested"
+               })
+
+      assert File.read!(Path.join([root, "manuals", "nested.md"])) == "# nested"
+      assert record.path == "manuals/nested.md"
+    end
+
+    test "deduplicates a name that is already taken", %{root: root} do
+      {:ok, _first} =
+        Ingestion.persist_record(%{"name" => "hello.md", "path" => @volume, "content" => "one"})
+
+      assert {:ok, %{record: record}} =
+               Ingestion.persist_record(%{
+                 "name" => "hello.md",
+                 "path" => @volume,
+                 "content" => "two"
+               })
+
+      assert record.name == "hello(1).md"
+      assert File.read!(Path.join(root, "hello.md")) == "one"
+      assert File.read!(Path.join(root, "hello(1).md")) == "two"
+      assert Document.get_by_source("#{@volume}/hello(1).md")
+    end
+
+    test "writes raw bytes for base64 content, not the encoded string", %{root: root} do
+      bytes = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+
+      assert {:ok, %{record: record}} =
+               Ingestion.persist_record(%{
+                 "name" => "logo.png",
+                 "path" => @volume,
+                 "content" => Base.encode64(bytes),
+                 "encoding" => "base64"
+               })
+
+      assert File.read!(Path.join(root, "logo.png")) == bytes
+      assert record.mime_type == "image/png"
+    end
+
+    test "refuses malformed base64" do
+      assert {:error, :invalid_base64} =
+               Ingestion.persist_record(%{
+                 "name" => "logo.png",
+                 "path" => @volume,
+                 "content" => "not base64!!",
+                 "encoding" => "base64"
+               })
+    end
+
+    test "refuses a path that names no mounted volume" do
+      assert {:error, :volume_required} =
+               Ingestion.persist_record(%{
+                 "name" => "notes.md",
+                 "path" => "somewhere",
+                 "content" => "hi"
+               })
+    end
+
+    test "refuses a request with no path" do
+      assert {:error, :path_required} =
+               Ingestion.persist_record(%{"name" => "notes.md", "content" => "hi"})
+    end
+
+    test "refuses a request with no name" do
+      assert {:error, :name_required} =
+               Ingestion.persist_record(%{"path" => @volume, "content" => "hi"})
+    end
+
+    test "treats a blank name as absent" do
+      assert {:error, :name_required} =
+               Ingestion.persist_record(%{"name" => "", "path" => @volume, "content" => "hi"})
+    end
+
+    test "defaults missing content to an empty file", %{root: root} do
+      assert {:ok, _} = Ingestion.persist_record(%{"name" => "empty.md", "path" => @volume})
+
+      assert File.read!(Path.join(root, "empty.md")) == ""
+    end
+
+    test "creating does not ingest — no chunks are produced" do
+      assert {:ok, %{record: record}} =
+               Ingestion.persist_record(%{
+                 "name" => "notes.md",
+                 "path" => @volume,
+                 "content" => "# notes"
+               })
+
+      document_id = String.to_integer(record.id)
+      assert Repo.aggregate(from(c in Chunk, where: c.document_id == ^document_id), :count) == 0
+    end
+
+    test "accepts atom-keyed requests", %{root: root} do
+      assert {:ok, %{record: record}} =
+               Ingestion.persist_record(%{name: "atom.md", path: @volume, content: "# atom"})
+
+      assert record.name == "atom.md"
+      assert File.read!(Path.join(root, "atom.md")) == "# atom"
+    end
+  end
+
+  # ── update_record/1 ─────────────────────────────────────────────────────────
+
+  describe "update_record/1" do
+    test "replaces the bytes in place, leaving the path alone", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "old")
+
+      assert {:ok, %{status: "updated", record: record}} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "content" => "new"
+               })
+
+      assert File.read!(Path.join(root, "guide.md")) == "new"
+      refute File.exists?(Path.join(root, "guide (1).md"))
+      assert record.id == to_string(document.id)
+      assert record.path == "guide.md"
+    end
+
+    test "renames the file, moves the source, and keeps the id", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "content")
+
+      assert {:ok, %{record: record}} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "name" => "renamed.md"
+               })
+
+      refute File.exists?(Path.join(root, "guide.md"))
+      assert File.read!(Path.join(root, "renamed.md")) == "content"
+      assert record.id == to_string(document.id)
+      assert record.name == "renamed.md"
+      assert Repo.get!(Document, document.id).source == "#{@volume}/renamed.md"
+    end
+
+    test "moves the file to another directory in the same volume", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "content")
+      File.mkdir_p!(Path.join(root, "manuals"))
+
+      assert {:ok, %{record: record}} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "path" => "#{@volume}/manuals"
+               })
+
+      refute File.exists?(Path.join(root, "guide.md"))
+      assert File.read!(Path.join([root, "manuals", "guide.md"])) == "content"
+      assert record.id == to_string(document.id)
+      assert record.path == "manuals/guide.md"
+      assert Repo.get!(Document, document.id).source == "#{@volume}/manuals/guide.md"
+    end
+
+    test "writes the new bytes under the new name at the new path", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "old")
+      File.mkdir_p!(Path.join(root, "manuals"))
+
+      assert {:ok, %{record: record}} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "name" => "renamed.md",
+                 "path" => "#{@volume}/manuals",
+                 "content" => "new"
+               })
+
+      refute File.exists?(Path.join(root, "guide.md"))
+      assert File.read!(Path.join([root, "manuals", "renamed.md"])) == "new"
+      assert record.path == "manuals/renamed.md"
+    end
+
+    test "an absent content key does not truncate the file", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "keep me")
+
+      assert {:ok, _} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "name" => "renamed.md"
+               })
+
+      assert File.read!(Path.join(root, "renamed.md")) == "keep me"
+    end
+
+    test "decodes base64 content before writing", %{root: root} do
+      document = seed_file(root, @volume, "logo.png", "old")
+      bytes = <<0x89, 0x50, 0x4E, 0x47>>
+
+      assert {:ok, _} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "content" => Base.encode64(bytes),
+                 "encoding" => "base64"
+               })
+
+      assert File.read!(Path.join(root, "logo.png")) == bytes
+    end
+
+    test "refuses a move across volumes", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "content")
+
+      assert {:error, :cross_volume_move_unsupported} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "path" => @other_volume
+               })
+
+      assert File.exists?(Path.join(root, "guide.md"))
+    end
+
+    test "refuses a path that names no mounted volume", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "content")
+
+      assert {:error, :volume_required} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "path" => "somewhere"
+               })
+    end
+
+    test "refuses an unknown id" do
+      assert {:error, :not_found} = Ingestion.update_record(%{"file_id" => "99999999"})
+    end
+
+    test "refuses a request with no file_id" do
+      assert {:error, :file_id_required} = Ingestion.update_record(%{"name" => "renamed.md"})
+    end
+
+    test "a rename with no other change is a no-op move", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "content")
+
+      assert {:ok, %{record: record}} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "name" => "guide.md"
+               })
+
+      assert record.path == "guide.md"
+      assert File.read!(Path.join(root, "guide.md")) == "content"
+    end
+
+    test "a linked sidecar follows the rename", %{root: root} do
+      sidecar_source = "#{@volume}/deck.md"
+
+      document =
+        seed_file(root, @volume, "deck.pdf", "%PDF", %{
+          metadata: %{"sidecar_source" => sidecar_source}
+        })
+
+      _sidecar =
+        seed_file(root, @volume, "deck.md", "# deck", %{
+          metadata: %{"source_document_source" => "#{@volume}/deck.pdf"}
+        })
+
+      assert {:ok, _} =
+               Ingestion.update_record(%{
+                 "file_id" => to_string(document.id),
+                 "name" => "slides.pdf"
+               })
+
+      assert File.exists?(Path.join(root, "slides.pdf"))
+      assert File.exists?(Path.join(root, "slides.md"))
+      refute File.exists?(Path.join(root, "deck.md"))
+      assert Document.get_by_source("#{@volume}/slides.md")
+      assert Repo.get!(Document, document.id).metadata["sidecar_source"] == "#{@volume}/slides.md"
+    end
+  end
+
+  # ── delete_record/1 ─────────────────────────────────────────────────────────
+
+  describe "delete_record/1" do
+    test "removes the row, the file, and the chunks", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      %Chunk{}
+      |> Chunk.changeset(%{
+        document_id: document.id,
+        content: "chunk",
+        chunk_index: 0,
+        source: document.source
+      })
+      |> Repo.insert!()
+
+      assert {:ok, %{status: "deleted", record: %Record{} = record}} =
+               Ingestion.delete_record(to_string(document.id))
+
+      assert record.id == to_string(document.id)
+      refute File.exists?(Path.join(root, "guide.md"))
+      assert Repo.get(Document, document.id) == nil
+
+      assert Repo.aggregate(from(c in Chunk, where: c.document_id == ^document.id), :count) == 0
+    end
+
+    test "captures the record before the row disappears", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %{record: record}} = Ingestion.delete_record(to_string(document.id))
+      assert record.name == "guide.md"
+      assert record.kind == :file
+    end
+
+    test "refuses an unknown id" do
+      assert {:error, :not_found} = Ingestion.delete_record("99999999")
+    end
+
+    test "accepts an integer id", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %{status: "deleted"}} = Ingestion.delete_record(document.id)
+    end
+
+    test "on a stale row the row still goes but the call reports :enoent" do
+      # Pinned as-is: the row is removed before the filesystem delete is attempted, so a row
+      # whose file is already gone reports the filesystem error while still being cleaned up.
+      document = seed_stale_row(@volume, "deleted.md")
+
+      assert {:error, :enoent} = Ingestion.delete_record(to_string(document.id))
+      assert Repo.get(Document, document.id) == nil
+    end
+  end
+
+  # ── materialize_record/1 ────────────────────────────────────────────────────
+
+  describe "materialize_record/1" do
+    test "returns markdown as a plain string with no encoding attribute", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %{record: record}} =
+               Ingestion.materialize_record(%{"file_id" => to_string(document.id)})
+
+      assert record.content == "# guide"
+      refute Map.has_key?(record.attributes, "encoding")
+      assert record.mime_type == "text/markdown"
+    end
+
+    test "returns a pdf base64-encoded, decoding back to the original bytes", %{root: root} do
+      bytes = <<0x25, 0x50, 0x44, 0x46, 0x00, 0xFF>>
+      document = seed_file(root, @volume, "deck.pdf", bytes)
+
+      assert {:ok, %{record: record}} =
+               Ingestion.materialize_record(%{"file_id" => to_string(document.id)})
+
+      assert record.attributes["encoding"] == "base64"
+      assert Base.decode64!(record.content) == bytes
+    end
+
+    test "an explicit base64 encoding forces encoding for a text file", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %{record: record}} =
+               Ingestion.materialize_record(%{
+                 "file_id" => to_string(document.id),
+                 "encoding" => "base64"
+               })
+
+      assert record.attributes["encoding"] == "base64"
+      assert Base.decode64!(record.content) == "# guide"
+    end
+
+    test "a markdown file holding invalid UTF-8 falls back to base64", %{root: root} do
+      bytes = <<0xFF, 0xFE, 0x00, 0x41>>
+      document = seed_file(root, @volume, "broken.md", bytes)
+
+      assert {:ok, %{record: record}} =
+               Ingestion.materialize_record(%{"file_id" => to_string(document.id)})
+
+      assert record.attributes["encoding"] == "base64"
+      assert Base.decode64!(record.content) == bytes
+    end
+
+    test "returns other textual types as plain strings", %{root: root} do
+      for {name, content} <- [
+            {"data.json", ~s({"a":1})},
+            {"data.xml", "<a>1</a>"},
+            {"data.csv", "a,b\n1,2"},
+            {"notes.txt", "plain"}
+          ] do
+        document = seed_file(root, @volume, name, content)
+
+        assert {:ok, %{record: record}} =
+                 Ingestion.materialize_record(%{"file_id" => to_string(document.id)})
+
+        assert record.content == content, "expected #{name} to come back as text"
+        refute Map.has_key?(record.attributes, "encoding")
+      end
+    end
+
+    test "refuses an unknown id" do
+      assert {:error, :not_found} = Ingestion.materialize_record(%{"file_id" => "99999999"})
+    end
+
+    test "refuses a request with no file_id" do
+      assert {:error, :file_id_required} = Ingestion.materialize_record(%{})
+    end
+
+    test "reports :enoent for a stale row" do
+      document = seed_stale_row(@volume, "deleted.md")
+
+      assert {:error, :enoent} =
+               Ingestion.materialize_record(%{"file_id" => to_string(document.id)})
+    end
+
+    test "a non-numeric file_id raises rather than answering :not_found" do
+      # Pinned: `file_id` reaches `Document.get/1` verbatim from agent tools, and Ecto casts
+      # it. Guarding this is a decision, not a bug fix — the test says which way it is today.
+      assert_raise Ecto.Query.CastError, fn ->
+        Ingestion.materialize_record(%{"file_id" => "disk:#{@volume}:guide.md"})
+      end
+    end
+  end
+
+  # ── search_records/1 ────────────────────────────────────────────────────────
+
+  describe "search_records/1" do
+    test "matches on the document source", %{root: root} do
+      document = seed_file(root, @volume, "quarterly-report.md", "# report")
+      _other = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: records}} =
+               Ingestion.search_records(%{"query" => "quarterly"})
+
+      assert Enum.map(records, & &1.id) == [to_string(document.id)]
+    end
+
+    test "matches on the document title", %{root: root} do
+      document = seed_file(root, @volume, "a.md", "# a", %{title: "Annual Budget"})
+      _other = seed_file(root, @volume, "b.md", "# b", %{title: "Something Else"})
+
+      assert {:ok, %RecordPage{records: records}} =
+               Ingestion.search_records(%{"query" => "Budget"})
+
+      assert Enum.map(records, & &1.id) == [to_string(document.id)]
+    end
+
+    test "matches case-insensitively", %{root: root} do
+      document = seed_file(root, @volume, "Quarterly.md", "# report")
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               Ingestion.search_records(%{"query" => "QUARTERLY"})
+
+      assert record.id == to_string(document.id)
+    end
+
+    test "excludes chunk and sidecar rows", %{root: root} do
+      document = seed_file(root, @volume, "deck.pdf", "%PDF")
+
+      _sidecar =
+        seed_file(root, @volume, "deck.md", "# deck", %{
+          metadata: %{"source_document_source" => "#{@volume}/deck.pdf"}
+        })
+
+      assert {:ok, %RecordPage{records: records}} = Ingestion.search_records(%{"query" => "deck"})
+
+      assert Enum.map(records, & &1.id) == [to_string(document.id)]
+    end
+
+    test "refuses a request with no query" do
+      assert {:error, :query_required} = Ingestion.search_records(%{})
+      assert {:error, :query_required} = Ingestion.search_records(%{"query" => ""})
+    end
+
+    test "answers with an empty page when nothing matches" do
+      assert {:ok, %RecordPage{records: [], stats: %{scanned: 0, returned: 0}}} =
+               Ingestion.search_records(%{"query" => "nothing-matches-this"})
+    end
+
+    test "caps the page at 100 rows", %{root: root} do
+      Enum.each(1..105, fn index ->
+        seed_file(root, @volume, "capped-#{index}.md", "# #{index}")
+      end)
+
+      assert {:ok, %RecordPage{records: records, stats: %{scanned: 100}}} =
+               Ingestion.search_records(%{"query" => "capped-"})
+
+      assert length(records) == 100
+    end
+  end
+
+  # ── list_record_permissions/1 ───────────────────────────────────────────────
+
+  describe "list_record_permissions/1" do
+    test "reports a person grant with the person's full name", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+      person = create_person()
+      {:ok, _} = Ingestion.set_document_permission(document.id, :person, person.id, ["read"])
+
+      assert {:ok, %RecordPage{resource_type: :permission, records: [record]}} =
+               Ingestion.list_record_permissions(to_string(document.id))
+
+      assert record.kind == :permission
+      assert record.name == person.full_name
+
+      assert record.attributes == %{
+               "type" => "person",
+               "target_id" => to_string(person.id),
+               "access_rights" => ["read"]
+             }
+    end
+
+    # Two branches of `permission_target/1` are unreachable through the schema and are left
+    # uncovered on purpose:
+    #
+    #   * the `full_name || email` fallback — `people.full_name` is NOT NULL and required on
+    #     create, so a preloaded person always has a name;
+    #   * the `{"unknown", nil, nil}` clause — a `check_person_or_team_present` check
+    #     constraint refuses a grant naming neither, so no such row can exist.
+    #
+    # Both stay as guards. Covering them would mean asserting against states the database
+    # forbids.
+
+    test "reports grants for a document with several kinds at once", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide", %{tags: ["public"]})
+      person = create_person()
+      team = create_team()
+      {:ok, _} = Ingestion.set_document_permission(document.id, :person, person.id, ["read"])
+      {:ok, _} = Ingestion.set_document_permission(document.id, :team, team.id, ["read"])
+
+      assert {:ok, %RecordPage{records: records, stats: %{scanned: 3, returned: 3}}} =
+               Ingestion.list_record_permissions(to_string(document.id))
+
+      assert Enum.sort(Enum.map(records, & &1.attributes["type"])) == ["person", "public", "team"]
+    end
+
+    test "reports a team grant", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+      team = create_team()
+      {:ok, _} = Ingestion.set_document_permission(document.id, :team, team.id, ["read", "write"])
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               Ingestion.list_record_permissions(to_string(document.id))
+
+      assert record.name == team.name
+
+      assert record.attributes == %{
+               "type" => "team",
+               "target_id" => to_string(team.id),
+               "access_rights" => ["read", "write"]
+             }
+    end
+
+    test "reports the public tag as a synthetic grant", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide", %{tags: ["public"]})
+
+      assert {:ok, %RecordPage{records: [record]}} =
+               Ingestion.list_record_permissions(to_string(document.id))
+
+      assert record.id == "public:#{document.id}"
+      assert record.name == "Public"
+
+      assert record.attributes == %{
+               "type" => "public",
+               "target_id" => nil,
+               "access_rights" => ["read"]
+             }
+    end
+
+    test "reports the public tag alongside an explicit grant", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide", %{tags: ["public"]})
+      person = create_person()
+      {:ok, _} = Ingestion.set_document_permission(document.id, :person, person.id, ["read"])
+
+      assert {:ok, %RecordPage{records: records, stats: %{scanned: 2, returned: 2}}} =
+               Ingestion.list_record_permissions(to_string(document.id))
+
+      assert Enum.map(records, & &1.attributes["type"]) == ["public", "person"]
+    end
+
+    test "answers with an empty page when nobody has access", %{root: root} do
+      document = seed_file(root, @volume, "guide.md", "# guide")
+
+      assert {:ok, %RecordPage{records: [], stats: %{scanned: 0, returned: 0}}} =
+               Ingestion.list_record_permissions(to_string(document.id))
+    end
+
+    test "refuses an unknown id" do
+      assert {:error, :not_found} = Ingestion.list_record_permissions("99999999")
+    end
+
+    test "answers for a stale row, since permissions do not need the file" do
+      document = seed_stale_row(@volume, "deleted.md")
+
+      assert {:ok, %RecordPage{records: []}} =
+               Ingestion.list_record_permissions(to_string(document.id))
+    end
+  end
+
+  # ── volume_stats/0 ──────────────────────────────────────────────────────────
+
+  describe "volume_stats/0" do
+    test "counts files, excluding chunk and sidecar rows", %{root: root} do
+      _document = seed_file(root, @volume, "deck.pdf", "%PDF")
+
+      _sidecar =
+        seed_file(root, @volume, "deck.md", "# deck", %{
+          metadata: %{"source_document_source" => "#{@volume}/deck.pdf"}
+        })
+
+      assert {:ok, %{files_count: 1}} = Ingestion.volume_stats()
+    end
+
+    test "counts directories holding at least one document", %{root: root} do
+      seed_file(root, @volume, "manuals/one.md", "# one")
+      seed_file(root, @volume, "manuals/two.md", "# two")
+      seed_file(root, @volume, "reports/three.md", "# three")
+
+      assert {:ok, %{folders_count: 2}} = Ingestion.volume_stats()
+    end
+
+    test "counts distinct principals across documents", %{root: root} do
+      one = seed_file(root, @volume, "one.md", "# one")
+      two = seed_file(root, @volume, "two.md", "# two")
+      person = create_person()
+      team = create_team()
+
+      {:ok, _} = Ingestion.set_document_permission(one.id, :person, person.id, ["read"])
+      {:ok, _} = Ingestion.set_document_permission(two.id, :person, person.id, ["read"])
+      {:ok, _} = Ingestion.set_document_permission(two.id, :team, team.id, ["read"])
+
+      assert {:ok, %{principals_count: 2}} = Ingestion.volume_stats()
+    end
+
+    test "a public tag adds no principal", %{root: root} do
+      seed_file(root, @volume, "one.md", "# one", %{tags: ["public"]})
+
+      assert {:ok, %{principals_count: 0}} = Ingestion.volume_stats()
+    end
+
+    test "reports the mounted volume names, sorted" do
+      assert {:ok, %{root_folders: [@volume, @other_volume]}} = Ingestion.volume_stats()
+    end
+  end
+end

--- a/test/zaq/ingestion/ingestion_disk_records_test.exs
+++ b/test/zaq/ingestion/ingestion_disk_records_test.exs
@@ -11,6 +11,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
   @volume "archives"
   @other_volume "vault"
+  @embedding_dimension 768
 
   setup do
     unique = System.unique_integer([:positive])
@@ -63,6 +64,14 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       Document.create(%{source: Path.join(volume, relative_path), content: "orphaned"})
 
     document
+  end
+
+  # `chunks` is not left behind by migrations: `20260326000000_reset_ingestion` drops it, and
+  # `Chunk.create_table/1` provisions it at runtime once an embedding dimension is known. A
+  # freshly migrated database has no such table, so a test asserting on chunks has to create
+  # it rather than assume one. The DDL rolls back with the sandbox transaction.
+  defp create_chunks_table do
+    Chunk.create_table(@embedding_dimension)
   end
 
   defp create_person do
@@ -322,6 +331,8 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     end
 
     test "creating does not ingest — no chunks are produced" do
+      create_chunks_table()
+
       assert {:ok, %{entry: entry}} =
                Ingestion.persist_record(%{
                  "name" => "notes.md",
@@ -510,6 +521,8 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
   describe "delete_record/1" do
     test "removes the row, the file, and the chunks", %{root: root} do
+      create_chunks_table()
+
       document = seed_file(root, @volume, "guide.md", "# guide")
 
       %Chunk{}

--- a/test/zaq/ingestion/ingestion_disk_records_test.exs
+++ b/test/zaq/ingestion/ingestion_disk_records_test.exs
@@ -4,8 +4,6 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
   use Zaq.DataCase, async: false
 
   alias Zaq.Accounts.People
-  alias Zaq.Contracts.Record
-  alias Zaq.Contracts.RecordPage
   alias Zaq.Ingestion
   alias Zaq.Ingestion.Chunk
   alias Zaq.Ingestion.Document
@@ -84,57 +82,40 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     team
   end
 
-  # ── describe_records/1 ──────────────────────────────────────────────────────
+  # ── describe_record/1 ───────────────────────────────────────────────────────
 
-  describe "describe_records/1" do
-    test "answers with one record per known document id", %{root: root} do
+  describe "describe_record/1" do
+    test "answers with the entry for a known document id", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: [record], stats: stats}} =
-               Ingestion.describe_records([to_string(document.id)])
+      assert {:ok, entry} = Ingestion.describe_record(to_string(document.id))
 
-      assert record.id == to_string(document.id)
-      assert record.name == "guide.md"
-      assert record.kind == :file
-      assert stats == %{scanned: 1, returned: 1}
+      assert entry.id == to_string(document.id)
+      assert entry.name == "guide.md"
+      assert entry.type == :file
+      assert entry.document_id == document.id
     end
 
-    test "drops unknown ids rather than failing the page", %{root: root} do
+    test "answers :not_found for an unknown id", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "# guide")
-      missing = to_string(document.id + 9_999)
 
-      assert {:ok, %RecordPage{records: records, stats: stats}} =
-               Ingestion.describe_records([to_string(document.id), missing])
-
-      assert Enum.map(records, & &1.id) == [to_string(document.id)]
-      assert stats == %{scanned: 2, returned: 1}
+      assert {:error, :not_found} = Ingestion.describe_record(to_string(document.id + 9_999))
     end
 
-    test "drops a stale row whose file is gone from the volume", %{root: root} do
-      live = seed_file(root, @volume, "guide.md", "# guide")
+    test "reports the filesystem error for a stale row whose file is gone" do
       stale = seed_stale_row(@volume, "deleted.md")
 
-      assert {:ok, %RecordPage{records: records, stats: stats}} =
-               Ingestion.describe_records([to_string(live.id), to_string(stale.id)])
-
-      assert Enum.map(records, & &1.id) == [to_string(live.id)]
-      assert stats == %{scanned: 2, returned: 1}
+      assert {:error, :enoent} = Ingestion.describe_record(to_string(stale.id))
     end
 
-    test "returns an empty page for no ids" do
-      assert {:ok, %RecordPage{records: [], stats: %{scanned: 0, returned: 0}}} =
-               Ingestion.describe_records([])
-    end
-
-    test "records travel unmaterialized with an event that names the same id", %{root: root} do
+    test "names the entry by its document row, not its volume path", %{root: root} do
+      # The id the caller holds is the document id; the volume-path id `from_path/2` derives
+      # for browsing is only for files with no row.
       document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: [record]}} =
-               Ingestion.describe_records([to_string(document.id)])
-
-      assert record.content == nil
-      assert record.materializing_event.request == %{file_id: to_string(document.id)}
-      assert record.materializing_event.opts[:action] == :materialize_record
+      assert {:ok, entry} = Ingestion.describe_record(to_string(document.id))
+      assert entry.id == to_string(document.id)
+      refute entry.id == "disk:#{@volume}:guide.md"
     end
   end
 
@@ -145,9 +126,9 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       archived = seed_file(root, @volume, "guide.md", "# guide")
       vaulted = seed_file(other, @other_volume, "secret.md", "# secret")
 
-      assert {:ok, %RecordPage{records: records}} = Ingestion.list_records(%{})
+      assert {:ok, %{entries: entries}} = Ingestion.list_records(%{})
 
-      ids = Enum.map(records, & &1.id)
+      ids = Enum.map(entries, & &1.id)
       assert to_string(archived.id) in ids
       assert to_string(vaulted.id) in ids
     end
@@ -155,27 +136,26 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     test "treats an empty parent filter as no filter", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: records}} =
+      assert {:ok, %{entries: entries}} =
                Ingestion.list_records(%{"filters" => %{"parent" => ""}})
 
-      assert to_string(document.id) in Enum.map(records, & &1.id)
+      assert to_string(document.id) in Enum.map(entries, & &1.id)
     end
 
     test "drops stale rows and reports the gap in stats", %{root: root} do
       _live = seed_file(root, @volume, "guide.md", "# guide")
       _stale = seed_stale_row(@volume, "deleted.md")
 
-      assert {:ok, %RecordPage{stats: %{scanned: scanned, returned: returned}}} =
-               Ingestion.list_records(%{})
+      assert {:ok, %{entries: entries, scanned: scanned}} = Ingestion.list_records(%{})
 
-      assert scanned == returned + 1
+      assert scanned == length(entries) + 1
     end
 
     test "defaults params to an empty map", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: records}} = Ingestion.list_records()
-      assert to_string(document.id) in Enum.map(records, & &1.id)
+      assert {:ok, %{entries: entries}} = Ingestion.list_records()
+      assert to_string(document.id) in Enum.map(entries, & &1.id)
     end
   end
 
@@ -184,43 +164,43 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       document = seed_file(root, @volume, "guide.md", "# guide")
       File.mkdir_p!(Path.join(root, "manuals"))
 
-      assert {:ok, %RecordPage{records: records}} =
+      assert {:ok, %{entries: entries}} =
                Ingestion.list_records(%{"filters" => %{"parent" => @volume}})
 
-      by_name = Map.new(records, &{&1.name, &1})
+      by_name = Map.new(entries, &{&1.name, &1})
       assert by_name["guide.md"].id == to_string(document.id)
-      assert by_name["manuals"].kind == :folder
+      assert by_name["manuals"].type == :directory
     end
 
     test "a subdirectory lists that directory", %{root: root} do
       document = seed_file(root, @volume, "manuals/nested.md", "# nested")
 
-      assert {:ok, %RecordPage{records: [record], stats: %{scanned: 1, returned: 1}}} =
+      assert {:ok, %{entries: [entry], scanned: 1}} =
                Ingestion.list_records(%{"filters" => %{"parent" => "#{@volume}/manuals"}})
 
-      assert record.id == to_string(document.id)
-      assert record.path == "manuals/nested.md"
+      assert entry.id == to_string(document.id)
+      assert entry.relative_path == "manuals/nested.md"
     end
 
     test "returns folders alongside files, with folders carrying a path id", %{root: root} do
       File.mkdir_p!(Path.join(root, "manuals"))
       _document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: records}} =
+      assert {:ok, %{entries: entries}} =
                Ingestion.list_records(%{"filters" => %{"parent" => @volume}})
 
-      folder = Enum.find(records, &(&1.kind == :folder))
+      folder = Enum.find(entries, &(&1.type == :directory))
       assert folder.id == "disk:#{@volume}:manuals"
-      assert folder.materializing_event == nil
+      assert folder.document_id == nil
     end
 
     test "a file with no document row carries the path-form id", %{root: root} do
       File.write!(Path.join(root, "unindexed.md"), "# unindexed")
 
-      assert {:ok, %RecordPage{records: [record]}} =
+      assert {:ok, %{entries: [entry]}} =
                Ingestion.list_records(%{"filters" => %{"parent" => @volume}})
 
-      assert record.id == "disk:#{@volume}:unindexed.md"
+      assert entry.id == "disk:#{@volume}:unindexed.md"
     end
 
     test "an unknown volume answers with FileExplorer's error rather than crashing" do
@@ -231,18 +211,18 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     test "accepts atom-keyed filters", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: records}} =
+      assert {:ok, %{entries: entries}} =
                Ingestion.list_records(%{filters: %{parent: @volume}})
 
-      assert to_string(document.id) in Enum.map(records, & &1.id)
+      assert to_string(document.id) in Enum.map(entries, & &1.id)
     end
   end
 
   # ── persist_record/1 ────────────────────────────────────────────────────────
 
   describe "persist_record/1" do
-    test "writes the file, registers the row, and names the record by the row", %{root: root} do
-      assert {:ok, %{status: "created", record: %Record{} = record}} =
+    test "writes the file, registers the row, and names the entry by the row", %{root: root} do
+      assert {:ok, %{status: "created", entry: entry}} =
                Ingestion.persist_record(%{
                  "name" => "notes.md",
                  "path" => @volume,
@@ -251,14 +231,14 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
       assert File.read!(Path.join(root, "notes.md")) == "# notes"
       document = Document.get_by_source("#{@volume}/notes.md")
-      assert record.id == to_string(document.id)
-      assert record.name == "notes.md"
+      assert entry.id == to_string(document.id)
+      assert entry.name == "notes.md"
     end
 
     test "writes into a subdirectory of the volume", %{root: root} do
       File.mkdir_p!(Path.join(root, "manuals"))
 
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.persist_record(%{
                  "name" => "nested.md",
                  "path" => "#{@volume}/manuals",
@@ -266,21 +246,21 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
                })
 
       assert File.read!(Path.join([root, "manuals", "nested.md"])) == "# nested"
-      assert record.path == "manuals/nested.md"
+      assert entry.relative_path == "manuals/nested.md"
     end
 
     test "deduplicates a name that is already taken", %{root: root} do
       {:ok, _first} =
         Ingestion.persist_record(%{"name" => "hello.md", "path" => @volume, "content" => "one"})
 
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.persist_record(%{
                  "name" => "hello.md",
                  "path" => @volume,
                  "content" => "two"
                })
 
-      assert record.name == "hello(1).md"
+      assert entry.name == "hello(1).md"
       assert File.read!(Path.join(root, "hello.md")) == "one"
       assert File.read!(Path.join(root, "hello(1).md")) == "two"
       assert Document.get_by_source("#{@volume}/hello(1).md")
@@ -289,7 +269,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     test "writes raw bytes for base64 content, not the encoded string", %{root: root} do
       bytes = <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
 
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.persist_record(%{
                  "name" => "logo.png",
                  "path" => @volume,
@@ -298,7 +278,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
                })
 
       assert File.read!(Path.join(root, "logo.png")) == bytes
-      assert record.mime_type == "image/png"
+      assert entry.name == "logo.png"
     end
 
     test "refuses malformed base64" do
@@ -342,22 +322,22 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     end
 
     test "creating does not ingest — no chunks are produced" do
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.persist_record(%{
                  "name" => "notes.md",
                  "path" => @volume,
                  "content" => "# notes"
                })
 
-      document_id = String.to_integer(record.id)
+      document_id = String.to_integer(entry.id)
       assert Repo.aggregate(from(c in Chunk, where: c.document_id == ^document_id), :count) == 0
     end
 
     test "accepts atom-keyed requests", %{root: root} do
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.persist_record(%{name: "atom.md", path: @volume, content: "# atom"})
 
-      assert record.name == "atom.md"
+      assert entry.name == "atom.md"
       assert File.read!(Path.join(root, "atom.md")) == "# atom"
     end
   end
@@ -368,7 +348,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     test "replaces the bytes in place, leaving the path alone", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "old")
 
-      assert {:ok, %{status: "updated", record: record}} =
+      assert {:ok, %{status: "updated", entry: entry}} =
                Ingestion.update_record(%{
                  "file_id" => to_string(document.id),
                  "content" => "new"
@@ -376,14 +356,14 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
       assert File.read!(Path.join(root, "guide.md")) == "new"
       refute File.exists?(Path.join(root, "guide (1).md"))
-      assert record.id == to_string(document.id)
-      assert record.path == "guide.md"
+      assert entry.id == to_string(document.id)
+      assert entry.relative_path == "guide.md"
     end
 
     test "renames the file, moves the source, and keeps the id", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "content")
 
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.update_record(%{
                  "file_id" => to_string(document.id),
                  "name" => "renamed.md"
@@ -391,8 +371,8 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
       refute File.exists?(Path.join(root, "guide.md"))
       assert File.read!(Path.join(root, "renamed.md")) == "content"
-      assert record.id == to_string(document.id)
-      assert record.name == "renamed.md"
+      assert entry.id == to_string(document.id)
+      assert entry.name == "renamed.md"
       assert Repo.get!(Document, document.id).source == "#{@volume}/renamed.md"
     end
 
@@ -400,7 +380,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       document = seed_file(root, @volume, "guide.md", "content")
       File.mkdir_p!(Path.join(root, "manuals"))
 
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.update_record(%{
                  "file_id" => to_string(document.id),
                  "path" => "#{@volume}/manuals"
@@ -408,8 +388,8 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
       refute File.exists?(Path.join(root, "guide.md"))
       assert File.read!(Path.join([root, "manuals", "guide.md"])) == "content"
-      assert record.id == to_string(document.id)
-      assert record.path == "manuals/guide.md"
+      assert entry.id == to_string(document.id)
+      assert entry.relative_path == "manuals/guide.md"
       assert Repo.get!(Document, document.id).source == "#{@volume}/manuals/guide.md"
     end
 
@@ -417,7 +397,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       document = seed_file(root, @volume, "guide.md", "old")
       File.mkdir_p!(Path.join(root, "manuals"))
 
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.update_record(%{
                  "file_id" => to_string(document.id),
                  "name" => "renamed.md",
@@ -427,7 +407,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
       refute File.exists?(Path.join(root, "guide.md"))
       assert File.read!(Path.join([root, "manuals", "renamed.md"])) == "new"
-      assert record.path == "manuals/renamed.md"
+      assert entry.relative_path == "manuals/renamed.md"
     end
 
     test "an absent content key does not truncate the file", %{root: root} do
@@ -489,13 +469,13 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     test "a rename with no other change is a no-op move", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "content")
 
-      assert {:ok, %{record: record}} =
+      assert {:ok, %{entry: entry}} =
                Ingestion.update_record(%{
                  "file_id" => to_string(document.id),
                  "name" => "guide.md"
                })
 
-      assert record.path == "guide.md"
+      assert entry.relative_path == "guide.md"
       assert File.read!(Path.join(root, "guide.md")) == "content"
     end
 
@@ -541,22 +521,21 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       })
       |> Repo.insert!()
 
-      assert {:ok, %{status: "deleted", record: %Record{} = record}} =
-               Ingestion.delete_record(to_string(document.id))
+      assert {:ok, %{status: "deleted"}} = Ingestion.delete_record(to_string(document.id))
 
-      assert record.id == to_string(document.id)
       refute File.exists?(Path.join(root, "guide.md"))
       assert Repo.get(Document, document.id) == nil
 
       assert Repo.aggregate(from(c in Chunk, where: c.document_id == ^document.id), :count) == 0
     end
 
-    test "captures the record before the row disappears", %{root: root} do
+    test "answers with the status alone, describing nothing that is gone", %{root: root} do
+      # The file is off the volume by the time this returns, so there is nothing left to
+      # read — the same answer `JidoConnectBridge.delete_file/2` gives.
       document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %{record: record}} = Ingestion.delete_record(to_string(document.id))
-      assert record.name == "guide.md"
-      assert record.kind == :file
+      assert {:ok, result} = Ingestion.delete_record(to_string(document.id))
+      assert result == %{status: "deleted"}
     end
 
     test "refuses an unknown id" do
@@ -676,29 +655,29 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       document = seed_file(root, @volume, "quarterly-report.md", "# report")
       _other = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: records}} =
+      assert {:ok, %{entries: entries}} =
                Ingestion.search_records(%{"query" => "quarterly"})
 
-      assert Enum.map(records, & &1.id) == [to_string(document.id)]
+      assert Enum.map(entries, & &1.id) == [to_string(document.id)]
     end
 
     test "matches on the document title", %{root: root} do
       document = seed_file(root, @volume, "a.md", "# a", %{title: "Annual Budget"})
       _other = seed_file(root, @volume, "b.md", "# b", %{title: "Something Else"})
 
-      assert {:ok, %RecordPage{records: records}} =
+      assert {:ok, %{entries: entries}} =
                Ingestion.search_records(%{"query" => "Budget"})
 
-      assert Enum.map(records, & &1.id) == [to_string(document.id)]
+      assert Enum.map(entries, & &1.id) == [to_string(document.id)]
     end
 
     test "matches case-insensitively", %{root: root} do
       document = seed_file(root, @volume, "Quarterly.md", "# report")
 
-      assert {:ok, %RecordPage{records: [record]}} =
+      assert {:ok, %{entries: [entry]}} =
                Ingestion.search_records(%{"query" => "QUARTERLY"})
 
-      assert record.id == to_string(document.id)
+      assert entry.id == to_string(document.id)
     end
 
     test "excludes chunk and sidecar rows", %{root: root} do
@@ -709,9 +688,9 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
           metadata: %{"source_document_source" => "#{@volume}/deck.pdf"}
         })
 
-      assert {:ok, %RecordPage{records: records}} = Ingestion.search_records(%{"query" => "deck"})
+      assert {:ok, %{entries: entries}} = Ingestion.search_records(%{"query" => "deck"})
 
-      assert Enum.map(records, & &1.id) == [to_string(document.id)]
+      assert Enum.map(entries, & &1.id) == [to_string(document.id)]
     end
 
     test "refuses a request with no query" do
@@ -720,7 +699,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     end
 
     test "answers with an empty page when nothing matches" do
-      assert {:ok, %RecordPage{records: [], stats: %{scanned: 0, returned: 0}}} =
+      assert {:ok, %{entries: [], scanned: 0}} =
                Ingestion.search_records(%{"query" => "nothing-matches-this"})
     end
 
@@ -729,10 +708,10 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
         seed_file(root, @volume, "capped-#{index}.md", "# #{index}")
       end)
 
-      assert {:ok, %RecordPage{records: records, stats: %{scanned: 100}}} =
+      assert {:ok, %{entries: entries, scanned: 100}} =
                Ingestion.search_records(%{"query" => "capped-"})
 
-      assert length(records) == 100
+      assert length(entries) == 100
     end
   end
 
@@ -740,20 +719,23 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
   describe "list_record_permissions/1" do
     test "reports a person grant with the person's full name", %{root: root} do
+      # Grants come back flattened, not as `DocumentPermission` structs — the bridge shaping
+      # them into records must not reach into an Ecto schema or its preloads.
       document = seed_file(root, @volume, "guide.md", "# guide")
       person = create_person()
-      {:ok, _} = Ingestion.set_document_permission(document.id, :person, person.id, ["read"])
 
-      assert {:ok, %RecordPage{resource_type: :permission, records: [record]}} =
+      {:ok, permission} =
+        Ingestion.set_document_permission(document.id, :person, person.id, ["read"])
+
+      assert {:ok, %{permissions: [grant], public?: false}} =
                Ingestion.list_record_permissions(to_string(document.id))
 
-      assert record.kind == :permission
-      assert record.name == person.full_name
-
-      assert record.attributes == %{
-               "type" => "person",
-               "target_id" => to_string(person.id),
-               "access_rights" => ["read"]
+      assert grant == %{
+               id: to_string(permission.id),
+               type: "person",
+               target_id: to_string(person.id),
+               name: person.full_name,
+               access_rights: ["read"]
              }
     end
 
@@ -775,10 +757,10 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       {:ok, _} = Ingestion.set_document_permission(document.id, :person, person.id, ["read"])
       {:ok, _} = Ingestion.set_document_permission(document.id, :team, team.id, ["read"])
 
-      assert {:ok, %RecordPage{records: records, stats: %{scanned: 3, returned: 3}}} =
+      assert {:ok, %{permissions: grants, public?: true}} =
                Ingestion.list_record_permissions(to_string(document.id))
 
-      assert Enum.sort(Enum.map(records, & &1.attributes["type"])) == ["person", "public", "team"]
+      assert Enum.sort(Enum.map(grants, & &1.type)) == ["person", "team"]
     end
 
     test "reports a team grant", %{root: root} do
@@ -786,32 +768,22 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       team = create_team()
       {:ok, _} = Ingestion.set_document_permission(document.id, :team, team.id, ["read", "write"])
 
-      assert {:ok, %RecordPage{records: [record]}} =
+      assert {:ok, %{permissions: [grant]}} =
                Ingestion.list_record_permissions(to_string(document.id))
 
-      assert record.name == team.name
-
-      assert record.attributes == %{
-               "type" => "team",
-               "target_id" => to_string(team.id),
-               "access_rights" => ["read", "write"]
-             }
+      assert grant.name == team.name
+      assert grant.type == "team"
+      assert grant.target_id == to_string(team.id)
+      assert grant.access_rights == ["read", "write"]
     end
 
-    test "reports the public tag as a synthetic grant", %{root: root} do
+    test "reports the public tag as a flag, with no grant row behind it", %{root: root} do
+      # Public access has no `resource_permissions` row. Ingestion reports the tag and the
+      # bridge synthesizes the grant record, so nothing here invents an id.
       document = seed_file(root, @volume, "guide.md", "# guide", %{tags: ["public"]})
 
-      assert {:ok, %RecordPage{records: [record]}} =
+      assert {:ok, %{permissions: [], public?: true}} =
                Ingestion.list_record_permissions(to_string(document.id))
-
-      assert record.id == "public:#{document.id}"
-      assert record.name == "Public"
-
-      assert record.attributes == %{
-               "type" => "public",
-               "target_id" => nil,
-               "access_rights" => ["read"]
-             }
     end
 
     test "reports the public tag alongside an explicit grant", %{root: root} do
@@ -819,16 +791,16 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       person = create_person()
       {:ok, _} = Ingestion.set_document_permission(document.id, :person, person.id, ["read"])
 
-      assert {:ok, %RecordPage{records: records, stats: %{scanned: 2, returned: 2}}} =
+      assert {:ok, %{permissions: [grant], public?: true}} =
                Ingestion.list_record_permissions(to_string(document.id))
 
-      assert Enum.map(records, & &1.attributes["type"]) == ["public", "person"]
+      assert grant.type == "person"
     end
 
-    test "answers with an empty page when nobody has access", %{root: root} do
+    test "answers with no grants when nobody has access", %{root: root} do
       document = seed_file(root, @volume, "guide.md", "# guide")
 
-      assert {:ok, %RecordPage{records: [], stats: %{scanned: 0, returned: 0}}} =
+      assert {:ok, %{permissions: [], public?: false}} =
                Ingestion.list_record_permissions(to_string(document.id))
     end
 
@@ -839,7 +811,7 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
     test "answers for a stale row, since permissions do not need the file" do
       document = seed_stale_row(@volume, "deleted.md")
 
-      assert {:ok, %RecordPage{records: []}} =
+      assert {:ok, %{permissions: []}} =
                Ingestion.list_record_permissions(to_string(document.id))
     end
   end

--- a/test/zaq/ingestion/ingestion_test.exs
+++ b/test/zaq/ingestion/ingestion_test.exs
@@ -824,22 +824,30 @@ defmodule Zaq.IngestionTest do
   end
 
   describe "local volume records" do
-    test "converts local volume entries into canonical records" do
-      entry = %{name: "file.md", type: :file, size: 12, modified_at: DateTime.utc_now()}
+    defp volume_entry do
+      %Zaq.Ingestion.FileExplorer.Entry{
+        name: "file.md",
+        type: :file,
+        size: 12,
+        modified_at: DateTime.utc_now(),
+        volume: "default",
+        relative_path: "docs/file.md"
+      }
+    end
 
-      record = VolumeRecords.from_entry(entry, "default", "docs")
+    test "converts local volume entries into canonical records" do
+      assert [record] = VolumeRecords.from_entries([volume_entry()])
 
       assert record.kind == :file
       assert record.name == "file.md"
       assert record.path == "docs/file.md"
-      assert record.attributes["provider"] == "zaq_local"
+      assert record.attributes["provider"] == "disk"
       assert record.attributes["volume"] == "default"
       assert record.attributes["relative_path"] == "docs/file.md"
     end
 
     test "storage maps round-trip back into records" do
-      entry = %{name: "file.md", type: :file, size: 12, modified_at: DateTime.utc_now()}
-      record = VolumeRecords.from_entry(entry, "default", "docs")
+      assert [record] = VolumeRecords.from_entries([volume_entry()])
 
       assert {:ok, decoded} =
                record |> RecordSource.to_storage_map() |> RecordSource.from_storage_map()
@@ -865,7 +873,7 @@ defmodule Zaq.IngestionTest do
       {:ok, entries} = FileExplorer.list(".")
 
       record =
-        entries |> VolumeRecords.from_entries("default", ".") |> Enum.find(&(&1.path == path))
+        entries |> VolumeRecords.from_entries() |> Enum.find(&(&1.path == path))
 
       expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
         {:ok, %{id: nil, chunks_count: 1, document_id: nil}}
@@ -873,7 +881,8 @@ defmodule Zaq.IngestionTest do
 
       assert {:ok, [job]} = Ingestion.ingest_records([record], %{mode: "inline"})
       assert job.file_path == path
-      assert job.volume_name == "default"
+      # Listed through the volume-less explorer path, so there is no volume to name.
+      assert job.volume_name == nil
       assert job.source_record["id"] == record.id
       assert job.source_record["attributes"]["relative_path"] == path
     end
@@ -888,7 +897,7 @@ defmodule Zaq.IngestionTest do
       {:ok, entries} = FileExplorer.list(".")
 
       record =
-        entries |> VolumeRecords.from_entries("default", ".") |> Enum.find(&(&1.path == folder))
+        entries |> VolumeRecords.from_entries() |> Enum.find(&(&1.path == folder))
 
       expect(Zaq.DocumentProcessorMock, :process_single_file, fn _path ->
         {:ok, %{id: nil, chunks_count: 1, document_id: nil}}
@@ -908,7 +917,7 @@ defmodule Zaq.IngestionTest do
       {:ok, entries} = FileExplorer.list(".")
 
       record =
-        entries |> VolumeRecords.from_entries("default", ".") |> Enum.find(&(&1.path == path))
+        entries |> VolumeRecords.from_entries() |> Enum.find(&(&1.path == path))
 
       bad_record = %Record{id: "bad", kind: :unsupported, name: "bad"}
 

--- a/test/zaq/ingestion/record_source_test.exs
+++ b/test/zaq/ingestion/record_source_test.exs
@@ -1,5 +1,7 @@
 defmodule Zaq.Ingestion.RecordSourceTest do
-  use ExUnit.Case, async: false
+  # Listing local-volume children resolves document identity, so these tests need a
+  # sandboxed Repo checkout, not a bare ExUnit case.
+  use Zaq.DataCase, async: false
 
   import Mox
 

--- a/test/zaq/ingestion/volume_entries_test.exs
+++ b/test/zaq/ingestion/volume_entries_test.exs
@@ -1,0 +1,230 @@
+defmodule Zaq.Ingestion.VolumeEntriesTest do
+  # async: false — these tests mount a volume through Application.put_env; concurrent runs
+  # would read each other's configuration.
+  use Zaq.DataCase, async: false
+
+  alias Zaq.Ingestion.Document
+  alias Zaq.Ingestion.FileExplorer.Entry
+  alias Zaq.Ingestion.VolumeEntries
+
+  @volume "archives"
+
+  setup do
+    root =
+      Path.join(System.tmp_dir!(), "zaq_volume_entries_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root)
+
+    original = Application.get_env(:zaq, Zaq.Ingestion)
+
+    Application.put_env(
+      :zaq,
+      Zaq.Ingestion,
+      Keyword.merge(original || [], volumes: %{@volume => root})
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root)
+
+      if is_nil(original) do
+        Application.delete_env(:zaq, Zaq.Ingestion)
+      else
+        Application.put_env(:zaq, Zaq.Ingestion, original)
+      end
+    end)
+
+    %{root: root}
+  end
+
+  defp file_entry(relative_path, volume \\ @volume) do
+    %Entry{
+      name: Path.basename(relative_path),
+      type: :file,
+      size: 12,
+      modified_at: 1_700_000_000,
+      volume: volume,
+      relative_path: relative_path
+    }
+  end
+
+  defp create_document(source) do
+    {:ok, document} = Document.create(%{source: source, content: "content for #{source}"})
+    document
+  end
+
+  describe "resolve/1 identity" do
+    test "answers with the document id when a row exists for the source" do
+      document = create_document("#{@volume}/product.pdf")
+
+      assert %Entry{id: id, document_id: document_id} =
+               VolumeEntries.resolve(file_entry("product.pdf"))
+
+      assert id == to_string(document.id)
+      assert document_id == document.id
+    end
+
+    test "falls back to a volume-path id when no document row exists" do
+      assert %Entry{id: id, document_id: nil} =
+               VolumeEntries.resolve(file_entry("unfiled/product.pdf"))
+
+      assert id == "disk:#{@volume}:unfiled/product.pdf"
+    end
+
+    test "resolves a document stored under the bare relative path" do
+      document = create_document("legacy.md")
+
+      assert %Entry{id: id} = VolumeEntries.resolve(file_entry("legacy.md"))
+      assert id == to_string(document.id)
+    end
+
+    test "resolves a document stored under the volume-prefixed path" do
+      document = create_document("#{@volume}/prefixed.md")
+
+      assert %Entry{id: id} = VolumeEntries.resolve(file_entry("prefixed.md"))
+      assert id == to_string(document.id)
+    end
+
+    test "considers only the bare relative path when there is no volume" do
+      bare = create_document("nil-volume.md")
+      _prefixed = create_document("#{@volume}/nil-volume.md")
+
+      assert %Entry{id: id} = VolumeEntries.resolve(file_entry("nil-volume.md", nil))
+      assert id == to_string(bare.id)
+    end
+
+    test "names the fallback volume 'default' when there is no volume" do
+      assert %Entry{id: "disk:default:orphan.md"} =
+               VolumeEntries.resolve(file_entry("orphan.md", nil))
+    end
+  end
+
+  describe "resolve/1 paths" do
+    test "normalizes a leading ./ on the relative path" do
+      assert %Entry{relative_path: "dotted.md"} =
+               VolumeEntries.resolve(file_entry("./dotted.md"))
+    end
+
+    test "takes the source from the first candidate, which is the bare relative path" do
+      # `Document.source` is volume-prefixed while the entry source is bare. Nothing looks a
+      # document up by `source` — pinned so it is not turned into a lookup key by accident.
+      document = create_document("#{@volume}/divergent.md")
+
+      assert %Entry{source: source, id: id} = VolumeEntries.resolve(file_entry("divergent.md"))
+      assert source == "divergent.md"
+      assert document.source == "#{@volume}/divergent.md"
+      assert id == to_string(document.id)
+    end
+
+    test "uses the bare relative path as the source when there is no volume" do
+      assert %Entry{source: "manuals/guide.md", volume: nil} =
+               VolumeEntries.resolve(file_entry("manuals/guide.md", nil))
+    end
+
+    test "falls back to the entry name when it carries no relative path" do
+      entry = %Entry{name: "loose.md", type: :file, volume: @volume}
+
+      assert %Entry{relative_path: "loose.md", source: "loose.md"} = VolumeEntries.resolve(entry)
+    end
+  end
+
+  describe "resolve/1 over a listing" do
+    test "resolves document ids for the whole listing" do
+      one = create_document("#{@volume}/one.md")
+      two = create_document("#{@volume}/two.md")
+
+      entries =
+        VolumeEntries.resolve([
+          file_entry("one.md"),
+          file_entry("two.md"),
+          file_entry("three.md")
+        ])
+
+      assert Enum.map(entries, & &1.id) == [
+               to_string(one.id),
+               to_string(two.id),
+               "disk:#{@volume}:three.md"
+             ]
+    end
+
+    test "issues one document query for the listing, not one per entry" do
+      Enum.each(1..5, &create_document("#{@volume}/batch#{&1}.md"))
+      entries = Enum.map(1..5, &file_entry("batch#{&1}.md"))
+
+      handler_id = "volume-entries-query-count-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:zaq, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if String.contains?(metadata.query, ~s(FROM "documents")) do
+            send(test_pid, :document_query)
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      VolumeEntries.resolve(entries)
+
+      assert_received :document_query
+      refute_received :document_query
+    end
+
+    test "returns an empty list for an empty listing" do
+      assert VolumeEntries.resolve([]) == []
+    end
+  end
+
+  describe "from_path/2" do
+    test "reads an entry off the volume and resolves it", %{root: root} do
+      File.write!(Path.join(root, "ondisk.md"), "# on disk")
+      document = create_document("#{@volume}/ondisk.md")
+
+      assert {:ok, %Entry{} = entry} = VolumeEntries.from_path(@volume, "ondisk.md")
+      assert entry.id == to_string(document.id)
+      assert entry.name == "ondisk.md"
+      assert entry.type == :file
+      assert entry.relative_path == "ondisk.md"
+    end
+
+    test "reads a nested file", %{root: root} do
+      File.mkdir_p!(Path.join(root, "manuals"))
+      File.write!(Path.join([root, "manuals", "nested.md"]), "# nested")
+
+      assert {:ok, entry} = VolumeEntries.from_path(@volume, "manuals/nested.md")
+      assert entry.relative_path == "manuals/nested.md"
+      assert entry.id == "disk:#{@volume}:manuals/nested.md"
+    end
+
+    test "normalizes a leading ./ before reading", %{root: root} do
+      File.write!(Path.join(root, "dotted.md"), "# dotted")
+
+      assert {:ok, entry} = VolumeEntries.from_path(@volume, "./dotted.md")
+      assert entry.relative_path == "dotted.md"
+    end
+
+    test "propagates the filesystem error for a missing file" do
+      assert {:error, :enoent} = VolumeEntries.from_path(@volume, "gone.md")
+    end
+
+    test "with no volume, reads through the volume-less explorer path", %{root: root} do
+      # Single-volume callers pass `nil` and a path that still resolves — the entry then
+      # carries no volume and its source is the bare path it was given.
+      File.write!(Path.join(root, "novolume.md"), "# no volume")
+      document = create_document("#{@volume}/novolume.md")
+
+      assert {:ok, entry} = VolumeEntries.from_path(nil, "#{@volume}/novolume.md")
+      assert entry.id == to_string(document.id)
+      assert entry.volume == nil
+      assert entry.source == "#{@volume}/novolume.md"
+    end
+  end
+
+  describe "local_provider/0" do
+    test "answers with the provider name embedded in fallback ids" do
+      assert VolumeEntries.local_provider() == "disk"
+    end
+  end
+end

--- a/test/zaq/ingestion/volume_records_test.exs
+++ b/test/zaq/ingestion/volume_records_test.exs
@@ -1,0 +1,286 @@
+defmodule Zaq.Ingestion.VolumeRecordsTest do
+  # async: false — these tests mount a volume through Application.put_env; concurrent runs
+  # would read each other's configuration.
+  use Zaq.DataCase, async: false
+
+  alias Zaq.Contracts.Record
+  alias Zaq.Event
+  alias Zaq.Ingestion.Document
+  alias Zaq.Ingestion.VolumeRecords
+
+  @volume "archives"
+
+  setup do
+    root =
+      Path.join(System.tmp_dir!(), "zaq_volume_records_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root)
+
+    original = Application.get_env(:zaq, Zaq.Ingestion)
+
+    Application.put_env(
+      :zaq,
+      Zaq.Ingestion,
+      Keyword.merge(original || [], volumes: %{@volume => root})
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root)
+
+      if is_nil(original) do
+        Application.delete_env(:zaq, Zaq.Ingestion)
+      else
+        Application.put_env(:zaq, Zaq.Ingestion, original)
+      end
+    end)
+
+    %{root: root}
+  end
+
+  defp file_entry(name, attrs \\ %{}) do
+    Map.merge(%{name: name, type: :file, size: 12, modified_at: 1_700_000_000}, attrs)
+  end
+
+  defp dir_entry(name) do
+    %{name: name, type: :directory, size: 0, modified_at: 1_700_000_000}
+  end
+
+  defp create_document(source) do
+    {:ok, document} = Document.create(%{source: source, content: "content for #{source}"})
+    document
+  end
+
+  describe "record_id/3" do
+    test "answers with the document id when a row exists for the source" do
+      document = create_document("#{@volume}/product.pdf")
+
+      assert VolumeRecords.record_id(@volume, "product.pdf") == to_string(document.id)
+    end
+
+    test "falls back to a volume-path id when no document row exists" do
+      assert VolumeRecords.record_id(@volume, "unfiled/product.pdf") ==
+               "disk:#{@volume}:unfiled/product.pdf"
+    end
+
+    test "resolves a document stored under the bare relative path" do
+      document = create_document("legacy.md")
+
+      assert VolumeRecords.record_id(@volume, "legacy.md") == to_string(document.id)
+    end
+
+    test "resolves a document stored under the volume-prefixed path" do
+      document = create_document("#{@volume}/prefixed.md")
+
+      assert VolumeRecords.record_id(@volume, "prefixed.md") == to_string(document.id)
+    end
+
+    test "considers only the bare relative path when there is no volume" do
+      bare = create_document("nil-volume.md")
+      _prefixed = create_document("#{@volume}/nil-volume.md")
+
+      assert VolumeRecords.record_id(nil, "nil-volume.md") == to_string(bare.id)
+    end
+
+    test "names the fallback volume 'default' when there is no volume" do
+      assert VolumeRecords.record_id(nil, "orphan.md") == "disk:default:orphan.md"
+    end
+
+    test "reads the id out of a prepared source map rather than querying" do
+      ids = %{"#{@volume}/mapped.md" => 4242}
+
+      assert VolumeRecords.record_id(@volume, "mapped.md", ids) == "4242"
+    end
+
+    test "falls back to the path id when the prepared map has no entry" do
+      assert VolumeRecords.record_id(@volume, "mapped.md", %{}) == "disk:#{@volume}:mapped.md"
+    end
+  end
+
+  describe "from_entry/4" do
+    test "derives the mime type from the extension for files" do
+      record = VolumeRecords.from_entry(file_entry("guide.md"), @volume, ".")
+
+      assert %Record{kind: :file, name: "guide.md", mime_type: "text/markdown"} = record
+    end
+
+    test "leaves the mime type nil for folders" do
+      record = VolumeRecords.from_entry(dir_entry("reports"), @volume, ".")
+
+      assert %Record{kind: :folder, mime_type: nil} = record
+    end
+
+    test "carries provider, volume, relative path, and source attributes" do
+      record = VolumeRecords.from_entry(file_entry("guide.md"), @volume, "manuals")
+
+      assert record.path == "manuals/guide.md"
+
+      assert record.attributes == %{
+               "provider" => "disk",
+               "volume" => @volume,
+               "relative_path" => "manuals/guide.md",
+               "source" => "manuals/guide.md"
+             }
+    end
+
+    test "keeps size and modified_at from the volume entry" do
+      entry = file_entry("guide.md", %{size: 99, modified_at: 1_712_345_678})
+      record = VolumeRecords.from_entry(entry, @volume, ".")
+
+      assert record.size == 99
+      assert record.modified_at == 1_712_345_678
+      assert record.raw == %{local_entry: entry}
+    end
+
+    test "attaches a materializing event whose file_id is the record id" do
+      document = create_document("#{@volume}/materializable.md")
+      record = VolumeRecords.from_entry(file_entry("materializable.md"), @volume, ".")
+
+      assert %Event{request: %{file_id: file_id}, opts: opts, next_hop: next_hop} =
+               record.materializing_event
+
+      assert file_id == record.id
+      assert file_id == to_string(document.id)
+      assert opts[:action] == :materialize_record
+      assert next_hop.destination == :ingestion
+    end
+
+    test "attaches a materializing event to files with no document row" do
+      record = VolumeRecords.from_entry(file_entry("unindexed.md"), @volume, ".")
+
+      assert %Event{request: %{file_id: file_id}} = record.materializing_event
+      assert file_id == record.id
+      assert file_id == "disk:#{@volume}:unindexed.md"
+    end
+
+    test "leaves folders with no materializing event" do
+      record = VolumeRecords.from_entry(dir_entry("reports"), @volume, ".")
+
+      assert record.materializing_event == nil
+    end
+
+    test "holds the bare relative path in attributes even when the document is prefixed" do
+      # `attributes["source"]` takes the first source candidate, which is the bare relative
+      # path, while `Document.source` is volume-prefixed. Nothing looks a document up by this
+      # attribute — pinned so it is not turned into a lookup key by accident.
+      document = create_document("#{@volume}/divergent.md")
+      record = VolumeRecords.from_entry(file_entry("divergent.md"), @volume, ".")
+
+      assert record.attributes["source"] == "divergent.md"
+      assert document.source == "#{@volume}/divergent.md"
+      assert record.id == to_string(document.id)
+    end
+  end
+
+  describe "from_entries/3" do
+    test "resolves document ids for the whole listing" do
+      one = create_document("#{@volume}/one.md")
+      two = create_document("#{@volume}/two.md")
+
+      records =
+        VolumeRecords.from_entries(
+          [file_entry("one.md"), file_entry("two.md"), file_entry("three.md")],
+          @volume,
+          "."
+        )
+
+      assert Enum.map(records, & &1.id) == [
+               to_string(one.id),
+               to_string(two.id),
+               "disk:#{@volume}:three.md"
+             ]
+    end
+
+    test "issues one document query for the listing, not one per entry" do
+      Enum.each(1..5, &create_document("#{@volume}/batch#{&1}.md"))
+      entries = Enum.map(1..5, &file_entry("batch#{&1}.md"))
+
+      handler_id = "volume-records-query-count-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:zaq, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if String.contains?(metadata.query, ~s(FROM "documents")) do
+            send(test_pid, :document_query)
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      VolumeRecords.from_entries(entries, @volume, ".")
+
+      assert_received :document_query
+      refute_received :document_query
+    end
+
+    test "returns folders alongside files" do
+      records =
+        VolumeRecords.from_entries([dir_entry("reports"), file_entry("guide.md")], @volume, ".")
+
+      assert Enum.map(records, & &1.kind) == [:folder, :file]
+    end
+
+    test "returns an empty list for an empty listing" do
+      assert VolumeRecords.from_entries([], @volume, ".") == []
+    end
+  end
+
+  describe "from_path/2" do
+    test "builds a record for a file on the volume", %{root: root} do
+      File.write!(Path.join(root, "ondisk.md"), "# on disk")
+      document = create_document("#{@volume}/ondisk.md")
+
+      assert {:ok, %Record{} = record} = VolumeRecords.from_path(@volume, "ondisk.md")
+      assert record.id == to_string(document.id)
+      assert record.name == "ondisk.md"
+      assert record.kind == :file
+      assert record.mime_type == "text/markdown"
+      assert record.content == nil
+    end
+
+    test "builds a record for a nested file", %{root: root} do
+      File.mkdir_p!(Path.join(root, "manuals"))
+      File.write!(Path.join([root, "manuals", "nested.md"]), "# nested")
+
+      assert {:ok, record} = VolumeRecords.from_path(@volume, "manuals/nested.md")
+      assert record.path == "manuals/nested.md"
+      assert record.id == "disk:#{@volume}:manuals/nested.md"
+    end
+
+    test "normalizes a leading ./ before reading", %{root: root} do
+      File.write!(Path.join(root, "dotted.md"), "# dotted")
+
+      assert {:ok, record} = VolumeRecords.from_path(@volume, "./dotted.md")
+      assert record.path == "dotted.md"
+    end
+
+    test "propagates the filesystem error for a missing file" do
+      assert {:error, :enoent} = VolumeRecords.from_path(@volume, "gone.md")
+    end
+
+    test "with no volume, reads through the volume-less explorer path", %{root: root} do
+      # Single-volume callers pass `nil` and a path that still resolves — the record then
+      # carries no volume and its source is the bare path it was given.
+      File.write!(Path.join(root, "novolume.md"), "# no volume")
+      document = create_document("#{@volume}/novolume.md")
+
+      assert {:ok, record} = VolumeRecords.from_path(nil, "#{@volume}/novolume.md")
+      assert record.id == to_string(document.id)
+      assert record.attributes["volume"] == nil
+      assert record.attributes["source"] == "#{@volume}/novolume.md"
+    end
+  end
+
+  describe "from_entry/4 with no volume" do
+    test "uses the bare relative path as the source" do
+      record = VolumeRecords.from_entry(file_entry("guide.md"), nil, "manuals")
+
+      assert record.attributes["volume"] == nil
+      assert record.attributes["source"] == "manuals/guide.md"
+      assert record.id == "disk:default:manuals/guide.md"
+    end
+  end
+end

--- a/test/zaq/ingestion/volume_records_test.exs
+++ b/test/zaq/ingestion/volume_records_test.exs
@@ -6,6 +6,7 @@ defmodule Zaq.Ingestion.VolumeRecordsTest do
   alias Zaq.Contracts.Record
   alias Zaq.Event
   alias Zaq.Ingestion.Document
+  alias Zaq.Ingestion.FileExplorer.Entry
   alias Zaq.Ingestion.VolumeRecords
 
   @volume "archives"
@@ -37,12 +38,29 @@ defmodule Zaq.Ingestion.VolumeRecordsTest do
     %{root: root}
   end
 
-  defp file_entry(name, attrs \\ %{}) do
-    Map.merge(%{name: name, type: :file, size: 12, modified_at: 1_700_000_000}, attrs)
+  defp file_entry(relative_path, attrs \\ %{}) do
+    struct!(
+      %Entry{
+        name: Path.basename(relative_path),
+        type: :file,
+        size: 12,
+        modified_at: 1_700_000_000,
+        volume: @volume,
+        relative_path: relative_path
+      },
+      attrs
+    )
   end
 
-  defp dir_entry(name) do
-    %{name: name, type: :directory, size: 0, modified_at: 1_700_000_000}
+  defp dir_entry(relative_path) do
+    %Entry{
+      name: Path.basename(relative_path),
+      type: :directory,
+      size: 0,
+      modified_at: 1_700_000_000,
+      volume: @volume,
+      relative_path: relative_path
+    }
   end
 
   defp create_document(source) do
@@ -50,67 +68,36 @@ defmodule Zaq.Ingestion.VolumeRecordsTest do
     document
   end
 
-  describe "record_id/3" do
-    test "answers with the document id when a row exists for the source" do
-      document = create_document("#{@volume}/product.pdf")
-
-      assert VolumeRecords.record_id(@volume, "product.pdf") == to_string(document.id)
-    end
-
-    test "falls back to a volume-path id when no document row exists" do
-      assert VolumeRecords.record_id(@volume, "unfiled/product.pdf") ==
-               "disk:#{@volume}:unfiled/product.pdf"
-    end
-
-    test "resolves a document stored under the bare relative path" do
-      document = create_document("legacy.md")
-
-      assert VolumeRecords.record_id(@volume, "legacy.md") == to_string(document.id)
-    end
-
-    test "resolves a document stored under the volume-prefixed path" do
-      document = create_document("#{@volume}/prefixed.md")
-
-      assert VolumeRecords.record_id(@volume, "prefixed.md") == to_string(document.id)
-    end
-
-    test "considers only the bare relative path when there is no volume" do
-      bare = create_document("nil-volume.md")
-      _prefixed = create_document("#{@volume}/nil-volume.md")
-
-      assert VolumeRecords.record_id(nil, "nil-volume.md") == to_string(bare.id)
-    end
-
-    test "names the fallback volume 'default' when there is no volume" do
-      assert VolumeRecords.record_id(nil, "orphan.md") == "disk:default:orphan.md"
-    end
-
-    test "reads the id out of a prepared source map rather than querying" do
-      ids = %{"#{@volume}/mapped.md" => 4242}
-
-      assert VolumeRecords.record_id(@volume, "mapped.md", ids) == "4242"
-    end
-
-    test "falls back to the path id when the prepared map has no entry" do
-      assert VolumeRecords.record_id(@volume, "mapped.md", %{}) == "disk:#{@volume}:mapped.md"
-    end
+  # `to_record/1` maps an already-resolved entry, so these build the resolved fields by hand
+  # rather than going through a database lookup.
+  defp resolved(%Entry{} = entry, id, source) do
+    %{entry | id: id, source: source}
   end
 
-  describe "from_entry/4" do
+  describe "to_record/1" do
     test "derives the mime type from the extension for files" do
-      record = VolumeRecords.from_entry(file_entry("guide.md"), @volume, ".")
+      record =
+        "guide.md"
+        |> file_entry()
+        |> resolved("disk:#{@volume}:guide.md", "guide.md")
+        |> VolumeRecords.to_record()
 
       assert %Record{kind: :file, name: "guide.md", mime_type: "text/markdown"} = record
     end
 
-    test "leaves the mime type nil for folders" do
-      record = VolumeRecords.from_entry(dir_entry("reports"), @volume, ".")
+    test "maps a directory entry onto the record's :folder kind, with no mime type" do
+      record =
+        "reports"
+        |> dir_entry()
+        |> resolved("disk:#{@volume}:reports", "reports")
+        |> VolumeRecords.to_record()
 
       assert %Record{kind: :folder, mime_type: nil} = record
     end
 
     test "carries provider, volume, relative path, and source attributes" do
-      record = VolumeRecords.from_entry(file_entry("guide.md"), @volume, "manuals")
+      entry = resolved(file_entry("manuals/guide.md"), "id-1", "manuals/guide.md")
+      record = VolumeRecords.to_record(entry)
 
       assert record.path == "manuals/guide.md"
 
@@ -123,8 +110,12 @@ defmodule Zaq.Ingestion.VolumeRecordsTest do
     end
 
     test "keeps size and modified_at from the volume entry" do
-      entry = file_entry("guide.md", %{size: 99, modified_at: 1_712_345_678})
-      record = VolumeRecords.from_entry(entry, @volume, ".")
+      entry =
+        "guide.md"
+        |> file_entry(%{size: 99, modified_at: 1_712_345_678})
+        |> resolved("id-1", "guide.md")
+
+      record = VolumeRecords.to_record(entry)
 
       assert record.size == 99
       assert record.modified_at == 1_712_345_678
@@ -132,99 +123,54 @@ defmodule Zaq.Ingestion.VolumeRecordsTest do
     end
 
     test "attaches a materializing event whose file_id is the record id" do
-      document = create_document("#{@volume}/materializable.md")
-      record = VolumeRecords.from_entry(file_entry("materializable.md"), @volume, ".")
+      entry = resolved(file_entry("materializable.md"), "4242", "materializable.md")
+      record = VolumeRecords.to_record(entry)
 
       assert %Event{request: %{file_id: file_id}, opts: opts, next_hop: next_hop} =
                record.materializing_event
 
       assert file_id == record.id
-      assert file_id == to_string(document.id)
+      assert file_id == "4242"
       assert opts[:action] == :materialize_record
       assert next_hop.destination == :ingestion
     end
 
+    test "leaves folders with no materializing event" do
+      record =
+        "reports"
+        |> dir_entry()
+        |> resolved("disk:#{@volume}:reports", "reports")
+        |> VolumeRecords.to_record()
+
+      assert record.materializing_event == nil
+    end
+  end
+
+  describe "from_entries/1" do
+    test "resolves ids and converts the listing into records" do
+      one = create_document("#{@volume}/one.md")
+
+      records = VolumeRecords.from_entries([file_entry("one.md"), file_entry("two.md")])
+
+      assert Enum.map(records, & &1.id) == [to_string(one.id), "disk:#{@volume}:two.md"]
+    end
+
+    test "returns folders alongside files" do
+      records = VolumeRecords.from_entries([dir_entry("reports"), file_entry("guide.md")])
+
+      assert Enum.map(records, & &1.kind) == [:folder, :file]
+    end
+
     test "attaches a materializing event to files with no document row" do
-      record = VolumeRecords.from_entry(file_entry("unindexed.md"), @volume, ".")
+      assert [record] = VolumeRecords.from_entries([file_entry("unindexed.md")])
 
       assert %Event{request: %{file_id: file_id}} = record.materializing_event
       assert file_id == record.id
       assert file_id == "disk:#{@volume}:unindexed.md"
     end
 
-    test "leaves folders with no materializing event" do
-      record = VolumeRecords.from_entry(dir_entry("reports"), @volume, ".")
-
-      assert record.materializing_event == nil
-    end
-
-    test "holds the bare relative path in attributes even when the document is prefixed" do
-      # `attributes["source"]` takes the first source candidate, which is the bare relative
-      # path, while `Document.source` is volume-prefixed. Nothing looks a document up by this
-      # attribute — pinned so it is not turned into a lookup key by accident.
-      document = create_document("#{@volume}/divergent.md")
-      record = VolumeRecords.from_entry(file_entry("divergent.md"), @volume, ".")
-
-      assert record.attributes["source"] == "divergent.md"
-      assert document.source == "#{@volume}/divergent.md"
-      assert record.id == to_string(document.id)
-    end
-  end
-
-  describe "from_entries/3" do
-    test "resolves document ids for the whole listing" do
-      one = create_document("#{@volume}/one.md")
-      two = create_document("#{@volume}/two.md")
-
-      records =
-        VolumeRecords.from_entries(
-          [file_entry("one.md"), file_entry("two.md"), file_entry("three.md")],
-          @volume,
-          "."
-        )
-
-      assert Enum.map(records, & &1.id) == [
-               to_string(one.id),
-               to_string(two.id),
-               "disk:#{@volume}:three.md"
-             ]
-    end
-
-    test "issues one document query for the listing, not one per entry" do
-      Enum.each(1..5, &create_document("#{@volume}/batch#{&1}.md"))
-      entries = Enum.map(1..5, &file_entry("batch#{&1}.md"))
-
-      handler_id = "volume-records-query-count-#{System.unique_integer([:positive])}"
-      test_pid = self()
-
-      :telemetry.attach(
-        handler_id,
-        [:zaq, :repo, :query],
-        fn _event, _measurements, metadata, _config ->
-          if String.contains?(metadata.query, ~s(FROM "documents")) do
-            send(test_pid, :document_query)
-          end
-        end,
-        nil
-      )
-
-      on_exit(fn -> :telemetry.detach(handler_id) end)
-
-      VolumeRecords.from_entries(entries, @volume, ".")
-
-      assert_received :document_query
-      refute_received :document_query
-    end
-
-    test "returns folders alongside files" do
-      records =
-        VolumeRecords.from_entries([dir_entry("reports"), file_entry("guide.md")], @volume, ".")
-
-      assert Enum.map(records, & &1.kind) == [:folder, :file]
-    end
-
     test "returns an empty list for an empty listing" do
-      assert VolumeRecords.from_entries([], @volume, ".") == []
+      assert VolumeRecords.from_entries([]) == []
     end
   end
 
@@ -271,16 +217,6 @@ defmodule Zaq.Ingestion.VolumeRecordsTest do
       assert record.id == to_string(document.id)
       assert record.attributes["volume"] == nil
       assert record.attributes["source"] == "#{@volume}/novolume.md"
-    end
-  end
-
-  describe "from_entry/4 with no volume" do
-    test "uses the bare relative path as the source" do
-      record = VolumeRecords.from_entry(file_entry("guide.md"), nil, "manuals")
-
-      assert record.attributes["volume"] == nil
-      assert record.attributes["source"] == "manuals/guide.md"
-      assert record.id == "disk:default:manuals/guide.md"
     end
   end
 end

--- a/test/zaq/utils/map_test.exs
+++ b/test/zaq/utils/map_test.exs
@@ -58,6 +58,54 @@ defmodule Zaq.Utils.MapTest do
     end
   end
 
+  describe "present_value/2" do
+    test "reads either string or existing atom keys" do
+      assert Map.present_value(%{"file_id" => "42"}, "file_id") == "42"
+      assert Map.present_value(%{file_id: "42"}, "file_id") == "42"
+      assert Map.present_value(%{"file_id" => "42"}, :file_id) == "42"
+      assert Map.present_value(%{file_id: "42"}, :file_id) == "42"
+    end
+
+    test "a key holding nil does not shadow the other spelling" do
+      # This is the whole reason the function exists over metadata_value/2: payloads
+      # assembled by more than one writer carry the same field twice, once empty.
+      assert Map.present_value(%{"file_id" => nil, :file_id => "42"}, "file_id") == "42"
+      assert Map.present_value(%{:file_id => nil, "file_id" => "42"}, :file_id) == "42"
+      assert Map.metadata_value(%{"file_id" => nil, :file_id => "42"}, "file_id") == nil
+    end
+
+    test "prefers the requested spelling when both hold a value" do
+      assert Map.present_value(%{"file_id" => "string", :file_id => "atom"}, "file_id") ==
+               "string"
+
+      assert Map.present_value(%{"file_id" => "string", :file_id => "atom"}, :file_id) == "atom"
+    end
+
+    test "treats false as absent" do
+      assert Map.present_value(%{"enabled" => false}, "enabled") == nil
+    end
+
+    test "keeps other falsey values" do
+      assert Map.present_value(%{"count" => 0}, "count") == 0
+      assert Map.present_value(%{"label" => ""}, "label") == ""
+    end
+
+    test "returns nil when neither spelling is present" do
+      assert Map.present_value(%{"other" => "x"}, "file_id") == nil
+    end
+
+    test "does not create an atom for a string key that has none yet" do
+      assert Map.present_value(%{}, "not_yet_an_atom_key_#{System.unique_integer([:positive])}") ==
+               nil
+    end
+
+    test "returns nil for invalid input or unsupported key types" do
+      assert Map.present_value("not-a-map", "file_id") == nil
+      assert Map.present_value(nil, "file_id") == nil
+      assert Map.present_value(%{"file_id" => "42"}, 123) == nil
+    end
+  end
+
   describe "stringify_keys/1" do
     test "converts atom keys to strings and leaves values untouched" do
       assert Map.stringify_keys(%{:originator => "zaqos", "scope" => "openid"}) == %{


### PR DESCRIPTION
The purpose of this PR is to organize the code and small refactor where the DataSourceTool used.

- Supported Zoi structure for 2 actions `create_document` and `download_document`. 
- Support encoding input for `create_document`
