### PR TITLE
feat(agent): store skill resources as tracked documents

### DIFF
--- a/docs/code-quality.md
+++ b/docs/code-quality.md
@@ -41,6 +41,17 @@
 
 ---
 
+## Comments & Diff Size
+
+- A comment above a function is **1–2 lines, maximum**, and states what the function does. Nothing else.
+- No reasoning, no justification, no alternatives considered, no history. If a decision needs an argument to survive review, it belongs in the PR description or `docs/services/`, not above the function.
+- Banned shapes in comments and `@moduledoc`: `## Why …` sections, "this is deliberate", "rather than X because Y", "for the rollout window", "Part 1 / Part 2", upstream issue or gap references, and changelog prose ("X used to be …").
+- State a constraint only when a caller must know it, and state it as a fact: "Returns `{:error, :not_found}` for an unmounted volume" — not a paragraph on why it is not raised.
+- Delete a comment that restates the code. `# Fetches the skill` above `fetch_skill/1` is noise.
+- Keep the diff small. Prefer editing an existing function over adding a parallel one, and delete the code a change replaces in the same PR. Reviewers comment on volume before they comment on logic.
+
+---
+
 ## Technical Debt Controls
 
 - Any temporary shortcut must be marked with an inline comment — Credo blocks bare `TODO` tags, so use this format instead:

--- a/docs/services/agent.md
+++ b/docs/services/agent.md
@@ -183,7 +183,8 @@ BO-managed skills built on **Open Agent Skills**, using Jido's *stateless* skill
 1. **Declaration.** `Zaq.Agent.Skill` (`agent_skills` table) is the source of truth: `name`
    (kebab-case, unique), `description` (**required**), `body` (markdown), `provided_tool_keys`
    (ZAQ `Tools.Registry` keys), `allowed_tools` (OAS tool names), `enabled_mcp_endpoint_ids`,
-   `resource_root`, `diagnostics` (validation cache), `tags`, `active`. BO CRUD at `/bo/skills`;
+   `resources` (bundled documents), `diagnostics` (validation cache), `tags`, `active`. BO CRUD
+   at `/bo/skills`;
    agents attach via `enabled_skill_ids` (array, no FK — ghost ids dropped at runtime).
 2. **Validation** (`Zaq.Agent.Skills.Validation`). Field shape is validated **by Jido's
    `Loader`**, not by ZAQ regexes: attrs are serialized to SKILL.md text and round-tripped
@@ -238,31 +239,43 @@ assembly only. Set it `false` to restore the eager renderer (`effective_system_p
 
 ### Skill resources (`Zaq.Agent.Skill.Resources`)
 
-Pure path derivation for a skill's reference files. Files live on an **ingestion volume**
-under `.agents/skills/{slug}/references/`, so they appear in the BO ingestion browser like
-any other ingested file — there is no separate storage mechanism.
+Owns `Skill.resources` — the documents a skill bundles — and the volume paths uploads land on.
 
-- `default_root/1` — `.agents/skills/{slug}` derived from `Skill.name`
-- `root/1` — the skill's effective root: the stored `resource_root` when present and safe,
-  else `default_root/1`. This is the directory removed on skill deletion
-- `references_dir/1` — `{root}/references`, where uploads land
+```elixir
+%{"references" => [%{"file_id" => "42", "file_name" => "prices.md", "provider" => "disk"}]}
+```
+
+`file_id` is a `documents.id`. Buckets are restricted to `references`, `scripts` and `assets`;
+only `references` is implemented. Every entry must carry all three keys.
+
+- `references/1` — the reference entries, `[]` when the skill has none
+- `add_references/2` / `remove_reference/2` — return the new resources map
+- `entry/3` — builds an entry from a bridge record
+- `record_page/1` — the references as unmaterialized `%Record{}` values in a `%RecordPage{}`
+- `references_dir/1` — `.agents/skills/{slug}/references`, where uploads land
 - `destination/2` — `{references_dir}/{basename}`; the client filename is reduced to a bare
   basename so directory components and traversal segments cannot survive
-- `slug/1` — defensive normaliser; identity for any persisted skill, since Jido already
-  constrains `name` to `~r/^[a-z0-9]+(-[a-z0-9]+)*$/`
+- `slug/1` — defensive normaliser; identity for any persisted skill
 
 **The module never touches the filesystem.** It derives path *strings* only; resolution and
 the authoritative containment check belong to the `:ingestion` role, the only node
-guaranteed to have the volume mounted. The sanitising here is a shape guard, not a security
-boundary — `FileExplorer.resolve_path/2` still rejects traversal independently.
+guaranteed to have the volume mounted.
 
-`resource_root` is **sticky**: written once on the first successful upload and reused
-thereafter, so renaming a skill does not orphan files already uploaded under the old name.
+**Write path (BO):** `SkillsLive` → `NodeRouter` (`:channels`, `:data_source_create_file`,
+provider `"disk"`) → `Zaq.Channels.DiskBridge` → `:ingestion`. The BO never calls ingestion
+directly. Files are written with `tags: ["public"]`, and the returned `documents.id` is
+appended to the skill's references bucket. Deleting a resource or a skill removes each
+recorded document by id — there is no volume sweep.
 
-**Write path (BO):** `SkillsLive` → `NodeRouter` (`:ingestion`) → `Ingestion.upload_file/3`
-+ `track_upload/2`. Uploading is gated on `Ingestion.volumes_configured?/0`. Wiring these
-files into the skill at runtime (progressive disclosure via `load_skill`) is not implemented
-yet.
+**Read path (agent):** `load_skill` returns `record_page/1` — metadata only, no content and
+no `materializing_event`. The model reads a file by calling `download_document` with the
+record's `id` and `attributes["provider"]`.
+
+> **Reads are not permission-filtered yet.** `Ingestion.materialize_record/1` and
+> `describe_record/1` take a bare `file_id`, and neither `DownloadDocument` nor
+> `ChannelTool.dispatch/5` forwards `:person_id`. The `"public"` tag is written now so the
+> data is correct when enforcement lands; until then any agent that can name a document id
+> can read it. Tracked in `docs/exec-plans/active/2026-08-07-skill-resources-documents.md`.
 
 **Staged uploads on an unsaved skill.** Resources can be added before a skill exists, as
 soon as a name is typed — the name is all the destination needs. Those entries are held in
@@ -282,17 +295,9 @@ Staged entries must be dropped whenever the form changes which skill it is about
 `consume_uploaded_entries/3` consumes *every* done entry in the config, so a leftover entry
 would otherwise be written into the next skill the operator touches.
 
-**Delete path (BO):** deleting a skill removes its whole `root/1` directory via
-`Ingestion.delete_path/4` (`"directory"`), which also clears the tracked `Document` rows.
-`Ingestion.file_info/2` gates each removal, because a skill that never had an upload has no
-directory and `delete_path/4` reports `{:error, :not_a_directory}` for a missing path.
-
-**Known gap — the volume is not persisted.** The upload modal lets the operator pick a
-volume, but only the volume-relative `resource_root` is stored, so which volume holds a
-skill's files is not recoverable from the record. Deletion therefore **sweeps every
-configured volume**, removing the root wherever it exists. This is correct but O(volumes);
-persisting a `resource_volume` column would make it a direct lookup and is the right fix if
-volume counts grow.
+**Delete path (BO):** deleting a skill removes each recorded `file_id` through
+`:data_source_delete_file`, which removes the file and its `Document` row. Deletion runs after the record is gone: the skill is the user's intent and
+already deleted, and orphaned files stay visible in the ingestion browser.
 
 ### `load_skill` tool (`Zaq.Agent.Tools.Skills.LoadSkill`, key `skills.load_skill`)
 - Returns a skill's full `instructions` as a tool result. **Stateless** — records nothing; the
@@ -310,9 +315,8 @@ volume counts grow.
   arrives with the deferred fork bump, Part 2 M0), and even that one resolves globally and leaks
   the catalog. Part 2 M2 adopts upstream's once it gains caller scoping (upstream U3).
 
-**Skill resources** (`load_skill_resource`, reading bundled `scripts/`/`references/`/`assets/`
-from the ingestion volume) are **Part 2 (M8)** — deferred until a skill ships bundled files. The
-`resource_root` column and its write-time validation exist from Part 1 but are unused until then.
+- Returns the skill's references as a `%RecordPage{}` of unmaterialized records. The model reads
+  one with `download_document`, passing the record's `id` and `attributes.provider`.
 
 ### Runtime Sync (`Zaq.Agent.RuntimeSync`)
 - Owns runtime orchestration after configured-agent, MCP endpoint, and skill mutations.

--- a/lib/zaq/agent/api.ex
+++ b/lib/zaq/agent/api.ex
@@ -23,6 +23,7 @@ defmodule Zaq.Agent.Api do
     PromptGuard,
     RequestRegistry,
     RuntimeSync,
+    Skills,
     Status
   }
 
@@ -55,6 +56,9 @@ defmodule Zaq.Agent.Api do
 
   - `:mcp_endpoint_updated` — delegates to `RuntimeSync.mcp_endpoint_updated/2`.
     Expects `event.request` to be a map with an `:action` key.
+
+  - `:agent_skill_created` — delegates to `Skills.create_skill/1`.
+    Expects `event.request` to carry `:attrs` (map).
 
   - `:agent_skill_updated` — delegates to `RuntimeSync.agent_skill_updated/3`.
     Expects `event.request` to carry `:id` (integer) and `:attrs` (map).
@@ -193,6 +197,18 @@ defmodule Zaq.Agent.Api do
 
       other ->
         invalid_request_response(event, other)
+    end
+  end
+
+  # Creates the skill without a RuntimeSync fan-out — a new skill has no agents attached.
+  def handle_event(%Event{} = event, :agent_skill_created, _context) do
+    case fetch_key(event.request, :attrs) do
+      {:ok, attrs} when is_map(attrs) ->
+        # Not normalized: the BO renders the changeset a failed create returns.
+        %{event | response: Skills.create_skill(attrs)}
+
+      _ ->
+        invalid_request_response(event, event.request)
     end
   end
 

--- a/lib/zaq/agent/skill.ex
+++ b/lib/zaq/agent/skill.ex
@@ -11,8 +11,7 @@ defmodule Zaq.Agent.Skill do
   Field-shape validation against the Open Agent Skills spec (name format, length caps,
   `allowed-tools` encoding) is **owned by `Jido.AI.Skill.Loader`**, reached through
   `Zaq.Agent.Skills.Validation` — ZAQ does not reimplement it. This module keeps only the
-  validations Jido cannot do: that `provided_tool_keys` exist in `Tools.Registry`, and
-  that `resource_root` is a safe relative path.
+  validations Jido cannot do: that `provided_tool_keys` exist in `Tools.Registry`.
 
   ## Two kinds of "tools" — do not conflate them
 
@@ -34,6 +33,7 @@ defmodule Zaq.Agent.Skill do
 
   import Ecto.Changeset
 
+  alias Zaq.Agent.Skill.Resources
   alias Zaq.Agent.Skills.Limits
   alias Zaq.Agent.Skills.Validation
   alias Zaq.Agent.TokenEstimator
@@ -49,7 +49,7 @@ defmodule Zaq.Agent.Skill do
     field :provided_tool_keys, {:array, :string}, default: []
     field :allowed_tools, {:array, :string}, default: []
     field :enabled_mcp_endpoint_ids, {:array, :integer}, default: []
-    field :resource_root, :string
+    field :resources, :map, default: %{}
     field :diagnostics, :map
     field :tags, {:array, :string}, default: []
     field :active, :boolean, default: true
@@ -64,7 +64,7 @@ defmodule Zaq.Agent.Skill do
   # `%Jido.AI.Skill.Spec{}` at all.
   @required_fields ~w(name description body)a
   @optional_fields ~w(tool_keys provided_tool_keys allowed_tools
-                      enabled_mcp_endpoint_ids resource_root tags active)a
+                      enabled_mcp_endpoint_ids resources tags active)a
 
   def changeset(skill, attrs) do
     skill
@@ -75,7 +75,7 @@ defmodule Zaq.Agent.Skill do
     |> normalize_allowed_tools()
     |> normalize_mcp_endpoint_ids()
     |> normalize_tags()
-    |> validate_resource_root()
+    |> validate_resources()
     |> validate_against_spec()
     |> validate_body_size()
     |> unique_constraint(:name)
@@ -132,35 +132,56 @@ defmodule Zaq.Agent.Skill do
     put_change(changeset, :diagnostics, updated)
   end
 
-  # `resource_root` is a path RELATIVE to an ingestion volume. This is a syntactic guard
-  # only — it rejects the shapes that could escape a volume, and nothing more.
-  #
-  # It deliberately does NOT resolve the path against the filesystem. Resolution belongs
-  # to the `:ingestion` role, which is the only node guaranteed to have the volume
-  # mounted (a changeset must not make a cross-service call, and the BO node may not see
-  # the volume at all). `Skill.Resources` re-checks containment at read time, on the
-  # ingestion node, which is the authoritative check.
-  defp validate_resource_root(changeset) do
-    case get_field(changeset, :resource_root) do
-      nil ->
-        changeset
+  # Rejects unknown buckets so a typo cannot silently create one, and rejects entries missing
+  # any of the three keys the BO and `load_skill` both read.
+  defp validate_resources(changeset) do
+    resources = get_field(changeset, :resources) || %{}
 
-      "" ->
-        put_change(changeset, :resource_root, nil)
+    cond do
+      not is_map(resources) ->
+        add_error(changeset, :resources, "must be a map of buckets")
 
-      root when is_binary(root) ->
-        cond do
-          String.starts_with?(root, "/") ->
-            add_error(changeset, :resource_root, "must be relative to an ingestion volume")
+      unknown = Enum.find(Map.keys(resources), &(&1 not in Resources.buckets())) ->
+        add_error(changeset, :resources, "has an unknown bucket: #{unknown}")
 
-          ".." in Path.split(root) ->
-            add_error(changeset, :resource_root, "must not contain \"..\"")
-
-          true ->
-            changeset
-        end
+      true ->
+        Enum.reduce(resources, changeset, &validate_bucket/2)
     end
   end
+
+  defp validate_bucket({bucket, entries}, changeset) when is_list(entries) do
+    max = Limits.get(:resource_max_files)
+
+    cond do
+      length(entries) > max ->
+        add_error(changeset, :resources, "#{bucket} holds more than #{max} files")
+
+      Enum.all?(entries, &valid_resource_entry?/1) ->
+        changeset
+
+      true ->
+        add_error(
+          changeset,
+          :resources,
+          "#{bucket} has an entry missing file_id/file_name/provider"
+        )
+    end
+  end
+
+  defp validate_bucket({bucket, _entries}, changeset) do
+    add_error(changeset, :resources, "#{bucket} must be a list")
+  end
+
+  defp valid_resource_entry?(entry) when is_map(entry) do
+    Enum.all?(Resources.entry_keys(), fn key ->
+      case Map.get(entry, key) do
+        value when is_binary(value) -> String.trim(value) != ""
+        _ -> false
+      end
+    end)
+  end
+
+  defp valid_resource_entry?(_entry), do: false
 
   # Field-shape validation (name format, length caps, allowed-tools encoding) is owned by
   # `Jido.AI.Skill.Loader` via `Validation.validate/1` — ZAQ does not reimplement it. See

--- a/lib/zaq/agent/skill/resources.ex
+++ b/lib/zaq/agent/skill/resources.ex
@@ -1,70 +1,112 @@
 defmodule Zaq.Agent.Skill.Resources do
   @moduledoc """
-  Derives the ingestion-volume paths that hold a skill's reference files.
+  Owns a skill's `resources` map and the volume paths its files are uploaded to.
 
-  A skill's resources live under `.agents/skills/{slug}/references/` on an ingestion
-  volume, so they show up in the BO ingestion browser like any other ingested file and
-  need no separate storage mechanism.
+  `Skill.resources` buckets the documents a skill bundles:
 
-  ## This module is pure
+      %{"references" => [%{"file_id" => "42", "file_name" => "prices.md", "provider" => "disk"}]}
 
-  It derives *path strings* and nothing else. It never touches the filesystem, never
-  resolves against a volume root, and never decides whether a path exists. Resolution and
-  the authoritative containment check belong to the `:ingestion` role — the only node
-  guaranteed to have the volume mounted (see `Zaq.Ingestion.FileExplorer.resolve_path/2`,
-  which re-checks containment against the real volume root). Keeping this separate is
-  what lets the BO node compute a destination for a volume it cannot itself see.
+  `file_id` is a `documents.id`, so reads and deletes go through the data-source bridge for
+  `provider` rather than through a path. Files are uploaded under
+  `.agents/skills/{slug}/references/` so they appear in the ingestion browser like any other
+  ingested file.
 
-  The sanitising here is therefore a *shape* guard, not a security boundary: it
-  guarantees the string handed to ingestion is a safe relative path, so a malicious
-  client filename cannot express an escape in the first place. Ingestion still rejects
-  traversal independently.
-
-  ## `resource_root` is sticky
-
-  Once `Skill.resource_root` is set it wins over the name-derived default, so renaming a
-  skill does not orphan files already uploaded under the old name. A stored root that is
-  not a safe relative path is ignored in favour of the derived one.
+  Path derivation here never touches the filesystem. Ingestion resolves the path against the
+  volume and rejects traversal independently; the sanitising here is a shape guard so a
+  malicious client filename cannot express an escape in the first place.
   """
 
   alias Zaq.Agent.Skill
+  alias Zaq.Contracts.Record
+  alias Zaq.Contracts.RecordPage
 
   @root_prefix ".agents/skills"
-  @references_dir "references"
+  @references "references"
   @fallback_slug "skill"
   @fallback_filename "file"
 
-  @doc """
-  The name-derived resource root for a skill, ignoring any stored `resource_root`.
+  @buckets ~w(references scripts assets)
+  @entry_keys ~w(file_id file_name provider)
 
-      iex> Zaq.Agent.Skill.Resources.default_root(%Zaq.Agent.Skill{name: "pricing-faq"})
-      ".agents/skills/pricing-faq"
-  """
-  @spec default_root(Skill.t()) :: String.t()
-  def default_root(%Skill{name: name}), do: Path.join(@root_prefix, slug(name))
+  @doc "The bucket names `Skill.resources` may hold."
+  @spec buckets() :: [String.t()]
+  def buckets, do: @buckets
 
-  @doc """
-  The skill's effective resource root — everything belonging to this skill lives under it.
+  @doc "The keys every resource entry must carry."
+  @spec entry_keys() :: [String.t()]
+  def entry_keys, do: @entry_keys
 
-  Uses the stored `resource_root` when it is present and safe, else `default_root/1`. This
-  is the directory to remove when a skill is deleted; `references_dir/1` is only one child
-  of it.
-  """
-  @spec root(Skill.t()) :: String.t()
-  def root(%Skill{resource_root: stored} = skill) do
-    case sanitize_root(stored) do
-      nil -> default_root(skill)
-      root -> root
+  @doc "The skill's reference entries, or `[]` when it has none."
+  @spec references(Skill.t()) :: [map()]
+  def references(%Skill{resources: resources}) when is_map(resources) do
+    case Map.get(resources, @references) do
+      entries when is_list(entries) -> entries
+      _ -> []
     end
   end
 
-  @doc """
-  The directory holding a skill's reference files.
+  def references(%Skill{}), do: []
 
-  Uses the stored `resource_root` when it is present and safe, else `default_root/1`.
+  @doc "Appends entries to the skill's references bucket. Appending none changes nothing."
+  @spec add_references(Skill.t(), [map()]) :: map()
+  def add_references(%Skill{resources: resources}, []), do: resources || %{}
+
+  def add_references(%Skill{} = skill, entries) when is_list(entries) do
+    put_references(skill, references(skill) ++ entries)
+  end
+
+  @doc "Drops the reference entry naming `file_id`."
+  @spec remove_reference(Skill.t(), String.t()) :: map()
+  def remove_reference(%Skill{} = skill, file_id) do
+    put_references(skill, Enum.reject(references(skill), &(&1["file_id"] == file_id)))
+  end
+
+  @doc "Builds a reference entry from a record written by a data-source bridge."
+  @spec entry(String.t(), String.t(), String.t()) :: map()
+  def entry(file_id, file_name, provider) do
+    %{"file_id" => to_string(file_id), "file_name" => file_name, "provider" => provider}
+  end
+
+  @doc """
+  The skill's references as unmaterialized records, for `load_skill` to hand the model.
+
+  Records carry metadata only. A caller that wants the bytes calls the `download_document`
+  tool with the record's `id` and `attributes["provider"]`.
+  """
+  @spec record_page(Skill.t()) :: RecordPage.t()
+  def record_page(%Skill{} = skill) do
+    records = skill |> references() |> Enum.map(&to_record/1)
+
+    %RecordPage{
+      resource_type: :item,
+      records: records,
+      stats: %{scanned: length(records), returned: length(records)}
+    }
+  end
+
+  defp to_record(%{"file_id" => id, "file_name" => name, "provider" => provider}) do
+    %Record{
+      id: id,
+      kind: :file,
+      name: name,
+      mime_type: MIME.from_path(name),
+      attributes: %{"provider" => provider}
+    }
+  end
+
+  defp put_references(%Skill{resources: resources}, entries) do
+    Map.put(resources || %{}, @references, entries)
+  end
+
+  @doc """
+  The directory a skill's reference files are uploaded to, relative to an ingestion volume.
+
+      iex> Zaq.Agent.Skill.Resources.references_dir(%Zaq.Agent.Skill{name: "pricing-faq"})
+      ".agents/skills/pricing-faq/references"
   """
   @spec references_dir(Skill.t()) :: String.t()
-  def references_dir(%Skill{} = skill), do: Path.join(root(skill), @references_dir)
+  def references_dir(%Skill{name: name}),
+    do: Path.join([@root_prefix, slug(name), @references])
 
   @doc """
   The destination path for an uploaded file, relative to an ingestion volume.
@@ -81,13 +123,7 @@ defmodule Zaq.Agent.Skill.Resources do
     Path.join(references_dir(skill), safe_filename(filename))
   end
 
-  @doc """
-  Normalises a skill name into a path-safe slug.
-
-  Jido already constrains `Skill.name` to `~r/^[a-z0-9]+(-[a-z0-9]+)*$/`, so for any
-  persisted skill this is the identity. It stays as a defensive normaliser: this module
-  builds filesystem paths and must not depend on a validation living in another layer.
-  """
+  @doc "Normalises a skill name into a path-safe slug."
   @spec slug(String.t() | nil) :: String.t()
   def slug(name) when is_binary(name) do
     name
@@ -104,25 +140,7 @@ defmodule Zaq.Agent.Skill.Resources do
 
   def slug(_), do: @fallback_slug
 
-  # A stored root is honoured only if it is a safe relative path. The `Skill` changeset
-  # already rejects absolute paths and `..`, so this is belt-and-braces for records
-  # written before that validation, or by a future import path.
-  defp sanitize_root(root) when is_binary(root) do
-    trimmed = String.trim(root)
-
-    cond do
-      trimmed == "" -> nil
-      String.starts_with?(trimmed, "/") -> nil
-      ".." in Path.split(trimmed) -> nil
-      true -> Path.join(Path.split(trimmed))
-    end
-  end
-
-  defp sanitize_root(_), do: nil
-
-  # `Path.basename/1` collapses any directory component, so "a/b/c.md", "../../c.md" and
-  # "/etc/c.md" all reduce to "c.md". What it cannot collapse — ".", ".." and "/" — is
-  # replaced outright rather than passed through as a directory-shaped name.
+  # `Path.basename/1` collapses directory components; what it cannot collapse is replaced.
   defp safe_filename(filename) when is_binary(filename) do
     case Path.basename(filename) do
       basename when basename in ["", ".", "..", "/"] -> @fallback_filename

--- a/lib/zaq/agent/tools/resources/registry.ex
+++ b/lib/zaq/agent/tools/resources/registry.ex
@@ -48,7 +48,7 @@ defmodule Zaq.Agent.Tools.Resources.Registry do
       module: Zaq.Agent.Skill,
       public?: true,
       fields:
-        ~w(id name description provided_tool_keys allowed_tools enabled_mcp_endpoint_ids resource_root tags active inserted_at updated_at)a,
+        ~w(id name description provided_tool_keys allowed_tools enabled_mcp_endpoint_ids tags active inserted_at updated_at)a,
       search_fields: ~w(name description tags)a,
       filter_fields: ~w(active provided_tool_keys allowed_tools enabled_mcp_endpoint_ids tags)a,
       sort_fields: ~w(id name active inserted_at updated_at)a,

--- a/lib/zaq/agent/tools/skills/load_skill.ex
+++ b/lib/zaq/agent/tools/skills/load_skill.ex
@@ -35,6 +35,9 @@ defmodule Zaq.Agent.Tools.Skills.LoadSkill do
     Load the full instructions for one of your available skills, by name. The system prompt
     lists each skill's name and what it is for; call this to read a skill's actual
     instructions before following it. Pass the exact skill name from the list.
+
+    The result also lists the skill's reference files. They arrive as metadata only — read
+    one with `download_document`, passing the record's `id` and `attributes.provider`.
     """,
     schema: [
       name: [type: :string, required: true, doc: "The exact name of the skill to load."]
@@ -43,14 +46,17 @@ defmodule Zaq.Agent.Tools.Skills.LoadSkill do
       name: [type: :string, required: true, doc: "The loaded skill's name."],
       instructions: [type: :string, required: true, doc: "The skill's full instructions."],
       resources: [
-        type: {:list, :any},
+        type: :any,
         required: false,
-        doc: "Resource files the skill bundles, loadable on demand (always [] in Part 1; Part 2)."
+        doc:
+          "The skill's reference files as unmaterialized records. Call `download_document` " <>
+            "with a record's `id` and `attributes.provider` to read one."
       ]
     ]
 
   alias Zaq.Agent
   alias Zaq.Agent.ConfiguredAgent
+  alias Zaq.Agent.Skill.Resources
   alias Zaq.Agent.Skills
   alias Zaq.Agent.TokenEstimator
 
@@ -66,9 +72,7 @@ defmodule Zaq.Agent.Tools.Skills.LoadSkill do
        %{
          name: skill.name,
          instructions: skill.body,
-         # Resource loading is Part 2 (§ M8). The key is present now so the tool's output
-         # shape stays stable when resources land — adding them is non-breaking.
-         resources: []
+         resources: Resources.record_page(skill)
        }}
     end
   end

--- a/lib/zaq/channels/disk_bridge.ex
+++ b/lib/zaq/channels/disk_bridge.ex
@@ -53,8 +53,9 @@ defmodule Zaq.Channels.DiskBridge do
   Writes a file onto a volume and registers its document row.
 
   `path` is the destination directory and carries the volume; `name` is the file. Binary
-  content travels base64-encoded under `encoding`. Ingestion owns which volumes are mounted,
-  so it validates the destination rather than this bridge.
+  content travels base64-encoded under `encoding`, and `tags` are written onto the document
+  row. Ingestion owns which volumes are mounted, so it validates the destination rather than
+  this bridge.
   """
   @impl true
   def create_file(config, params) when is_map(config) and is_map(params) do
@@ -235,7 +236,8 @@ defmodule Zaq.Channels.DiskBridge do
       "name" => fetch(params, "name"),
       "path" => fetch(params, "path"),
       "content" => fetch(params, "content") || "",
-      "encoding" => fetch(params, "encoding")
+      "encoding" => fetch(params, "encoding"),
+      "tags" => fetch(params, "tags") || []
     }
   end
 

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -456,9 +456,17 @@ defmodule Zaq.Ingestion do
          {:ok, content} <- decode_content(request),
          dest = dir |> Path.join(name) |> SourcePath.normalize_relative(),
          {:ok, absolute_path} <- upload_file(volume_name, dest, content),
-         {:ok, %Document{} = document} <- track_upload(volume_name, absolute_path),
+         {:ok, %Document{} = document} <-
+           track_upload(volume_name, absolute_path, request_tags(request)),
          {:ok, entry} <- describe_document(document) do
       {:ok, %{status: "created", entry: entry}}
+    end
+  end
+
+  defp request_tags(request) do
+    case MapUtils.present_value(request, "tags") do
+      tags when is_list(tags) -> Enum.filter(tags, &is_binary/1)
+      _ -> []
     end
   end
 
@@ -592,7 +600,9 @@ defmodule Zaq.Ingestion do
        files_count: length(sources),
        folders_count: length(folders),
        principals_count: count_principals(),
-       root_folders: FileExplorer.list_volumes() |> Map.keys() |> Enum.sort()
+       root_folders: FileExplorer.list_volumes() |> Map.keys() |> Enum.sort(),
+       # `root_folders` synthesizes a "default" entry, so it cannot answer this.
+       volumes_configured?: FileExplorer.volumes_configured?()
      }}
   end
 
@@ -1024,12 +1034,14 @@ defmodule Zaq.Ingestion do
   end
 
   @doc """
-  Records a newly uploaded file in the documents table.
+  Records a newly uploaded file in the documents table, optionally tagged.
   Called immediately at upload time so the file browser sees it right away.
   """
-  def track_upload(_volume_name, path) do
+  def track_upload(volume_name, path, tags \\ [])
+
+  def track_upload(_volume_name, path, tags) when is_list(tags) do
     {:ok, source} = SourcePath.absolute_to_source(path)
-    Document.insert_new(%{source: source})
+    Document.insert_new(%{source: source, tags: tags})
   end
 
   def delete_path(volume_name, path, type, volumes \\ nil) do

--- a/lib/zaq_web/components/design_system/modal_upload.ex
+++ b/lib/zaq_web/components/design_system/modal_upload.ex
@@ -53,9 +53,9 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
   attr :folder_drop_skipped, :list, default: []
 
   # Optional volume picker.
-  attr :volumes, :map,
+  attr :volumes, :any,
     default: %{},
-    doc: "`%{name => abs_path}`. The picker appears only with more than one entry."
+    doc: "`%{name => abs_path}` or a list of names. The picker appears above one entry."
 
   attr :current_volume, :string, default: nil
   attr :volume_event, :string, default: "select_volume"
@@ -210,7 +210,9 @@ defmodule ZaqWeb.Components.DesignSystem.ModalUpload do
   end
 
   # `Map.keys/1` ordering is not guaranteed, so sort for a stable picker across renders.
-  defp volume_options(volumes) when is_map(volumes) do
-    volumes |> Map.keys() |> Enum.sort() |> Enum.map(&{&1, &1})
+  defp volume_options(volumes) when is_map(volumes), do: volume_options(Map.keys(volumes))
+
+  defp volume_options(volumes) when is_list(volumes) do
+    volumes |> Enum.sort() |> Enum.map(&{&1, &1})
   end
 end

--- a/lib/zaq_web/live/bo/ai/skills_live.ex
+++ b/lib/zaq_web/live/bo/ai/skills_live.ex
@@ -10,16 +10,13 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
 
   ## Skill resources
 
-  A skill's reference files are uploaded here but stored by **ingestion**, under
-  `.agents/skills/{slug}/references/` on a volume — so they appear in the ingestion
-  browser like any other file and need no separate storage. Every filesystem hop goes
-  through `NodeRouter` to the `:ingestion` role: the BO node is not guaranteed to have
-  the volume mounted. Path derivation is `Zaq.Agent.Skill.Resources`' job, not this
-  module's.
+  Reference files are uploaded through the `"disk"` data-source bridge on the `:channels`
+  role, which writes them under `.agents/skills/{slug}/references/` on an ingestion volume
+  and registers a document row tagged `"public"`. The document id is recorded in
+  `Skill.resources`, so listing and deleting resolve by id rather than by path.
 
-  Uploading requires an explicitly configured volume (`Ingestion.volumes_configured?/0`),
-  not merely a non-empty `list_volumes/0` — that call synthesizes a `"default"` entry and
-  can never be empty.
+  Uploads stage in the LiveView's buffer and are written by `save_skill/2`, whether the
+  skill is being created or edited.
   """
 
   use ZaqWeb, :live_view
@@ -36,7 +33,6 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
   alias Zaq.Agent.Skills.Limits
   alias Zaq.Agent.Tools.Registry
   alias Zaq.Event
-  alias Zaq.Ingestion
   alias Zaq.NodeRouter
   alias ZaqWeb.Components.DesignSystem.Button, as: DSButton
   alias ZaqWeb.Components.DesignSystem.ModalUpload
@@ -47,6 +43,11 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
   # Narrower than IngestionLive's list on purpose: skill resources are reference material
   # the agent reads, so only the formats that make sense in that role are accepted.
   @allowed_extensions ~w(.json .md .pdf .png)
+
+  @provider "disk"
+
+  # Public so an agent granted the skill can read the file back through `download_document`.
+  @resource_tags ["public"]
 
   @impl true
   def mount(_params, _session, socket) do
@@ -164,8 +165,8 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
   end
 
   def handle_event("select_resource_volume", %{"volume" => volume}, socket) do
-    if Map.has_key?(socket.assigns.volumes, volume) do
-      {:noreply, socket |> assign(:resource_volume, volume) |> load_skill_resources()}
+    if volume in socket.assigns.volumes do
+      {:noreply, assign(socket, :resource_volume, volume)}
     else
       {:noreply, socket}
     end
@@ -177,43 +178,22 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
     {:noreply, cancel_upload(socket, :skill_resources, ref)}
   end
 
-  # On a skill that does not exist yet there is nowhere to write: leave the entries in the
-  # LiveView's upload buffer and close the modal. They are written by `save_skill/2` once
-  # the record — and therefore the destination path — exists. Phoenix garbage-collects
-  # unconsumed entries if this LiveView dies, so abandoning the form leaves nothing behind.
-  def handle_event("upload_skill_resource", _params, %{assigns: %{mode: :new}} = socket) do
+  # Stages only — `save_skill/2` writes the entries.
+  def handle_event("upload_skill_resource", _params, socket) do
     {:noreply, assign(socket, :resource_modal, nil)}
   end
 
-  def handle_event(
-        "upload_skill_resource",
-        _params,
-        %{assigns: %{mode: :edit, selected_skill: %Skill{} = skill}} = socket
-      ) do
-    if Enum.all?(socket.assigns.uploads.skill_resources.entries, &(&1.progress == 100)) do
-      volume = socket.assigns.resource_volume
+  def handle_event("remove_skill_resource", %{"file_id" => file_id}, socket) do
+    %Skill{} = skill = socket.assigns.selected_skill
 
-      results =
-        consume_uploaded_entries(socket, :skill_resources, fn %{path: tmp_path}, entry ->
-          {:ok, upload_resource(skill, volume, tmp_path, entry)}
-        end)
+    case delete_resource(skill, file_id) do
+      :ok ->
+        {:noreply, persist_resources(socket, skill, Resources.remove_reference(skill, file_id))}
 
-      {uploaded, failed} = Enum.split_with(results, &match?({:ok, _}, &1))
-
-      socket =
-        socket
-        |> maybe_persist_resource_root(skill, uploaded)
-        |> load_skill_resources()
-        |> put_resource_upload_toast(uploaded, failed)
-        |> maybe_close_resource_modal(uploaded, failed)
-
-      {:noreply, socket}
-    else
-      {:noreply, socket}
+      {:error, reason} ->
+        {:noreply, put_toast(socket, :error, "Could not remove the file: #{inspect(reason)}")}
     end
   end
-
-  def handle_event("upload_skill_resource", _params, socket), do: {:noreply, socket}
 
   def handle_event("open_tools_picker", _params, socket) do
     {:noreply, assign(socket, :tools_picker_open, true)}
@@ -283,17 +263,15 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
 
   def handle_event("delete_skill", %{"id" => id}, socket) do
     skill_id = String.to_integer(id)
-    # Read the skill before deleting it: its resource root is derived from fields that are
-    # gone once the record is.
+    # Read before deleting: the entries naming its documents are gone with the record.
     skill = Skills.get_skill(skill_id)
-
     event = Event.new(%{id: skill_id}, :agent, opts: [action: :agent_skill_deleted])
 
     case node_router().dispatch(event).response do
       {:ok, _payload} ->
         socket =
           socket
-          |> put_delete_flash(delete_skill_resources(socket, skill))
+          |> put_delete_flash(delete_skill_resources(skill))
           |> reset_form()
           |> refresh_skills()
 
@@ -305,15 +283,7 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
   end
 
   defp save_skill(%{assigns: %{mode: :new}} = socket, attrs) do
-    # Creation dispatches straight to `Skills.create_skill/1` via `:invoke` rather
-    # than through `RuntimeSync` (as update/delete do): a brand-new skill has no
-    # agent references yet, so there is nothing to fan out to live agent servers.
-    # Runtime propagation only becomes relevant once the skill is attached to an
-    # agent, which happens through the agent form's own sync path.
-    event =
-      Event.new(%{module: Skills, function: :create_skill, args: [attrs]}, :agent,
-        opts: [action: :invoke]
-      )
+    event = Event.new(%{attrs: attrs}, :agent, opts: [action: :agent_skill_created])
 
     case node_router().dispatch(event).response do
       {:ok, %Skill{} = skill} ->
@@ -321,11 +291,9 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
         # written here, against the name as *saved* — not the one typed at staging time.
         {uploaded, failed} = flush_staged_resources(socket, skill)
 
-        # The drawer closes on create, so the flash — not the resources table — is what
-        # reports whether the staged files made it to the volume.
         socket =
           socket
-          |> maybe_persist_resource_root(skill, uploaded)
+          |> persist_resources(skill, Resources.add_references(skill, uploaded))
           |> put_create_flash(uploaded, failed)
           |> reset_form_state()
           |> refresh_skills()
@@ -341,14 +309,15 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
   end
 
   defp save_skill(%{assigns: %{mode: :edit, selected_skill: %Skill{} = skill}} = socket, attrs) do
-    event =
-      Event.new(%{id: skill.id, attrs: attrs}, :agent, opts: [action: :agent_skill_updated])
+    {uploaded, failed} = flush_staged_resources(socket, skill)
+    attrs = Map.put(attrs, "resources", Resources.add_references(skill, uploaded))
+    event = Event.new(%{id: skill.id, attrs: attrs}, :agent, opts: [action: :agent_skill_updated])
 
     case node_router().dispatch(event).response do
       {:ok, %{skill: updated}} ->
         socket =
           socket
-          |> put_flash(:info, "Skill saved")
+          |> put_save_flash(uploaded, failed)
           |> assign(:selected_skill, updated)
           |> assign(:form_tool_keys, updated.tool_keys || [])
           |> assign(:form_mcp_endpoint_ids, updated.enabled_mcp_endpoint_ids || [])
@@ -409,22 +378,21 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
   # ── Skill resources ─────────────────────────────────────────────
 
   defp assign_volumes(socket) do
-    volumes =
-      case ingestion_invoke(:list_volumes, []) do
-        volumes when is_map(volumes) -> volumes
-        _ -> %{}
-      end
+    stats = channel_stats()
+    volumes = Map.get(stats, :root_folders, [])
 
     socket
     |> assign(:volumes, volumes)
-    |> assign(:volumes_connected?, ingestion_invoke(:volumes_configured?, []) == true)
-    |> assign(:resource_volume, default_volume(volumes))
+    |> assign(:volumes_connected?, Map.get(stats, :volumes_configured?, false) == true)
+    |> assign(:resource_volume, List.first(volumes))
   end
 
-  # `Map.keys/1` ordering is not guaranteed, so sort rather than take whichever key the
-  # map happens to yield first — otherwise the preselected volume could differ per node.
-  defp default_volume(volumes) do
-    volumes |> Map.keys() |> Enum.sort() |> List.first()
+  # A degraded ingestion role yields no volumes, which the modal renders as "connect a volume".
+  defp channel_stats do
+    case data_source_dispatch(:data_source_channel_stats, %{}) do
+      {:ok, stats} when is_map(stats) -> stats
+      _ -> %{}
+    end
   end
 
   # Resources need a destination, and the destination needs a name. A saved skill always
@@ -442,8 +410,8 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
   defp resource_target(%{mode: :edit, selected_skill: %Skill{} = skill}), do: skill
   defp resource_target(%{form: form}), do: %Skill{name: form[:name].value}
 
-  # Writes entries staged while the skill did not exist. Returns the `{uploaded, failed}`
-  # split so the caller can both flash and decide whether to persist `resource_root`.
+  # Writes the staged entries against the skill as saved. Returns `{uploaded, failed}` —
+  # `uploaded` are resource entries ready to append to the skill's references bucket.
   defp flush_staged_resources(socket, %Skill{} = skill) do
     volume = socket.assigns.resource_volume
     entries = socket.assigns.uploads.skill_resources.entries
@@ -454,50 +422,68 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
         {:ok, upload_resource(skill, volume, tmp_path, entry)}
       end)
       |> Enum.split_with(&match?({:ok, _}, &1))
+      |> then(fn {uploaded, failed} -> {Enum.map(uploaded, &elem(&1, 1)), failed} end)
     else
       {[], []}
     end
   end
 
-  defp put_create_flash(socket, [], []), do: put_flash(socket, :info, "Skill created")
-
-  defp put_create_flash(socket, uploaded, []) do
-    put_flash(socket, :info, "Skill created with #{length(uploaded)} resource(s).")
-  end
-
-  defp put_create_flash(socket, uploaded, failed) do
-    put_flash(
-      socket,
-      :error,
-      "Skill created with #{length(uploaded)} resource(s). " <>
-        "#{length(failed)} could not be uploaded."
-    )
-  end
-
-  defp upload_resource(skill, volume, tmp_path, entry) do
-    destination = Resources.destination(skill, entry.client_name)
-
-    # Both failure shapes are already `{:error, reason}`, so they fall through as-is.
+  # Uploads one file and returns the entry naming the document it created.
+  defp upload_resource(%Skill{} = skill, volume, tmp_path, entry) do
     with {:ok, binary} <- File.read(tmp_path),
-         {:ok, written} <- ingestion_invoke(:upload_file, [volume, destination, binary]) do
-      # Same as IngestionLive: track immediately so the file browser sees the file
-      # without waiting for a filesystem watcher.
-      ingestion_invoke(:track_upload, [volume, written])
-      {:ok, written}
+         {:ok, %{record: record}} <- create_file(skill, volume, binary, entry.client_name) do
+      {:ok, Resources.entry(record.id, record.name, @provider)}
     end
   end
 
-  # Written once, on the first successful upload, and never recomputed — a later rename
-  # must not strand files already sitting under the original root.
-  defp maybe_persist_resource_root(socket, %Skill{resource_root: nil} = skill, [_ | _]) do
-    attrs = %{"resource_root" => Resources.default_root(skill)}
-    event = Event.new(%{id: skill.id, attrs: attrs}, :agent, opts: [action: :agent_skill_updated])
+  defp create_file(%Skill{} = skill, volume, binary, filename) do
+    params = %{
+      "path" => Path.join(volume, Resources.references_dir(skill)),
+      "name" => Path.basename(Resources.destination(skill, filename)),
+      "content" => Base.encode64(binary),
+      "encoding" => "base64",
+      "tags" => @resource_tags
+    }
+
+    data_source_dispatch(:data_source_create_file, params)
+  end
+
+  defp delete_resource(%Skill{} = skill, file_id) do
+    case Enum.find(Resources.references(skill), &(&1["file_id"] == file_id)) do
+      nil -> {:error, :not_found}
+      entry -> file_id |> delete_file(entry["provider"]) |> normalize_delete()
+    end
+  end
+
+  defp delete_file(file_id, provider) do
+    data_source_dispatch(:data_source_delete_file, %{"file_id" => file_id}, provider)
+  end
+
+  defp normalize_delete({:ok, _payload}), do: :ok
+  defp normalize_delete(other), do: other
+
+  # Removes every document the skill recorded. Runs after the record is deleted.
+  defp delete_skill_resources(nil), do: []
+
+  defp delete_skill_resources(%Skill{} = skill) do
+    skill
+    |> Resources.references()
+    |> Enum.map(&(&1["file_id"] |> delete_file(&1["provider"]) |> normalize_delete()))
+    |> Enum.reject(&(&1 == :ok))
+  end
+
+  # Writes the resources map back onto the skill and refreshes what the drawer renders from.
+  defp persist_resources(socket, %Skill{} = skill, resources) do
+    event =
+      Event.new(%{id: skill.id, attrs: %{"resources" => resources}}, :agent,
+        opts: [action: :agent_skill_updated]
+      )
 
     case node_router().dispatch(event).response do
       {:ok, %{skill: updated}} ->
         socket
         |> assign(:selected_skill, updated)
-        |> assign_changeset(Skills.change_skill(updated))
+        |> assign(:skill_resources, Resources.references(updated))
         |> refresh_skills()
 
       _ ->
@@ -505,25 +491,10 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
     end
   end
 
-  defp maybe_persist_resource_root(socket, _skill, _uploaded), do: socket
-
-  defp load_skill_resources(
-         %{assigns: %{selected_skill: %Skill{} = skill, resource_volume: volume}} = socket
-       )
-       when is_binary(volume) do
-    entries =
-      case ingestion_invoke(:list_entries, [volume, references_dir(skill)]) do
-        {:ok, entries} when is_list(entries) -> Enum.filter(entries, &(&1.type == :file))
-        # A skill with no uploads yet has no directory — that is the empty state, not an error.
-        _ -> []
-      end
-
-    assign(socket, :skill_resources, entries)
+  defp load_skill_resources(%{assigns: %{selected_skill: %Skill{} = skill}} = socket) do
+    assign(socket, :skill_resources, Resources.references(skill))
   end
 
-  # No skill selected, or no volume to read from (nothing configured, or the ingestion node
-  # did not answer). `FileExplorer.list/2` requires a binary volume, so guard rather than
-  # let a degraded ingestion role crash the page.
   defp load_skill_resources(socket), do: assign(socket, :skill_resources, [])
 
   defp references_dir(%Skill{} = skill), do: Resources.references_dir(skill)
@@ -544,99 +515,57 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLive do
     "#{extensions} — max #{max}"
   end
 
-  # Removes a deleted skill's whole resource directory — `.agents/skills/{slug}`, not just
-  # its `references/` child.
-  #
-  # The volume is swept rather than looked up: the upload modal lets the operator choose a
-  # volume, but only the volume-relative `resource_root` is persisted, so which volume
-  # holds the files is not recoverable from the skill. Sweeping is safe because the root is
-  # namespaced per skill, and volumes without the directory are skipped.
-  #
-  # Runs *after* the record is deleted. If it fails, the skill is still gone and the files
-  # remain visible in the ingestion browser — recoverable. The reverse order could strip a
-  # live skill's resources when the record deletion then failed.
-  defp delete_skill_resources(_socket, nil), do: []
+  defp put_create_flash(socket, [], []), do: put_flash(socket, :info, "Skill created")
 
-  defp delete_skill_resources(socket, %Skill{} = skill) do
-    root = Resources.root(skill)
-
-    socket.assigns.volumes
-    |> Map.keys()
-    |> Enum.map(&delete_resource_dir(&1, root))
-    |> Enum.reject(&(&1 == :absent))
+  defp put_create_flash(socket, uploaded, []) do
+    put_flash(socket, :info, "Skill created with #{length(uploaded)} resource(s).")
   end
 
-  # A skill that never had a resource uploaded has no directory. `delete_path/3` surfaces
-  # `{:error, :not_a_directory}` for a missing path, so check before asking.
-  defp delete_resource_dir(volume, root) do
-    case ingestion_invoke(:file_info, [volume, root]) do
-      {:ok, %{type: :directory}} ->
-        # `delete_path/4` also clears the tracked `Document` rows under the folder, which
-        # `track_upload/2` created at upload time.
-        ingestion_invoke(:delete_path, [volume, root, "directory"])
-
-      _ ->
-        :absent
-    end
+  defp put_create_flash(socket, uploaded, failed) do
+    put_flash(
+      socket,
+      :error,
+      "Skill created with #{length(uploaded)} resource(s). " <>
+        "#{length(failed)} could not be uploaded."
+    )
   end
 
-  defp put_delete_flash(socket, results) do
-    case Enum.reject(results, &(&1 == :ok)) do
-      [] ->
-        put_flash(socket, :info, "Skill deleted")
+  # An overlay toast, not a BOLayout flash — the drawer stays open on save.
+  defp put_save_flash(socket, [], []), do: put_toast(socket, :info, "Skill saved")
 
-      errors ->
-        put_flash(
-          socket,
-          :error,
-          "Skill deleted, but its resources could not be removed: #{inspect(errors)}"
-        )
-    end
+  defp put_save_flash(socket, uploaded, []) do
+    put_toast(socket, :info, "Skill saved with #{length(uploaded)} resource(s) added.")
   end
 
-  # An overlay toast, not a BOLayout flash: resources are added with the skill drawer open,
-  # and the inline banner renders behind it (`--zaq-z-overlay` outranks the page content).
-  # Same reason the ingestion jobs drawer reports through `#ingest-toast`.
-  defp put_resource_upload_toast(socket, [], []), do: socket
-
-  defp put_resource_upload_toast(socket, uploaded, []) do
-    put_toast(socket, :info, "#{length(uploaded)} resource(s) added.")
+  defp put_save_flash(socket, uploaded, failed) do
+    put_toast(
+      socket,
+      :error,
+      "Skill saved with #{length(uploaded)} resource(s) added. " <>
+        "#{length(failed)} could not be uploaded."
+    )
   end
 
-  defp put_resource_upload_toast(socket, [], failed) do
-    put_toast(socket, :error, "Upload failed: #{upload_failure_reasons(failed)}")
-  end
+  defp put_delete_flash(socket, []), do: put_flash(socket, :info, "Skill deleted")
 
-  defp put_resource_upload_toast(socket, uploaded, failed) do
-    put_toast(socket, :info, "#{length(uploaded)} resource(s) added. #{length(failed)} failed.")
+  defp put_delete_flash(socket, errors) do
+    put_flash(
+      socket,
+      :error,
+      "Skill deleted, but its resources could not be removed: #{inspect(errors)}"
+    )
   end
 
   defp put_toast(socket, kind, message) do
     assign(socket, :upload_toast, %{kind: kind, message: message})
   end
 
-  defp upload_failure_reasons(failed) do
-    failed
-    |> Enum.map(fn {:error, reason} -> inspect(reason) end)
-    |> Enum.uniq()
-    |> Enum.join(", ")
-  end
-
-  defp maybe_close_resource_modal(socket, uploaded, failed) do
-    if uploaded != [] and failed == [] do
-      assign(socket, :resource_modal, nil)
-    else
-      socket
-    end
-  end
-
-  defp ingestion_invoke(fun, args) do
-    event =
-      Event.new(%{module: Ingestion, function: fun, args: args}, :ingestion,
-        opts: [action: :invoke]
-      )
-
-    node_router().dispatch(event).response
+  # Every filesystem hop goes through the disk bridge on the channels node.
+  defp data_source_dispatch(action, params, provider \\ @provider) do
+    %{provider: provider, params: params}
+    |> Event.new(:channels, opts: [action: action])
+    |> node_router().dispatch()
+    |> Map.fetch!(:response)
   end
 
   defp form_base_skill(%{assigns: %{mode: :edit, selected_skill: %Skill{} = skill}}), do: skill

--- a/lib/zaq_web/live/bo/ai/skills_live.html.heex
+++ b/lib/zaq_web/live/bo/ai/skills_live.html.heex
@@ -319,8 +319,8 @@
           <:head>
             <DSTable.table_head_row>
               <DSTable.table_cell element={:th}>File</DSTable.table_cell>
-              <DSTable.table_cell element={:th}>Size</DSTable.table_cell>
-              <DSTable.table_cell element={:th}>Modified</DSTable.table_cell>
+              <DSTable.table_cell element={:th}>Status</DSTable.table_cell>
+              <DSTable.table_cell element={:th}></DSTable.table_cell>
             </DSTable.table_head_row>
           </:head>
           <:body>
@@ -330,34 +330,48 @@
             >
               No resources yet.
             </DSTable.table_empty>
-            <%!-- Staged: uploaded to the server but not yet written to a volume, because
-                  the skill has no destination until it is saved. --%>
+            <%!-- Staged: held in the upload buffer until the skill is saved. --%>
             <DSTable.table_row :for={entry <- @uploads.skill_resources.entries}>
               <DSTable.table_cell>
                 <DSTable.table_text label={entry.client_name} />
               </DSTable.table_cell>
               <DSTable.table_cell>
-                <DSTable.table_text
-                  label={ZaqWeb.Helpers.SizeFormat.format_size(entry.client_size)}
-                  tone={:secondary}
-                />
+                <span class="zaq-pill zaq-text-caption zaq-pill--elevated">
+                  Pending save
+                </span>
               </DSTable.table_cell>
               <DSTable.table_cell>
-                <span class="zaq-pill zaq-text-caption zaq-pill--elevated">Pending</span>
+                <DSButton.button
+                  variant={:ghost}
+                  type="button"
+                  icon_only
+                  aria-label={"Remove #{entry.client_name}"}
+                  phx-click="cancel_skill_resource"
+                  phx-value-ref={entry.ref}
+                >
+                  <.icon name="hero-x-mark" class="zaq-icon-sm" />
+                </DSButton.button>
               </DSTable.table_cell>
             </DSTable.table_row>
             <DSTable.table_row :for={resource <- @skill_resources}>
               <DSTable.table_cell>
-                <DSTable.table_text label={resource.name} />
+                <DSTable.table_text label={resource["file_name"]} />
               </DSTable.table_cell>
               <DSTable.table_cell>
-                <DSTable.table_text
-                  label={ZaqWeb.Helpers.SizeFormat.format_size(resource.size)}
-                  tone={:secondary}
-                />
+                <DSTable.table_text label={resource["provider"]} tone={:secondary} />
               </DSTable.table_cell>
               <DSTable.table_cell>
-                <DSTable.table_datetime value={resource.modified_at} />
+                <DSButton.button
+                  variant={:ghost}
+                  type="button"
+                  icon_only
+                  aria-label={"Remove #{resource["file_name"]}"}
+                  phx-click="remove_skill_resource"
+                  phx-value-file_id={resource["file_id"]}
+                  data-confirm="Remove this file? It is deleted from the volume."
+                >
+                  <.icon name="hero-trash" class="zaq-icon-sm" />
+                </DSButton.button>
               </DSTable.table_cell>
             </DSTable.table_row>
           </:body>
@@ -368,7 +382,7 @@
         >
           {if @mode == :new,
             do: "Name the skill to add resources — they upload when you save.",
-            else: "Reference files, stored on an ingestion volume."}
+            else: "Reference files, uploaded when you save."}
         </p>
       </div>
 

--- a/priv/repo/migrations/20260807000000_replace_skill_resource_root_with_resources.exs
+++ b/priv/repo/migrations/20260807000000_replace_skill_resource_root_with_resources.exs
@@ -1,0 +1,17 @@
+defmodule Zaq.Repo.Migrations.ReplaceSkillResourceRootWithResources do
+  use Ecto.Migration
+
+  def up do
+    alter table(:agent_skills) do
+      remove :resource_root
+      add :resources, :map, null: false, default: %{}
+    end
+  end
+
+  def down do
+    alter table(:agent_skills) do
+      add :resource_root, :string
+      remove :resources
+    end
+  end
+end

--- a/test/zaq/agent/skill/resources_test.exs
+++ b/test/zaq/agent/skill/resources_test.exs
@@ -4,6 +4,7 @@ defmodule Zaq.Agent.Skill.ResourcesTest do
 
   alias Zaq.Agent.Skill
   alias Zaq.Agent.Skill.Resources
+  alias Zaq.Contracts.RecordPage
 
   defp skill(attrs), do: struct(%Skill{name: "calculator"}, attrs)
 
@@ -28,59 +29,124 @@ defmodule Zaq.Agent.Skill.ResourcesTest do
     end
   end
 
-  describe "default_root/1" do
-    test "derives the root from the skill name" do
-      assert Resources.default_root(skill(%{name: "pricing-faq"})) == ".agents/skills/pricing-faq"
+  describe "references/1" do
+    test "returns the entries in the references bucket" do
+      entry = Resources.entry("42", "prices.md", "disk")
+      s = skill(%{resources: %{"references" => [entry]}})
+
+      assert Resources.references(s) == [entry]
     end
 
-    test "ignores any stored resource_root" do
-      s = skill(%{name: "pricing-faq", resource_root: ".agents/skills/old-name"})
-      assert Resources.default_root(s) == ".agents/skills/pricing-faq"
+    test "returns [] when the skill has no resources" do
+      assert Resources.references(skill(%{resources: %{}})) == []
+      assert Resources.references(skill(%{resources: nil})) == []
+    end
+
+    test "returns [] when another bucket is populated" do
+      assert Resources.references(skill(%{resources: %{"scripts" => [%{}]}})) == []
     end
   end
 
-  describe "root/1" do
-    test "derives from the name when no resource_root is stored" do
-      assert Resources.root(skill(%{name: "pricing-faq"})) == ".agents/skills/pricing-faq"
+  describe "add_references/2 and remove_reference/2" do
+    test "appends to an empty skill" do
+      entry = Resources.entry("42", "prices.md", "disk")
+
+      assert Resources.add_references(skill(%{resources: %{}}), [entry]) ==
+               %{"references" => [entry]}
     end
 
-    test "prefers a stored resource_root" do
-      s = skill(%{name: "new-name", resource_root: ".agents/skills/old-name"})
-      assert Resources.root(s) == ".agents/skills/old-name"
+    test "appends without dropping existing entries or other buckets" do
+      first = Resources.entry("1", "a.md", "disk")
+      second = Resources.entry("2", "b.md", "disk")
+      s = skill(%{resources: %{"references" => [first], "scripts" => []}})
+
+      assert Resources.add_references(s, [second]) ==
+               %{"references" => [first, second], "scripts" => []}
     end
 
-    test "ignores an unsafe stored root" do
-      assert Resources.root(skill(%{name: "s", resource_root: "/etc"})) == ".agents/skills/s"
-      assert Resources.root(skill(%{name: "s", resource_root: "../escape"})) == ".agents/skills/s"
+    test "removes only the entry naming the file_id" do
+      first = Resources.entry("1", "a.md", "disk")
+      second = Resources.entry("2", "b.md", "disk")
+      s = skill(%{resources: %{"references" => [first, second]}})
+
+      assert Resources.remove_reference(s, "1") == %{"references" => [second]}
     end
 
-    test "is the parent of references_dir/1" do
-      # Deleting a skill removes `root/1`; `references_dir/1` is only one child of it.
-      s = skill(%{name: "pricing-faq"})
-      assert Resources.references_dir(s) == Path.join(Resources.root(s), "references")
+    test "removing an absent file_id is a no-op" do
+      entry = Resources.entry("1", "a.md", "disk")
+      s = skill(%{resources: %{"references" => [entry]}})
+
+      assert Resources.remove_reference(s, "999") == %{"references" => [entry]}
+    end
+  end
+
+  describe "entry/3" do
+    test "stringifies a numeric document id" do
+      assert Resources.entry(42, "a.md", "disk")["file_id"] == "42"
+    end
+  end
+
+  describe "record_page/1" do
+    test "maps each reference to an unmaterialized record" do
+      s =
+        skill(%{
+          resources: %{
+            "references" => [
+              Resources.entry("42", "prices.md", "disk"),
+              Resources.entry("43", "chart.png", "gdrive")
+            ]
+          }
+        })
+
+      assert %RecordPage{resource_type: :item, records: [first, second]} =
+               Resources.record_page(s)
+
+      assert first.id == "42"
+      assert first.name == "prices.md"
+      assert first.kind == :file
+      assert first.mime_type == "text/markdown"
+      assert first.attributes == %{"provider" => "disk"}
+      assert second.attributes == %{"provider" => "gdrive"}
+      assert second.mime_type == "image/png"
+    end
+
+    test "never carries content or a materializing event" do
+      s = skill(%{resources: %{"references" => [Resources.entry("1", "a.md", "disk")]}})
+
+      assert %RecordPage{records: [record]} = Resources.record_page(s)
+      assert record.content == nil
+      assert record.materializing_event == nil
+    end
+
+    test "counts what it returned" do
+      s = skill(%{resources: %{"references" => [Resources.entry("1", "a.md", "disk")]}})
+
+      assert %RecordPage{stats: %{scanned: 1, returned: 1}} = Resources.record_page(s)
+    end
+
+    test "is empty for a skill with no references" do
+      assert %RecordPage{records: [], stats: %{returned: 0}} =
+               Resources.record_page(skill(%{resources: %{}}))
+
+      assert %RecordPage{records: []} =
+               Resources.record_page(skill(%{resources: %{"scripts" => []}}))
     end
   end
 
   describe "references_dir/1" do
-    test "uses the default root when resource_root is nil" do
+    test "derives the directory from the skill name" do
       assert Resources.references_dir(skill(%{name: "pricing-faq"})) ==
                ".agents/skills/pricing-faq/references"
     end
 
-    test "uses the default root when resource_root is empty" do
-      assert Resources.references_dir(skill(%{name: "pricing-faq", resource_root: ""})) ==
+    test "follows a rename" do
+      assert Resources.references_dir(skill(%{name: "new-name"})) ==
+               ".agents/skills/new-name/references"
+    end
+
+    test "normalises a name the spec would have rejected" do
+      assert Resources.references_dir(skill(%{name: "Pricing FAQ"})) ==
                ".agents/skills/pricing-faq/references"
-    end
-
-    test "reuses a stored resource_root verbatim, even after a rename" do
-      # The skill was renamed but its files still live under the original root.
-      s = skill(%{name: "new-name", resource_root: ".agents/skills/old-name"})
-      assert Resources.references_dir(s) == ".agents/skills/old-name/references"
-    end
-
-    test "normalises a trailing slash on the stored root" do
-      s = skill(%{name: "x", resource_root: ".agents/skills/old-name/"})
-      assert Resources.references_dir(s) == ".agents/skills/old-name/references"
     end
   end
 
@@ -114,8 +180,6 @@ defmodule Zaq.Agent.Skill.ResourcesTest do
     end
 
     test "preserves spaces and case in the filename itself" do
-      # Only the *path shape* is sanitised — the filename is the operator's to choose,
-      # and the ingestion browser displays it verbatim.
       assert Resources.destination(skill(%{name: "s"}), "Q3 Report.pdf") ==
                ".agents/skills/s/references/Q3 Report.pdf"
     end
@@ -135,19 +199,6 @@ defmodule Zaq.Agent.Skill.ResourcesTest do
         refute String.starts_with?(dest, "/")
         # exactly: .agents, skills, <slug>, references, <file>
         assert length(Path.split(dest)) == 5
-      end
-    end
-
-    property "a stored resource_root still cannot escape" do
-      check all(
-              root <- string(:printable, max_length: 40),
-              filename <- string(:printable, max_length: 40),
-              max_runs: 300
-            ) do
-        dest = Resources.destination(skill(%{name: "s", resource_root: root}), filename)
-
-        refute ".." in Path.split(dest)
-        refute String.starts_with?(dest, "/")
       end
     end
   end

--- a/test/zaq/agent/skill_resources_e2e_test.exs
+++ b/test/zaq/agent/skill_resources_e2e_test.exs
@@ -1,0 +1,209 @@
+defmodule Zaq.Agent.SkillResourcesE2ETest do
+  @moduledoc """
+  The full skill-resource loop: a file written through the disk bridge, recorded on the
+  skill, listed by `load_skill`, and read back by `download_document`.
+
+  Nothing between the tools and ingestion is stubbed — the seam is the point.
+  """
+
+  # async: false — mounts a volume through Application.put_env.
+  use Zaq.DataCase, async: false
+
+  import Zaq.SystemConfigFixtures
+
+  alias Zaq.Agent
+  alias Zaq.Agent.Skill.Resources
+  alias Zaq.Agent.Skills
+  alias Zaq.Agent.Tools.DataSource.DownloadDocument
+  alias Zaq.Agent.Tools.Skills.LoadSkill
+  alias Zaq.Channels.Api, as: ChannelsApi
+  alias Zaq.Contracts.RecordPage
+  alias Zaq.Event
+  alias Zaq.Ingestion
+  alias Zaq.Ingestion.Document
+
+  @volume "documents"
+
+  # Short-circuits the transport only: channels events reach the real Channels API, and the
+  # bridge dispatches on to ingestion from there.
+  defmodule RealRouter do
+    alias Zaq.Channels.Api, as: ChannelsApi
+
+    def dispatch(%{request: %{provider: _, params: _}} = event) do
+      ChannelsApi.handle_event(event, Keyword.fetch!(event.opts, :action), %{})
+    end
+
+    def dispatch(%{request: request} = event) do
+      %{event | response: Ingestion.materialize_record(request)}
+    end
+  end
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "zaq_skill_res_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    original = Application.get_env(:zaq, Zaq.Ingestion)
+
+    Application.put_env(
+      :zaq,
+      Zaq.Ingestion,
+      Keyword.merge(original || [], volumes: %{@volume => root})
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root)
+
+      if is_nil(original),
+        do: Application.delete_env(:zaq, Zaq.Ingestion),
+        else: Application.put_env(:zaq, Zaq.Ingestion, original)
+    end)
+
+    %{root: root}
+  end
+
+  defp skill!(attrs) do
+    {:ok, skill} =
+      Map.merge(
+        %{
+          name: "pricing-faq",
+          description: "Prices and how to quote them.",
+          body: "Follow this."
+        },
+        attrs
+      )
+      |> Skills.create_skill()
+
+    skill
+  end
+
+  defp agent!(skill) do
+    credential =
+      ai_credential_fixture(%{provider: "openai", endpoint: "https://api.openai.com/v1"})
+
+    {:ok, agent} =
+      Agent.create_agent(%{
+        name: "resource-reader-#{System.unique_integer([:positive])}",
+        job: "Read skill references.",
+        model: "gpt-4.1-mini",
+        credential_id: credential.id,
+        strategy: "react",
+        active: true,
+        enabled_skill_ids: [skill.id]
+      })
+
+    agent
+  end
+
+  # Writes through the same bridge call the BO makes.
+  defp upload!(skill, filename, content) do
+    params = %{
+      "path" => Path.join(@volume, Resources.references_dir(skill)),
+      "name" => filename,
+      "content" => Base.encode64(content),
+      "encoding" => "base64",
+      "tags" => ["public"]
+    }
+
+    event =
+      Event.new(%{provider: "disk", params: params}, :channels,
+        opts: [action: :data_source_create_file]
+      )
+
+    {:ok, %{record: record}} =
+      ChannelsApi.handle_event(event, :data_source_create_file, %{}).response
+
+    record
+  end
+
+  defp ctx(agent), do: %{configured_agent_id: agent.id, node_router: RealRouter}
+
+  test "a skill resource survives upload, load_skill, and download_document", %{root: root} do
+    skill = skill!(%{name: "pricing-faq"})
+    record = upload!(skill, "prices.md", "# Q3 prices")
+
+    {:ok, skill} =
+      Skills.update_skill(skill, %{
+        resources:
+          Resources.add_references(skill, [
+            Resources.entry(record.id, record.name, "disk")
+          ])
+      })
+
+    agent = agent!(skill)
+
+    # The file really landed on the volume, tagged public.
+    assert File.read!(Path.join(root, ".agents/skills/pricing-faq/references/prices.md")) ==
+             "# Q3 prices"
+
+    assert "public" in Document.get(record.id).tags
+
+    # load_skill hands the model metadata only.
+    assert {:ok, loaded} = LoadSkill.run(%{name: "pricing-faq"}, ctx(agent))
+    assert %RecordPage{records: [listed]} = loaded.resources
+    assert listed.content == nil
+    assert listed.name == "prices.md"
+
+    # The model materializes it with the id and provider the record named.
+    assert {:ok, %{record: downloaded}} =
+             DownloadDocument.run(
+               %{provider: listed.attributes["provider"], document_id: listed.id},
+               ctx(agent)
+             )
+
+    assert downloaded.content == "# Q3 prices"
+  end
+
+  test "a reference whose document was deleted reports an error, not a crash" do
+    skill =
+      skill!(%{
+        name: "stale-skill",
+        resources: %{
+          "references" => [
+            %{"file_id" => "999999", "file_name" => "gone.md", "provider" => "disk"}
+          ]
+        }
+      })
+
+    agent = agent!(skill)
+
+    assert {:ok, loaded} = LoadSkill.run(%{name: "stale-skill"}, ctx(agent))
+    assert %RecordPage{records: [listed]} = loaded.resources
+
+    assert {:error, message} =
+             DownloadDocument.run(%{provider: "disk", document_id: listed.id}, ctx(agent))
+
+    assert message =~ "Data source document download failed"
+  end
+
+  # Documents the gap the permission-enforcement follow-up closes: nothing on this path
+  # checks who is asking, so an untagged document is returned exactly like a public one.
+  test "reads are not permission-filtered yet" do
+    skill = skill!(%{name: "private-skill"})
+
+    params = %{
+      "path" => Path.join(@volume, Resources.references_dir(skill)),
+      "name" => "private.md",
+      "content" => Base.encode64("secret"),
+      "encoding" => "base64"
+    }
+
+    event =
+      Event.new(%{provider: "disk", params: params}, :channels,
+        opts: [action: :data_source_create_file]
+      )
+
+    {:ok, %{record: record}} =
+      ChannelsApi.handle_event(event, :data_source_create_file, %{}).response
+
+    assert Document.get(record.id).tags == []
+
+    agent = agent!(skill)
+
+    assert {:ok, %{record: downloaded}} =
+             DownloadDocument.run(
+               %{provider: "disk", document_id: record.id},
+               Map.put(ctx(agent), :person_id, nil)
+             )
+
+    assert downloaded.content == "secret"
+  end
+end

--- a/test/zaq/agent/skill_test.exs
+++ b/test/zaq/agent/skill_test.exs
@@ -3,6 +3,7 @@ defmodule Zaq.Agent.SkillTest do
   use ExUnitProperties
 
   alias Zaq.Agent.Skill
+  alias Zaq.Agent.Skills.Limits
   alias Zaq.Repo
 
   @valid_attrs %{
@@ -416,17 +417,10 @@ defmodule Zaq.Agent.SkillTest do
       assert {:ok, skill} = %Skill{} |> Skill.changeset(@valid_attrs) |> Repo.insert()
 
       assert skill.allowed_tools == []
-      assert skill.resource_root == nil
+      assert skill.resources == %{}
       # diagnostics is written by validation, string-keyed to match the stored/reloaded
       # shape, and a clean skill has none to report.
       assert %{"warning_count" => 0, "errors" => []} = skill.diagnostics
-    end
-
-    test "resource_root round-trips" do
-      attrs = Map.put(@valid_attrs, :resource_root, "skills/calculator")
-
-      assert {:ok, skill} = %Skill{} |> Skill.changeset(attrs) |> Repo.insert()
-      assert skill.resource_root == "skills/calculator"
     end
 
     test "diagnostics is not user-settable — validation owns it" do
@@ -437,6 +431,85 @@ defmodule Zaq.Agent.SkillTest do
       # The submitted value is discarded, not merged: diagnostics is a cache of what the
       # loader reported, and a user-supplied one would be a lie the BO then badges on.
       assert %{"warnings" => []} = skill.diagnostics
+    end
+  end
+
+  describe "resources" do
+    defp entry(overrides \\ %{}) do
+      Map.merge(
+        %{"file_id" => "42", "file_name" => "prices.md", "provider" => "disk"},
+        overrides
+      )
+    end
+
+    defp with_resources(resources), do: Map.put(@valid_attrs, :resources, resources)
+
+    test "round-trips a references bucket" do
+      resources = %{"references" => [entry(), entry(%{"file_id" => "43"})]}
+
+      assert {:ok, skill} =
+               %Skill{} |> Skill.changeset(with_resources(resources)) |> Repo.insert()
+
+      assert skill.resources == resources
+    end
+
+    test "accepts an empty map" do
+      changeset = Skill.changeset(%Skill{}, with_resources(%{}))
+      assert changeset.valid?
+    end
+
+    test "accepts the scripts and assets buckets" do
+      changeset =
+        Skill.changeset(%Skill{}, with_resources(%{"scripts" => [], "assets" => [entry()]}))
+
+      assert changeset.valid?
+    end
+
+    test "rejects an unknown bucket" do
+      changeset = Skill.changeset(%Skill{}, with_resources(%{"referances" => []}))
+
+      refute changeset.valid?
+      assert "has an unknown bucket: referances" in errors_on(changeset).resources
+    end
+
+    test "rejects a bucket that is not a list" do
+      changeset = Skill.changeset(%Skill{}, with_resources(%{"references" => entry()}))
+
+      refute changeset.valid?
+      assert "references must be a list" in errors_on(changeset).resources
+    end
+
+    for key <- ~w(file_id file_name provider) do
+      test "rejects an entry missing #{key}" do
+        resources = %{"references" => [Map.delete(entry(), unquote(key))]}
+        changeset = Skill.changeset(%Skill{}, with_resources(resources))
+
+        refute changeset.valid?
+        assert Enum.any?(errors_on(changeset).resources, &(&1 =~ "missing"))
+      end
+    end
+
+    test "rejects a non-binary file_id" do
+      resources = %{"references" => [entry(%{"file_id" => 42})]}
+      changeset = Skill.changeset(%Skill{}, with_resources(resources))
+
+      refute changeset.valid?
+    end
+
+    test "rejects a blank file_name" do
+      resources = %{"references" => [entry(%{"file_name" => "   "})]}
+      changeset = Skill.changeset(%Skill{}, with_resources(resources))
+
+      refute changeset.valid?
+    end
+
+    test "rejects more entries than the file cap allows" do
+      max = Limits.get(:resource_max_files)
+      entries = for i <- 0..max, do: entry(%{"file_id" => to_string(i)})
+      changeset = Skill.changeset(%Skill{}, with_resources(%{"references" => entries}))
+
+      refute changeset.valid?
+      assert Enum.any?(errors_on(changeset).resources, &(&1 =~ "more than #{max}"))
     end
   end
 

--- a/test/zaq/agent/skills/validation_test.exs
+++ b/test/zaq/agent/skills/validation_test.exs
@@ -183,23 +183,6 @@ defmodule Zaq.Agent.Skills.ValidationTest do
     end
   end
 
-  describe "resource_root" do
-    test "accepts a relative path inside a volume" do
-      changeset = Skill.changeset(%Skill{}, Map.put(@valid, :resource_root, "skills/calculator"))
-      assert changeset.valid?
-    end
-
-    test "rejects an absolute path" do
-      changeset = Skill.changeset(%Skill{}, Map.put(@valid, :resource_root, "/etc/passwd"))
-      assert "must be relative to an ingestion volume" in errors_on(changeset).resource_root
-    end
-
-    test "rejects traversal out of the volume" do
-      changeset = Skill.changeset(%Skill{}, Map.put(@valid, :resource_root, "skills/../../etc"))
-      assert ~s(must not contain "..") in errors_on(changeset).resource_root
-    end
-  end
-
   property "validation never silently changes a field it accepts" do
     check all(
             description <- string(:alphanumeric, min_length: 1, max_length: 200),

--- a/test/zaq/agent/tools/skills/load_skill_test.exs
+++ b/test/zaq/agent/tools/skills/load_skill_test.exs
@@ -6,6 +6,7 @@ defmodule Zaq.Agent.Tools.Skills.LoadSkillTest do
   alias Zaq.Agent
   alias Zaq.Agent.Skills
   alias Zaq.Agent.Tools.Skills.LoadSkill
+  alias Zaq.Contracts.RecordPage
 
   defp skill!(attrs) do
     {:ok, skill} =
@@ -56,7 +57,33 @@ defmodule Zaq.Agent.Tools.Skills.LoadSkillTest do
 
       assert result.name == "calculator"
       assert result.instructions == "SECRET_INSTRUCTIONS"
-      assert result.resources == []
+      assert %RecordPage{records: []} = result.resources
+    end
+
+    test "lists the skill's references as unmaterialized records" do
+      skill =
+        skill!(%{
+          name: "pricing",
+          resources: %{
+            "references" => [
+              %{"file_id" => "42", "file_name" => "prices.md", "provider" => "disk"}
+            ]
+          }
+        })
+
+      agent = agent!(%{enabled_skill_ids: [skill.id]})
+
+      assert {:ok, result} = LoadSkill.run(%{name: "pricing"}, ctx(agent))
+
+      assert %RecordPage{resource_type: :item, records: [record]} = result.resources
+      assert record.id == "42"
+      assert record.name == "prices.md"
+      assert record.kind == :file
+      assert record.mime_type == "text/markdown"
+      assert record.attributes["provider"] == "disk"
+      # Metadata only — the model fetches bytes through `download_document`.
+      assert record.content == nil
+      assert record.materializing_event == nil
     end
 
     test "is idempotent — a repeat call returns the body again, not an error" do

--- a/test/zaq/channels/disk_bridge_test.exs
+++ b/test/zaq/channels/disk_bridge_test.exs
@@ -191,7 +191,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
   end
 
   describe "create_file/2" do
-    test "dispatches :persist_record carrying name, path, content, and encoding" do
+    test "dispatches :persist_record carrying name, path, content, encoding, and tags" do
       stub_response({:ok, %{status: "created", entry: entry("42")}})
 
       assert {:ok, %{status: "created", record: %Record{id: "42"}}} =
@@ -199,7 +199,8 @@ defmodule Zaq.Channels.DiskBridgeTest do
                  "name" => "notes.md",
                  "path" => "archives",
                  "content" => "# notes",
-                 "encoding" => "base64"
+                 "encoding" => "base64",
+                 "tags" => ["public"]
                })
 
       assert_received {:dispatch, :ingestion, :persist_record, request}
@@ -208,7 +209,8 @@ defmodule Zaq.Channels.DiskBridgeTest do
                "name" => "notes.md",
                "path" => "archives",
                "content" => "# notes",
-               "encoding" => "base64"
+               "encoding" => "base64",
+               "tags" => ["public"]
              }
     end
 
@@ -220,6 +222,7 @@ defmodule Zaq.Channels.DiskBridgeTest do
       assert_received {:dispatch, :ingestion, :persist_record, request}
       assert request["content"] == ""
       assert request["encoding"] == nil
+      assert request["tags"] == []
     end
 
     test "passes an ingestion error back unchanged" do

--- a/test/zaq/ingestion/ingestion_disk_records_test.exs
+++ b/test/zaq/ingestion/ingestion_disk_records_test.exs
@@ -244,6 +244,41 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
       assert entry.name == "notes.md"
     end
 
+    test "writes the requested tags onto the document row" do
+      assert {:ok, _} =
+               Ingestion.persist_record(%{
+                 "name" => "tagged.md",
+                 "path" => @volume,
+                 "content" => "hi",
+                 "tags" => ["public"]
+               })
+
+      assert Document.get_by_source("#{@volume}/tagged.md").tags == ["public"]
+    end
+
+    test "defaults to no tags" do
+      assert {:ok, _} =
+               Ingestion.persist_record(%{
+                 "name" => "untagged.md",
+                 "path" => @volume,
+                 "content" => "hi"
+               })
+
+      assert Document.get_by_source("#{@volume}/untagged.md").tags == []
+    end
+
+    test "ignores tags that are not strings" do
+      assert {:ok, _} =
+               Ingestion.persist_record(%{
+                 "name" => "mixed.md",
+                 "path" => @volume,
+                 "content" => "hi",
+                 "tags" => ["public", 42, nil]
+               })
+
+      assert Document.get_by_source("#{@volume}/mixed.md").tags == ["public"]
+    end
+
     test "writes into a subdirectory of the volume", %{root: root} do
       File.mkdir_p!(Path.join(root, "manuals"))
 
@@ -872,6 +907,21 @@ defmodule Zaq.Ingestion.DiskRecordsTest do
 
     test "reports the mounted volume names, sorted" do
       assert {:ok, %{root_folders: [@volume, @other_volume]}} = Ingestion.volume_stats()
+    end
+
+    test "reports whether volumes were actually configured" do
+      assert {:ok, %{volumes_configured?: true}} = Ingestion.volume_stats()
+    end
+
+    test "reports volumes as unconfigured when none are set, though root_folders is not empty" do
+      original = Application.get_env(:zaq, Zaq.Ingestion)
+      Application.put_env(:zaq, Zaq.Ingestion, Keyword.delete(original || [], :volumes))
+      on_exit(fn -> Application.put_env(:zaq, Zaq.Ingestion, original) end)
+
+      assert {:ok, %{volumes_configured?: false, root_folders: folders}} =
+               Ingestion.volume_stats()
+
+      refute folders == []
     end
   end
 end

--- a/test/zaq_web/live/bo/ai/skills_live_test.exs
+++ b/test/zaq_web/live/bo/ai/skills_live_test.exs
@@ -1,7 +1,6 @@
 defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
   use ZaqWeb.ConnCase
 
-  import Ecto.Query
   import Mox
   import Phoenix.LiveViewTest
   import Zaq.AccountsFixtures
@@ -12,7 +11,6 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
   alias Zaq.Agent.Skills
   alias Zaq.Agent.Skills.Limits
   alias Zaq.Ingestion.Document
-  alias Zaq.Repo
   alias ZaqWeb.Helpers.SizeFormat
   alias ZaqWeb.Live.BO.AI.SkillsLive
 
@@ -76,13 +74,23 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
   end
 
   # Routes events to the real modules instead of stubbing them: the whole point of the
-  # resource-upload tests is the LiveView → NodeRouter → Ingestion seam, so the hop under
-  # test must not be faked. Only the transport is short-circuited.
+  # resource tests is the LiveView → NodeRouter → Channels → Ingestion seam, so the hops
+  # under test must not be faked. Only the transport is short-circuited.
   defmodule RealRouter do
     alias Zaq.Agent.Skills
+    alias Zaq.Channels.Api, as: ChannelsApi
+
+    def dispatch(%{request: %{provider: _, params: _}} = event) do
+      ChannelsApi.handle_event(event, Keyword.fetch!(event.opts, :action), %{})
+    end
 
     def dispatch(%{request: %{module: mod, function: fun, args: args}} = event) do
       %{event | response: apply(mod, fun, args)}
+    end
+
+    # `:agent_skill_created` carries attrs with no id.
+    def dispatch(%{request: %{attrs: attrs}} = event) when not is_map_key(event.request, :id) do
+      %{event | response: Skills.create_skill(attrs)}
     end
 
     def dispatch(%{request: %{id: id, attrs: attrs}} = event) do
@@ -103,47 +111,23 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
     end
   end
 
-  # Writes fail, reads succeed — proves a failed upload does not persist `resource_root`.
+  # Writes fail, reads succeed.
   defmodule UploadFailureRouter do
-    def dispatch(%{request: %{function: :upload_file}} = event) do
+    def dispatch(%{opts: [action: :data_source_create_file]} = event) do
       %{event | response: {:error, :eacces}}
     end
 
     def dispatch(event), do: RealRouter.dispatch(event)
   end
 
-  # The ingestion node is unreachable, so `list_volumes` yields an error tuple instead of
-  # the expected map.
+  # The ingestion node is unreachable, so the bridge's stats call yields an error tuple
+  # instead of the expected map.
   defmodule IngestionDownRouter do
-    def dispatch(%{request: %{function: :list_volumes}} = event) do
-      %{event | response: {:error, :node_down}}
-    end
-
-    def dispatch(%{request: %{function: :volumes_configured?}} = event) do
+    def dispatch(%{opts: [action: :data_source_channel_stats]} = event) do
       %{event | response: {:error, :node_down}}
     end
 
     def dispatch(event), do: RealRouter.dispatch(event)
-  end
-
-  # Everything works except removing the resource directory.
-  defmodule ResourceDeleteFailureRouter do
-    def dispatch(%{request: %{function: :delete_path}} = event) do
-      %{event | response: {:error, :eperm}}
-    end
-
-    def dispatch(event), do: RealRouter.dispatch(event)
-  end
-
-  # Uploads succeed but persisting `resource_root` back onto the skill fails.
-  defmodule SkillUpdateFailureRouter do
-    def dispatch(%{request: %{module: _, function: _, args: _}} = event) do
-      RealRouter.dispatch(event)
-    end
-
-    def dispatch(%{request: %{id: _, attrs: _}} = event) do
-      %{event | response: {:error, :sync_failed}}
-    end
   end
 
   defp configure_volumes(volumes) do
@@ -166,6 +150,27 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
 
   defp open_skill(view, skill) do
     view |> element("[phx-click='select_skill'][phx-value-id='#{skill.id}']") |> render_click()
+  end
+
+  # Uploads stage until the skill is saved, so every resource test ends here.
+  defp save_skill_form(view, skill) do
+    view
+    |> form("#skill-form",
+      skill: %{name: skill.name, description: skill.description, body: skill.body}
+    )
+    |> render_submit()
+  end
+
+  defp stage_file(view, filename, content \\ "x", type \\ "text/markdown") do
+    view |> element("#add-resource-button") |> render_click()
+
+    upload =
+      file_input(view, "#skill-resource-form", :skill_resources, [
+        %{name: filename, content: content, type: type}
+      ])
+
+    assert render_upload(upload, filename)
+    view |> form("#skill-resource-form") |> render_submit()
   end
 
   describe "skill resources — volume gate" do
@@ -216,8 +221,7 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
   end
 
   describe "skill resources — upload" do
-    test "writes the file under .agents/skills/{name}/references and persists resource_root",
-         %{conn: conn} do
+    test "writes the file under .agents/skills/{name}/references on save", %{conn: conn} do
       volume = tmp_volume("upload")
       configure_volumes(%{"documents" => volume})
       with_skills_live_node_router(RealRouter)
@@ -225,37 +229,41 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
-      view |> element("#add-resource-button") |> render_click()
+      stage_file(view, "prices.md", "# Prices")
 
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "prices.md", content: "# Prices", type: "text/markdown"}
-        ])
+      # Staging alone must not write.
+      refute File.exists?(Path.join(volume, ".agents/skills/pricing-faq/references/prices.md"))
 
-      assert render_upload(upload, "prices.md")
-      view |> form("#skill-resource-form") |> render_submit()
+      save_skill_form(view, skill)
 
       assert File.exists?(Path.join(volume, ".agents/skills/pricing-faq/references/prices.md"))
-      assert Skills.get_skill!(skill.id).resource_root == ".agents/skills/pricing-faq"
     end
 
-    test "lists the uploaded file in the resources panel", %{conn: conn} do
-      volume = tmp_volume("listing")
-      configure_volumes(%{"documents" => volume})
+    test "records the document id and tags it public", %{conn: conn} do
+      configure_volumes(%{"documents" => tmp_volume("tagged")})
+      with_skills_live_node_router(RealRouter)
+      skill = create_skill!(%{name: "tagged-skill"})
+
+      {:ok, view, _html} = live(conn, ~p"/bo/skills")
+      open_skill(view, skill)
+      stage_file(view, "notes.md", "notes")
+      save_skill_form(view, skill)
+
+      assert [%{"file_id" => file_id, "file_name" => "notes.md", "provider" => "disk"}] =
+               Skills.get_skill!(skill.id).resources["references"]
+
+      assert "public" in Document.get(file_id).tags
+    end
+
+    test "lists the saved file in the resources panel", %{conn: conn} do
+      configure_volumes(%{"documents" => tmp_volume("listing")})
       with_skills_live_node_router(RealRouter)
       skill = create_skill!(%{name: "listing-skill"})
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
-      view |> element("#add-resource-button") |> render_click()
-
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "notes.md", content: "notes", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "notes.md")
-      html = view |> form("#skill-resource-form") |> render_submit()
+      stage_file(view, "notes.md", "notes")
+      html = save_skill_form(view, skill)
 
       assert html =~ "notes.md"
       refute has_element?(view, "#skill-resource-modal")
@@ -271,92 +279,54 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
       view |> element("#add-resource-button") |> render_click()
-
       render_change(view, "select_resource_volume", %{"volume" => "documents"})
-
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "picked.md", content: "picked", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "picked.md")
-      view |> form("#skill-resource-form") |> render_submit()
+      stage_file(view, "picked.md", "picked")
+      save_skill_form(view, skill)
 
       assert File.exists?(Path.join(documents, ".agents/skills/multi-vol/references/picked.md"))
       refute File.exists?(Path.join(archives, ".agents/skills/multi-vol/references/picked.md"))
     end
 
-    test "a renamed skill keeps writing to its original resource_root", %{conn: conn} do
+    test "a renamed skill writes under its new name", %{conn: conn} do
       volume = tmp_volume("rename")
       configure_volumes(%{"documents" => volume})
       with_skills_live_node_router(RealRouter)
       skill = create_skill!(%{name: "original-name"})
-      {:ok, _} = Skills.update_skill(skill, %{resource_root: ".agents/skills/original-name"})
-      {:ok, renamed} = Skills.update_skill(Skills.get_skill!(skill.id), %{name: "new-name"})
+      {:ok, renamed} = Skills.update_skill(skill, %{name: "new-name"})
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, renamed)
-      view |> element("#add-resource-button") |> render_click()
+      stage_file(view, "after-rename.md")
+      save_skill_form(view, renamed)
 
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "after-rename.md", content: "x", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "after-rename.md")
-      view |> form("#skill-resource-form") |> render_submit()
-
-      # The sticky root wins — files already uploaded under the old name are not orphaned.
-      assert File.exists?(
-               Path.join(volume, ".agents/skills/original-name/references/after-rename.md")
-             )
-
-      refute File.exists?(Path.join(volume, ".agents/skills/new-name/references/after-rename.md"))
+      assert File.exists?(Path.join(volume, ".agents/skills/new-name/references/after-rename.md"))
     end
 
-    test "reports an upload failure and does not persist resource_root", %{conn: conn} do
-      volume = tmp_volume("failure")
-      configure_volumes(%{"documents" => volume})
+    test "reports an upload failure and records nothing", %{conn: conn} do
+      configure_volumes(%{"documents" => tmp_volume("failure")})
       with_skills_live_node_router(UploadFailureRouter)
       skill = create_skill!(%{name: "failing-skill"})
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
-      view |> element("#add-resource-button") |> render_click()
+      stage_file(view, "nope.md")
+      save_skill_form(view, skill)
 
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "nope.md", content: "x", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "nope.md")
-      html = view |> form("#skill-resource-form") |> render_submit()
-
-      assert html =~ "Upload failed"
-      assert has_element?(view, "#skill-resource-modal")
-      assert Skills.get_skill!(skill.id).resource_root == nil
+      assert has_element?(view, "#resource-upload-toast", "could not be uploaded")
+      assert Skills.get_skill!(skill.id).resources == %{}
     end
 
     test "reports the result in the overlay toast, not the BOLayout flash", %{conn: conn} do
-      volume = tmp_volume("toast")
-      configure_volumes(%{"documents" => volume})
+      configure_volumes(%{"documents" => tmp_volume("toast")})
       with_skills_live_node_router(RealRouter)
       skill = create_skill!(%{name: "toast-skill"})
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
-      view |> element("#add-resource-button") |> render_click()
+      stage_file(view, "seen.md")
+      save_skill_form(view, skill)
 
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "seen.md", content: "x", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "seen.md")
-      view |> form("#skill-resource-form") |> render_submit()
-
-      # The drawer is open, so an inline BOLayout banner would render behind it. The toast
-      # outranks the overlay — assert the message lands there and nowhere else.
+      # The drawer is open, so an inline BOLayout banner would render behind it.
       assert has_element?(view, "#resource-upload-toast", "1 resource(s) added.")
       refute has_element?(view, "#flash-info")
     end
@@ -368,15 +338,8 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
-      view |> element("#add-resource-button") |> render_click()
-
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "gone.md", content: "x", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "gone.md")
-      view |> form("#skill-resource-form") |> render_submit()
+      stage_file(view, "gone.md")
+      save_skill_form(view, skill)
       assert has_element?(view, "#resource-upload-toast")
 
       render_click(view, "dismiss_upload_toast", %{})
@@ -384,7 +347,7 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
       refute has_element?(view, "#resource-upload-toast")
     end
 
-    test "cancelling a queued entry removes it before submit", %{conn: conn} do
+    test "cancelling a queued entry removes it before save", %{conn: conn} do
       configure_volumes(%{"documents" => tmp_volume("cancel")})
       with_skills_live_node_router(RealRouter)
       skill = create_skill!(%{name: "cancel-skill"})
@@ -410,6 +373,43 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
     end
   end
 
+  describe "skill resources — removing one" do
+    test "deletes the document and drops the entry", %{conn: conn} do
+      volume = tmp_volume("remove_one")
+      configure_volumes(%{"documents" => volume})
+      with_skills_live_node_router(RealRouter)
+      skill = create_skill!(%{name: "remove-skill"})
+
+      {:ok, view, _html} = live(conn, ~p"/bo/skills")
+      open_skill(view, skill)
+      stage_file(view, "doomed.md")
+      save_skill_form(view, skill)
+
+      [%{"file_id" => file_id}] = Skills.get_skill!(skill.id).resources["references"]
+      render_click(view, "remove_skill_resource", %{"file_id" => file_id})
+
+      assert Skills.get_skill!(skill.id).resources["references"] == []
+      assert Document.get(file_id) == nil
+      refute File.exists?(Path.join(volume, ".agents/skills/remove-skill/references/doomed.md"))
+    end
+
+    test "reports a failure and keeps the entry", %{conn: conn} do
+      configure_volumes(%{"documents" => tmp_volume("remove_fail")})
+      with_skills_live_node_router(RealRouter)
+      skill = create_skill!(%{name: "remove-fail"})
+
+      {:ok, view, _html} = live(conn, ~p"/bo/skills")
+      open_skill(view, skill)
+      stage_file(view, "kept.md")
+      save_skill_form(view, skill)
+
+      render_click(view, "remove_skill_resource", %{"file_id" => "999999"})
+
+      assert has_element?(view, "#resource-upload-toast", "Could not remove")
+      assert [_] = Skills.get_skill!(skill.id).resources["references"]
+    end
+  end
+
   describe "skill resources — degraded ingestion" do
     test "treats an unreachable ingestion node as no volumes, without crashing", %{conn: conn} do
       configure_volumes(%{"documents" => tmp_volume("down")})
@@ -421,8 +421,8 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
 
       html = view |> element("#add-resource-button") |> render_click()
 
-      # `list_volumes` returned an error tuple, not a map — the page degrades to the gate
-      # rather than rendering an upload form it cannot service.
+      # The stats call failed, so the page degrades to the gate rather than rendering an
+      # upload form it cannot service.
       assert html =~ "Please, connect a volume to be able upload a resource"
     end
 
@@ -435,66 +435,19 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
       view |> element("#add-resource-button") |> render_click()
-
       render_change(view, "select_resource_volume", %{"volume" => "does-not-exist"})
+      stage_file(view, "safe.md")
+      save_skill_form(view, skill)
 
       # The selection is refused, so the upload still targets the real volume.
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "safe.md", content: "x", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "safe.md")
-      view |> form("#skill-resource-form") |> render_submit()
-
       assert File.exists?(
                Path.join(volume, ".agents/skills/unknown-vol-skill/references/safe.md")
              )
     end
-
-    test "still reports the upload when persisting resource_root fails", %{conn: conn} do
-      volume = tmp_volume("sync_fail")
-      configure_volumes(%{"documents" => volume})
-      with_skills_live_node_router(SkillUpdateFailureRouter)
-      skill = create_skill!(%{name: "sync-fail-skill"})
-
-      {:ok, view, _html} = live(conn, ~p"/bo/skills")
-      open_skill(view, skill)
-      view |> element("#add-resource-button") |> render_click()
-
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: "written.md", content: "x", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, "written.md")
-      html = view |> form("#skill-resource-form") |> render_submit()
-
-      # The file is on disk, so the operator must be told it succeeded even though the
-      # bookkeeping write did not land.
-      assert File.exists?(
-               Path.join(volume, ".agents/skills/sync-fail-skill/references/written.md")
-             )
-
-      assert html =~ "1 resource(s) added."
-      assert Skills.get_skill!(skill.id).resource_root == nil
-    end
   end
 
   describe "skill resources — cleanup on delete" do
-    defp upload_resource!(view, filename) do
-      view |> element("#add-resource-button") |> render_click()
-
-      upload =
-        file_input(view, "#skill-resource-form", :skill_resources, [
-          %{name: filename, content: "x", type: "text/markdown"}
-        ])
-
-      assert render_upload(upload, filename)
-      view |> form("#skill-resource-form") |> render_submit()
-    end
-
-    test "removes the skill's resource directory from the volume", %{conn: conn} do
+    test "deletes every document the skill recorded", %{conn: conn} do
       volume = tmp_volume("delete_res")
       configure_volumes(%{"documents" => volume})
       with_skills_live_node_router(RealRouter)
@@ -502,44 +455,21 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
-      upload_resource!(view, "doomed.md")
+      stage_file(view, "doomed.md")
+      save_skill_form(view, skill)
 
-      skill_dir = Path.join(volume, ".agents/skills/doomed-skill")
-      assert File.dir?(skill_dir)
+      [%{"file_id" => file_id}] = Skills.get_skill!(skill.id).resources["references"]
 
-      view |> element("#delete-skill-button") |> render_click()
+      html = view |> element("#delete-skill-button") |> render_click()
 
-      # The whole {slug} directory goes, not just references/.
-      refute File.exists?(skill_dir)
+      assert html =~ "Skill deleted"
       assert Skills.get_skill(skill.id) == nil
+      assert Document.get(file_id) == nil
+      refute File.exists?(Path.join(volume, ".agents/skills/doomed-skill/references/doomed.md"))
     end
 
-    test "removes the tracked document rows along with the files", %{conn: conn} do
-      volume = tmp_volume("delete_docs")
-      configure_volumes(%{"documents" => volume})
-      with_skills_live_node_router(RealRouter)
-      skill = create_skill!(%{name: "tracked-skill"})
-
-      {:ok, view, _html} = live(conn, ~p"/bo/skills")
-      open_skill(view, skill)
-      upload_resource!(view, "tracked.md")
-
-      assert Repo.aggregate(
-               from(d in Document, where: like(d.source, "%tracked-skill%")),
-               :count
-             ) > 0
-
-      view |> element("#delete-skill-button") |> render_click()
-
-      assert Repo.aggregate(
-               from(d in Document, where: like(d.source, "%tracked-skill%")),
-               :count
-             ) == 0
-    end
-
-    test "deletes a skill that never had resources without erroring", %{conn: conn} do
-      volume = tmp_volume("delete_none")
-      configure_volumes(%{"documents" => volume})
+    test "deletes a skill that never had resources", %{conn: conn} do
+      configure_volumes(%{"documents" => tmp_volume("delete_none")})
       with_skills_live_node_router(RealRouter)
       skill = create_skill!(%{name: "bare-skill"})
 
@@ -548,70 +478,30 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
 
       html = view |> element("#delete-skill-button") |> render_click()
 
-      # No directory was ever created — the existence check must make this a no-op, not
-      # a surfaced `{:error, :not_a_directory}`.
       assert html =~ "Skill deleted"
       refute html =~ "resources could not be removed"
       assert Skills.get_skill(skill.id) == nil
     end
 
-    test "finds and removes resources on a non-default volume", %{conn: conn} do
-      documents = tmp_volume("sweep_docs")
-      archives = tmp_volume("sweep_arch")
-      configure_volumes(%{"documents" => documents, "archives" => archives})
+    test "still deletes the skill when a document removal fails, and says so", %{conn: conn} do
+      configure_volumes(%{"documents" => tmp_volume("delete_fail")})
       with_skills_live_node_router(RealRouter)
-      skill = create_skill!(%{name: "swept-skill"})
+
+      skill =
+        create_skill!(%{
+          name: "cleanup-fail",
+          resources: %{
+            "references" => [
+              %{"file_id" => "999999", "file_name" => "gone.md", "provider" => "disk"}
+            ]
+          }
+        })
 
       {:ok, view, _html} = live(conn, ~p"/bo/skills")
       open_skill(view, skill)
-      render_change(view, "select_resource_volume", %{"volume" => "archives"})
-      upload_resource!(view, "swept.md")
-
-      archived_dir = Path.join(archives, ".agents/skills/swept-skill")
-      assert File.dir?(archived_dir)
-
-      view |> element("#delete-skill-button") |> render_click()
-
-      # The volume is not persisted on the skill, so deletion sweeps every volume.
-      refute File.exists?(archived_dir)
-    end
-
-    test "removes the original directory for a renamed skill", %{conn: conn} do
-      volume = tmp_volume("delete_rename")
-      configure_volumes(%{"documents" => volume})
-      with_skills_live_node_router(RealRouter)
-      skill = create_skill!(%{name: "before-rename"})
-
-      {:ok, view, _html} = live(conn, ~p"/bo/skills")
-      open_skill(view, skill)
-      upload_resource!(view, "kept.md")
-
-      {:ok, _} = Skills.update_skill(Skills.get_skill!(skill.id), %{name: "after-rename"})
-
-      {:ok, view, _html} = live(conn, ~p"/bo/skills")
-      open_skill(view, skill)
-      view |> element("#delete-skill-button") |> render_click()
-
-      # The sticky resource_root, not the current name, decides what gets removed.
-      refute File.exists?(Path.join(volume, ".agents/skills/before-rename"))
-    end
-
-    test "still deletes the skill when resource cleanup fails, and says so", %{conn: conn} do
-      volume = tmp_volume("delete_fail")
-      configure_volumes(%{"documents" => volume})
-      with_skills_live_node_router(RealRouter)
-      skill = create_skill!(%{name: "cleanup-fail"})
-
-      {:ok, view, _html} = live(conn, ~p"/bo/skills")
-      open_skill(view, skill)
-      upload_resource!(view, "stuck.md")
-
-      with_skills_live_node_router(ResourceDeleteFailureRouter)
 
       html = view |> element("#delete-skill-button") |> render_click()
 
-      # The record deletion is the user's intent and already succeeded; orphaned files are
-      # recoverable from the ingestion browser, so warn rather than pretend it all worked.
       assert html =~ "resources could not be removed"
       assert Skills.get_skill(skill.id) == nil
     end
@@ -780,9 +670,6 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
       assert File.exists?(
                Path.join(volume, ".agents/skills/saved-with-res/references/arrived.md")
              )
-
-      skill = Skills.search_skills(%{q: "saved-with-res", tags: []}) |> hd()
-      assert skill.resource_root == ".agents/skills/saved-with-res"
     end
 
     test "uses the name as saved, not the name at staging time", %{conn: conn} do
@@ -832,7 +719,8 @@ defmodule ZaqWeb.Live.BO.AI.SkillsLiveTest do
 
       # Walk away from the new skill by selecting an existing one, then upload there.
       open_skill(view, other)
-      upload_resource!(view, "legit.md")
+      stage_file(view, "legit.md")
+      save_skill_form(view, other)
 
       innocent_dir = Path.join(volume, ".agents/skills/innocent-skill/references")
       assert File.exists?(Path.join(innocent_dir, "legit.md"))


### PR DESCRIPTION
- Removed resource root and the old management of files that was implemented in the Skill page.
- Added a `resources` column to the skill table to add a reference for the skill resources in the following format `%{"references => [file_id: , file_name: , provider: "data_source_provider"]"}` . This will help us to support `assets` and  `scripts` later on without any new migration.