### PR TITLE
refactor(Actions): introduce the materialization event to lazily download documents from Data sources

### DIFF
--- a/lib/zaq/agent/tools/data_source/download_document.ex
+++ b/lib/zaq/agent/tools/data_source/download_document.ex
@@ -1,9 +1,45 @@
 defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
   @moduledoc """
-  ReAct tool: downloads a document by id from a datasource provider.
+  ReAct tool: downloads datasource document content.
+
+  Prefer passing a metadata `%Zaq.Contracts.Record{}` returned by browse/list/search/get when it
+  has a `materializing_event`; that event is the provider-specific download route and preserves
+  the record metadata that selected the document. The legacy `provider` + `document_id` path is
+  still supported for callers that only have an identifier.
 
   Delegates to Channels through `NodeRouter.dispatch/1`.
   """
+
+  @schema Zoi.object(
+            %{
+              record:
+                Zoi.map(description: "Metadata record with a materializing event.")
+                |> Zoi.optional(),
+              provider:
+                Zoi.string(description: "Datasource provider key.")
+                |> Zoi.optional(),
+              document_id:
+                Zoi.string(description: "Provider document identifier.")
+                |> Zoi.optional(),
+              document_mime_type:
+                Zoi.string(
+                  description:
+                    "Optional source MIME type of the provider document. Used for automatic export type decision."
+                )
+                |> Zoi.optional(),
+              export_mime_type:
+                Zoi.string(
+                  description:
+                    "Optional target MIME type to request provider export when supported."
+                )
+                |> Zoi.optional(),
+              config_id:
+                Zoi.string(description: "Optional scoped datasource config id.")
+                |> Zoi.optional()
+            },
+            unrecognized_keys: :preserve
+          )
+          |> Zoi.refine({__MODULE__, :validate_input_mode, []})
 
   use Zaq.Engine.Workflows.Action,
     name: "download_document",
@@ -11,29 +47,59 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
       record: [type: :any, required: false, doc: "Normalized record including document content"]
     ],
     description: """
-    Download a document by id from a specific datasource provider.
+    Download datasource document content.
+
+    Pass either a metadata record with a materializing event, or a provider plus document_id.
+    The record path is preferred when the document came from a datasource browse/list/search/get
+    result, because the event already carries the correct routed download request.
+
     Returns a normalized record including document content.
     """,
-    schema: [
-      provider: [type: :string, required: true, doc: "Datasource provider key"],
-      document_id: [type: :string, required: true, doc: "Provider document identifier"],
-      document_mime_type: [
-        type: :string,
-        required: false,
-        doc:
-          "Optional source MIME type of the provider document. Used for automatic export type decision."
-      ],
-      export_mime_type: [
-        type: :string,
-        required: false,
-        doc: "Optional target MIME type to request provider export when supported"
-      ],
-      config_id: [type: :string, required: false, doc: "Optional scoped datasource config id"]
-    ]
+    schema: @schema
 
+  alias Jido.Action.Tool
   alias Zaq.Agent.Tools.DataSourceTool
+  alias Zaq.Contracts.RecordMaterializer
 
   @impl Jido.Action
+
+  def on_before_validate_params(params) when is_map(params),
+    do: {:ok, Tool.convert_params_using_schema(params, schema())}
+
+  def on_before_validate_params(params), do: {:ok, params}
+
+  @doc false
+  def validate_input_mode(params, _opts \\ [])
+
+  def validate_input_mode(params, _opts) when is_map(params) do
+    has_record? = present?(Map.get(params, :record) || Map.get(params, "record"))
+    has_provider? = present?(Map.get(params, :provider) || Map.get(params, "provider"))
+    has_document_id? = present?(Map.get(params, :document_id) || Map.get(params, "document_id"))
+
+    cond do
+      has_record? ->
+        :ok
+
+      has_provider? and has_document_id? ->
+        :ok
+
+      true ->
+        {:error, "provide either record or provider with document_id"}
+    end
+  end
+
+  def validate_input_mode(_params, _opts),
+    do: {:error, "download_document input must be an object"}
+
+  @impl Jido.Action
+
+  def run(%{record: record}, context) do
+    RecordMaterializer.materialize(
+      %{record: record},
+      context,
+      "Data source document download failed"
+    )
+  end
 
   def run(%{provider: provider, document_id: document_id} = params, context) do
     request =
@@ -45,11 +111,20 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
       ])
       |> DataSourceTool.wrap_request(provider)
 
+    error_prefix = "Data source document download failed"
+
     DataSourceTool.dispatch(
       :data_source_download_document,
       request,
       context,
-      "Data source document download failed"
+      error_prefix,
+      &RecordMaterializer.materialize(&1, context, error_prefix)
     )
   end
+
+  def run(_params, _context), do: {:error, "Provide either record or provider with document_id"}
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(nil), do: false
+  defp present?(_value), do: true
 end

--- a/lib/zaq/channels/jido_connect_bridge.ex
+++ b/lib/zaq/channels/jido_connect_bridge.ex
@@ -96,7 +96,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
     with {:ok, payload} <- invoke_intent(config, :list_items, params) do
       files = read_list(payload, [:files, "files"], []) |> Enum.filter(&is_map/1)
-      {:ok, build_item_record_page(files, params, payload)}
+      {:ok, build_item_record_page(files, config, params, payload)}
     end
   end
 
@@ -111,7 +111,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
   @impl true
   def get_file(config, params) when is_map(config) and is_map(params) do
     with {:ok, payload} <- invoke_intent(config, :get_item_metadata, params),
-         {:ok, record} <- map_file_from_payload(payload) do
+         {:ok, record} <- map_file_from_payload(payload, config, params) do
       {:ok, %{record: record}}
     end
   end
@@ -134,7 +134,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
   @impl true
   def search_files(config, params) when is_map(config) and is_map(params) do
     with {:ok, payload} <- invoke_intent(config, :search_items, params) do
-      map_file_page(payload, params)
+      map_file_page(payload, config, params)
     end
   end
 
@@ -341,11 +341,13 @@ defmodule Zaq.Channels.JidoConnectBridge do
     end
   end
 
-  defp map_file_from_payload(payload) when is_map(payload) do
+  defp map_file_from_payload(payload, config \\ nil, params \\ %{})
+
+  defp map_file_from_payload(payload, config, params) when is_map(payload) do
     raw = read_any(payload, [:file, "file"]) || payload
 
     if is_map(raw) do
-      {:ok, map_file_record(raw)}
+      {:ok, map_file_record(raw, config, params)}
     else
       {:error, :unsupported}
     end
@@ -353,7 +355,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
     _ -> {:error, :unsupported}
   end
 
-  defp map_file_from_payload(_), do: {:error, :unsupported}
+  defp map_file_from_payload(_, _config, _params), do: {:error, :unsupported}
 
   defp map_downloaded_document_record(payload, params) when is_map(payload) and is_map(params) do
     with content_payload when is_map(content_payload) <-
@@ -695,20 +697,20 @@ defmodule Zaq.Channels.JidoConnectBridge do
     }
   end
 
-  defp map_file_page(payload, params) when is_map(payload) and is_map(params) do
+  defp map_file_page(payload, config, params) when is_map(payload) and is_map(params) do
     files = read_list(payload, [:files, "files"], []) |> Enum.filter(&is_map/1)
 
-    {:ok, build_item_record_page(files, params, payload)}
+    {:ok, build_item_record_page(files, config, params, payload)}
   end
 
-  defp build_item_record_page(files, params, payload)
+  defp build_item_record_page(files, config, params, payload)
        when is_list(files) and is_map(params) and is_map(payload) do
     next_cursor = read_stringish(payload, [:next_page_token, "next_page_token"])
     page_size = map_get_integer(params, [:page_size, "page_size"])
 
     %RecordPage{
       resource_type: :item,
-      records: Enum.map(files, &map_file_record/1),
+      records: Enum.map(files, &map_file_record(&1, config, params)),
       pagination: %{
         cursor: next_cursor,
         has_more?: is_binary(next_cursor) and next_cursor != "",
@@ -1697,18 +1699,22 @@ defmodule Zaq.Channels.JidoConnectBridge do
     end
   end
 
-  defp map_file_record(raw) when is_map(raw) do
+  defp map_file_record(raw, config \\ nil, params \\ %{}) when is_map(raw) do
     id = fetch_required_string!(raw, ["id", :id, "file_id", :file_id], "file")
     parent_ids = read_parent_ids(raw)
     permissions = map_embedded_permissions(raw)
+    kind = infer_item_kind(raw)
+    mime_type = read_stringish(raw, ["mimeType", :mimeType, "mime_type", :mime_type])
+    {content, encoding} = extract_metadata_content(raw)
 
     %Record{
       id: id,
-      kind: infer_item_kind(raw),
+      kind: kind,
+      content: content,
       name: read_stringish(raw, ["name", :name, "title", :title]),
       parent_id: List.first(parent_ids),
       parent_ids: parent_ids,
-      mime_type: read_stringish(raw, ["mime_type", :mime_type]),
+      mime_type: mime_type,
       path: read_stringish(raw, ["path", :path]),
       url: read_stringish(raw, ["web_view_link", :web_view_link]),
       size: read_integer(raw, ["size", :size]),
@@ -1722,10 +1728,46 @@ defmodule Zaq.Channels.JidoConnectBridge do
       lifecycle_state: :active,
       deleted_at: nil,
       permissions: permissions,
-      attributes: %{},
+      materializing_event: materializing_event(config, params, id, kind, content, mime_type),
+      attributes: %{} |> maybe_put_attr("encoding", encoding),
       raw: raw
     }
   end
+
+  defp extract_metadata_content(raw) when is_map(raw) do
+    declared_encoding = read_stringish(raw, ["encoding", :encoding])
+    content = read_any(raw, ["content", :content])
+    base64_content = read_stringish(raw, ["content_base64", :content_base64])
+
+    cond do
+      not is_nil(content) -> {content, declared_encoding}
+      is_binary(base64_content) -> {base64_content, "base64"}
+      true -> {nil, nil}
+    end
+  end
+
+  defp materializing_event(config, params, file_id, :file, nil, mime_type) when is_map(params) do
+    provider = config && Map.get(config, :provider)
+
+    if is_nil(provider) do
+      nil
+    else
+      request = %{
+        provider: provider,
+        params:
+          %{"file_id" => file_id}
+          |> maybe_put_attr(
+            "config_id",
+            Map.get(params, "config_id") || Map.get(params, :config_id) || Map.get(config, :id)
+          )
+          |> maybe_put_attr("document_mime_type", mime_type)
+      }
+
+      Event.new(request, :channels, opts: [action: :data_source_download_document])
+    end
+  end
+
+  defp materializing_event(_config, _params, _file_id, _kind, _content, _mime_type), do: nil
 
   defp map_permission_record(raw) when is_map(raw) do
     id = fetch_required_string!(raw, ["id", :id, "permission_id", :permission_id], "permission")

--- a/lib/zaq/contracts/record_materializer.ex
+++ b/lib/zaq/contracts/record_materializer.ex
@@ -1,0 +1,105 @@
+defmodule Zaq.Contracts.RecordMaterializer do
+  @moduledoc """
+  Materializes records whose content is available through a trusted event.
+
+  `Zaq.Contracts.Record` stays a pure struct. This module owns the opt-in second
+  hop for callers that hold an in-memory record with a dispatchable
+  `materializing_event`.
+  """
+
+  alias Zaq.Contracts.Record
+  alias Zaq.Event
+  alias Zaq.NodeRouter
+
+  @doc """
+  Fills in a record's content when the bridge answered with an unmaterialized one.
+
+  A bridge whose bytes already sit inside ZAQ returns `content: nil` and a
+  `materializing_event` instead of carrying the payload back through the channels node — the
+  disk data source does this, since its files live on an ingestion volume. Dispatching that
+  event is the second hop that actually reads them.
+
+  A payload that already has content, or a record with no event to dispatch, passes through
+  untouched — so a caller can run this over any provider's answer.
+
+  The event may answer with the bytes alone (`%{content: content}`) or with the current
+  datasource download response shape (`%{record: %Record{content: content}}`). Whoever holds
+  the original record already has the metadata, so the content and optional encoding are merged
+  into that original record here.
+
+  Read `attributes["encoding"]` on the result: `"base64"` means the content is encoded bytes,
+  and its absence means it is already text.
+  """
+  @spec materialize(map(), map(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def materialize(
+        %{record: %Record{content: nil, materializing_event: %Event{} = event} = record} =
+          payload,
+        context,
+        error_prefix
+      ) do
+    node_router = Map.get(context, :node_router, NodeRouter)
+
+    event
+    |> node_router.dispatch()
+    |> Map.fetch!(:response)
+    |> format_response(error_prefix, fn
+      %{record: %Record{content: content} = answer} when not is_nil(content) ->
+        {:ok, %{payload | record: put_content(record, content, answer)}}
+
+      %{record: %{content: content} = answer} when not is_nil(content) ->
+        {:ok, %{payload | record: put_content(record, content, answer)}}
+
+      %{content: content} = answer ->
+        {:ok, %{payload | record: put_content(record, content, answer)}}
+
+      other ->
+        {:error, "#{error_prefix}: unexpected materialize response #{inspect(other)}"}
+    end)
+  end
+
+  def materialize(payload, _context, _error_prefix), do: {:ok, payload}
+
+  # `encoding` travels beside the content rather than inside the record, so it is stamped onto
+  # the record's attributes here — the key `RecordSource.store_download/2` reads.
+  defp put_content(%Record{} = record, content, answer) do
+    case encoding(answer) do
+      nil ->
+        %{record | content: content}
+
+      encoding ->
+        %{
+          record
+          | content: content,
+            attributes: Map.put(record.attributes || %{}, "encoding", encoding)
+        }
+    end
+  end
+
+  defp encoding(%Record{attributes: attrs}) when is_map(attrs),
+    do: Map.get(attrs, "encoding") || Map.get(attrs, :encoding)
+
+  defp encoding(answer) when is_map(answer) do
+    Map.get(answer, :encoding) || Map.get(answer, "encoding") ||
+      answer |> Map.get(:attributes, %{}) |> encoding_from_attrs() ||
+      answer |> Map.get("attributes", %{}) |> encoding_from_attrs()
+  end
+
+  defp encoding(_), do: nil
+
+  defp encoding_from_attrs(attrs) when is_map(attrs),
+    do: Map.get(attrs, "encoding") || Map.get(attrs, :encoding)
+
+  defp encoding_from_attrs(_), do: nil
+
+  defp format_response({:ok, payload}, _error_prefix, on_ok) when is_map(payload),
+    do: on_ok.(payload)
+
+  defp format_response({:error, reason}, error_prefix, _on_ok),
+    do: {:error, "#{error_prefix}: #{format_reason(reason)}"}
+
+  defp format_response(other, _error_prefix, _on_ok),
+    do: {:error, "Unexpected materialize response: #{inspect(other)}"}
+
+  defp format_reason(reason) when is_binary(reason), do: reason
+  defp format_reason(reason), do: inspect(reason, limit: 20, printable_limit: 500)
+end

--- a/test/zaq/agent/tools/data_source/download_document_test.exs
+++ b/test/zaq/agent/tools/data_source/download_document_test.exs
@@ -1,7 +1,9 @@
 defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
   use Zaq.DataCase, async: true
 
+  alias Jido.Action.Schema
   alias Zaq.Agent.Tools.DataSource.DownloadDocument
+  alias Zaq.Contracts.Record
   alias Zaq.Event
 
   defmodule StubNodeRouter do
@@ -39,6 +41,117 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
         Event.new(%{}, :channels)
         | response: :weird_response
       }
+    end
+  end
+
+  defmodule StubNodeRouterMaterializing do
+    def dispatch(%Event{request: %{provider: "google_drive", params: params}, opts: opts}) do
+      send(self(), {:dispatch, opts[:action], params})
+
+      materializing_event =
+        Event.new(%{file_id: params["file_id"]}, :channels,
+          opts: [action: :read_materialized_bytes]
+        )
+
+      %{
+        Event.new(%{}, :channels)
+        | response:
+            {:ok,
+             %{
+               record: %Record{
+                 id: params["file_id"],
+                 kind: :file,
+                 content: nil,
+                 materializing_event: materializing_event
+               }
+             }}
+      }
+    end
+
+    def dispatch(%Event{request: %{file_id: "f1"}, opts: opts} = event) do
+      send(self(), {:dispatch, opts[:action], event.request})
+      %{event | response: {:ok, %{content: "materialized", encoding: "base64"}}}
+    end
+  end
+
+  defmodule StubNodeRouterCurrentDownloadResponse do
+    def dispatch(%Event{} = event) do
+      send(self(), {:dispatch, event.opts[:action], event.request})
+
+      downloaded = %Record{
+        id: "f1",
+        kind: :file,
+        content: "materialized from current API",
+        attributes: %{"encoding" => "base64"}
+      }
+
+      %{event | response: {:ok, %{record: downloaded}}}
+    end
+  end
+
+  describe "schema" do
+    test "is a valid Zoi action schema" do
+      assert :ok = Schema.validate_config_schema(DownloadDocument.schema())
+      assert is_map(Schema.to_json_schema(DownloadDocument.schema()))
+    end
+
+    test "accepts a metadata record input" do
+      assert :ok =
+               DownloadDocument.validate_input_mode(%{
+                 record: %Record{id: "f1", kind: :file}
+               })
+    end
+
+    test "accepts provider and document_id input" do
+      assert :ok =
+               DownloadDocument.validate_input_mode(%{
+                 provider: "google_drive",
+                 document_id: "f1"
+               })
+    end
+
+    test "rejects missing input mode" do
+      assert {:error, "provide either record or provider with document_id"} =
+               DownloadDocument.validate_input_mode(%{})
+    end
+
+    test "rejects partial provider input mode" do
+      assert {:error, "provide either record or provider with document_id"} =
+               DownloadDocument.validate_input_mode(%{provider: "google_drive"})
+
+      assert {:error, "provide either record or provider with document_id"} =
+               DownloadDocument.validate_input_mode(%{document_id: "f1"})
+    end
+
+    test "pre-validation converts map params using the action schema" do
+      assert {:ok, converted} =
+               DownloadDocument.on_before_validate_params(%{
+                 "provider" => "google_drive",
+                 "document_id" => "f1",
+                 "config_id" => "12",
+                 "ignored" => "kept"
+               })
+
+      assert converted.provider == "google_drive"
+      assert converted.document_id == "f1"
+      assert converted.config_id == "12"
+      assert converted["ignored"] == "kept"
+    end
+
+    test "pre-validation leaves non-map params unchanged" do
+      assert {:ok, :raw_params} = DownloadDocument.on_before_validate_params(:raw_params)
+      assert {:ok, nil} = DownloadDocument.on_before_validate_params(nil)
+
+      assert {:ok, [:not, :a, :map]} =
+               DownloadDocument.on_before_validate_params([:not, :a, :map])
+    end
+
+    test "rejects non-object input mode" do
+      assert {:error, "download_document input must be an object"} =
+               DownloadDocument.validate_input_mode(:raw_params)
+
+      assert {:error, "download_document input must be an object"} =
+               DownloadDocument.validate_input_mode(nil)
     end
   end
 
@@ -105,6 +218,57 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
                DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
                  node_router: StubNodeRouterUnexpected
                })
+    end
+
+    test "materializes unmaterialized record responses" do
+      assert {:ok, %{record: %Record{} = record}} =
+               DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
+                 node_router: StubNodeRouterMaterializing
+               })
+
+      assert record.id == "f1"
+      assert record.content == "materialized"
+      assert record.attributes["encoding"] == "base64"
+      assert_received {:dispatch, :data_source_download_document, %{"file_id" => "f1"}}
+      assert_received {:dispatch, :read_materialized_bytes, %{file_id: "f1"}}
+    end
+
+    test "consumes metadata records with materializing events" do
+      event =
+        Event.new(%{provider: "google_drive", params: %{"file_id" => "f1"}}, :channels,
+          opts: [action: :data_source_download_document]
+        )
+
+      metadata_record = %Record{
+        id: "f1",
+        kind: :file,
+        name: "Document.pdf",
+        materializing_event: event
+      }
+
+      assert {:ok, %{record: %Record{} = record}} =
+               DownloadDocument.run(%{record: metadata_record}, %{
+                 node_router: StubNodeRouterCurrentDownloadResponse
+               })
+
+      assert record.id == "f1"
+      assert record.name == "Document.pdf"
+      assert record.content == "materialized from current API"
+      assert record.attributes["encoding"] == "base64"
+
+      assert_received {:dispatch, :data_source_download_document,
+                       %{provider: "google_drive", params: %{"file_id" => "f1"}}}
+    end
+
+    test "run returns an error when params do not contain a record or provider document id" do
+      assert {:error, "Provide either record or provider with document_id"} =
+               DownloadDocument.run(%{}, %{})
+
+      assert {:error, "Provide either record or provider with document_id"} =
+               DownloadDocument.run(%{provider: "google_drive"}, %{})
+
+      assert {:error, "Provide either record or provider with document_id"} =
+               DownloadDocument.run(%{document_id: "f1"}, %{})
     end
   end
 end

--- a/test/zaq/channels/jido_connect_bridge_test.exs
+++ b/test/zaq/channels/jido_connect_bridge_test.exs
@@ -2,7 +2,9 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
   use Zaq.DataCase, async: false
 
   alias Zaq.Channels.{ChannelConfig, JidoConnectBridge}
+  alias Zaq.Contracts.Record
   alias Zaq.Engine.Connect
+  alias Zaq.Event
   alias Zaq.Repo
 
   defmodule StubIntegration do
@@ -218,6 +220,36 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
            binary: false,
            size: 8
          }
+       }}
+    end
+  end
+
+  defmodule StubJidoConnectInlineContentList do
+    def actions(_integration) do
+      {:ok,
+       [
+         %{
+           id: "stub.files.list",
+           resource: :file,
+           verb: :list,
+           auth_profile: :user,
+           auth_profiles: [:user]
+         }
+       ]}
+    end
+
+    def invoke(_integration, "stub.files.list", _params, _opts) do
+      {:ok,
+       %{
+         files: [
+           %{
+             "id" => "f-inline",
+             "name" => "Inline.txt",
+             "mimeType" => "text/plain",
+             "content" => "already here",
+             "encoding" => "utf-8"
+           }
+         ]
        }}
     end
   end
@@ -1096,6 +1128,48 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
 
     assert opts[:context].connection.id == "grant:#{grant.id}"
     assert opts[:credential_lease].connection_id == "grant:#{grant.id}"
+  end
+
+  test "list_files attaches materializing events to metadata file records" do
+    config = insert_data_source_config(:google_drive)
+    credential = create_credential!()
+    _grant = create_active_grant!(credential, config.id)
+
+    assert {:ok, %Zaq.Contracts.RecordPage{records: records}} =
+             JidoConnectBridge.list_resources(config, %{})
+
+    assert %Record{id: "f1", kind: :folder, materializing_event: nil} =
+             Enum.find(records, &(&1.id == "f1"))
+
+    assert %Record{id: "f2", kind: :file, content: nil, materializing_event: %Event{} = event} =
+             Enum.find(records, &(&1.id == "f2"))
+
+    assert event.opts[:action] == :data_source_download_document
+    assert event.next_hop.destination == :channels
+    assert to_string(event.request.provider) == "google_drive"
+    assert event.request.params["file_id"] == "f2"
+    assert event.request.params["config_id"] == config.id
+    assert event.request.params["document_mime_type"] == "application/pdf"
+  end
+
+  test "list_files preserves inline content without a materializing event" do
+    config = insert_data_source_config(:google_drive)
+    credential = create_credential!()
+    _grant = create_active_grant!(credential, config.id)
+
+    Application.put_env(
+      :zaq,
+      :jido_connect_bridge_jido_connect_module,
+      StubJidoConnectInlineContentList
+    )
+
+    assert {:ok, %Zaq.Contracts.RecordPage{records: [%Record{} = record]}} =
+             JidoConnectBridge.list_resources(config, %{})
+
+    assert record.id == "f-inline"
+    assert record.content == "already here"
+    assert record.attributes["encoding"] == "utf-8"
+    assert record.materializing_event == nil
   end
 
   test "create_file uses upload action when content is present" do

--- a/test/zaq/contracts/record_materializer_test.exs
+++ b/test/zaq/contracts/record_materializer_test.exs
@@ -1,0 +1,274 @@
+defmodule Zaq.Contracts.RecordMaterializerTest do
+  use Zaq.DataCase, async: true
+
+  alias Zaq.Contracts.Record
+  alias Zaq.Contracts.RecordMaterializer
+  alias Zaq.Event
+
+  defmodule OkNodeRouter do
+    def dispatch(%Event{request: %{id: "bytes"}} = event) do
+      send(self(), {:dispatch, event})
+      %{event | response: {:ok, %{content: "hello"}}}
+    end
+  end
+
+  defmodule AtomEncodingNodeRouter do
+    def dispatch(%Event{} = event) do
+      %{event | response: {:ok, %{content: "aGVsbG8=", encoding: "base64"}}}
+    end
+  end
+
+  defmodule StringEncodingNodeRouter do
+    def dispatch(%Event{} = event) do
+      %{event | response: {:ok, %{"encoding" => "base64", content: "aGVsbG8="}}}
+    end
+  end
+
+  defmodule RecordResponseNodeRouter do
+    def dispatch(%Event{} = event) do
+      response_record = %Record{
+        id: "downloaded",
+        kind: :file,
+        content: "downloaded content",
+        attributes: %{"encoding" => "base64"}
+      }
+
+      %{event | response: {:ok, %{record: response_record}}}
+    end
+  end
+
+  defmodule PlainMapRecordResponseNodeRouter do
+    def dispatch(%Event{} = event) do
+      %{event | response: {:ok, %{record: %{content: "plain map content", encoding: "base64"}}}}
+    end
+  end
+
+  defmodule RecordWithoutEncodingAttrsNodeRouter do
+    def dispatch(%Event{} = event) do
+      response_record = %Record{
+        id: "downloaded",
+        kind: :file,
+        content: "downloaded without encoding",
+        attributes: nil
+      }
+
+      %{event | response: {:ok, %{record: response_record}}}
+    end
+  end
+
+  defmodule NonMapAttributesNodeRouter do
+    def dispatch(%Event{} = event) do
+      %{event | response: {:ok, %{content: "hello", attributes: "not-a-map"}}}
+    end
+  end
+
+  defmodule ErrorNodeRouter do
+    def dispatch(%Event{} = event), do: %{event | response: {:error, :timeout}}
+  end
+
+  defmodule BinaryErrorNodeRouter do
+    def dispatch(%Event{} = event), do: %{event | response: {:error, "download failed"}}
+  end
+
+  defmodule UnexpectedOkNodeRouter do
+    def dispatch(%Event{} = event), do: %{event | response: {:ok, %{bytes: "hello"}}}
+  end
+
+  defmodule UnexpectedResponseNodeRouter do
+    def dispatch(%Event{} = event), do: %{event | response: :weird_response}
+  end
+
+  test "passes through records that already have content" do
+    payload = %{record: %Record{id: "r1", kind: :file, content: "ready"}}
+
+    assert RecordMaterializer.materialize(payload, %{}, "failed") == {:ok, payload}
+  end
+
+  test "passes through records with no materializing event" do
+    payload = %{record: %Record{id: "r1", kind: :file, content: nil}}
+
+    assert RecordMaterializer.materialize(payload, %{}, "failed") == {:ok, payload}
+  end
+
+  test "dispatches materializing event and merges returned content" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+    payload = %{record: %Record{id: "r1", kind: :file, materializing_event: event}}
+
+    assert {:ok, %{record: %Record{content: "hello"}}} =
+             RecordMaterializer.materialize(payload, %{node_router: OkNodeRouter}, "failed")
+
+    assert_received {:dispatch, ^event}
+  end
+
+  test "copies atom encoding onto record attributes" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+    payload = %{record: %Record{id: "r1", kind: :file, materializing_event: event}}
+
+    assert {:ok, %{record: record}} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: AtomEncodingNodeRouter},
+               "failed"
+             )
+
+    assert record.content == "aGVsbG8="
+    assert record.attributes["encoding"] == "base64"
+  end
+
+  test "copies string encoding onto record attributes" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+    payload = %{record: %Record{id: "r1", kind: :file, materializing_event: event}}
+
+    assert {:ok, %{record: record}} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: StringEncodingNodeRouter},
+               "failed"
+             )
+
+    assert record.content == "aGVsbG8="
+    assert record.attributes["encoding"] == "base64"
+  end
+
+  test "merges content from current download_document record responses" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :data_source_download_document])
+
+    payload = %{
+      record: %Record{
+        id: "metadata",
+        kind: :file,
+        name: "Metadata Name",
+        materializing_event: event
+      }
+    }
+
+    assert {:ok, %{record: record}} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: RecordResponseNodeRouter},
+               "failed"
+             )
+
+    assert record.id == "metadata"
+    assert record.name == "Metadata Name"
+    assert record.content == "downloaded content"
+    assert record.attributes["encoding"] == "base64"
+  end
+
+  test "merges content from plain map record responses" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+
+    payload = %{
+      record: %Record{
+        id: "original",
+        kind: :file,
+        name: "Original Name",
+        materializing_event: event
+      }
+    }
+
+    assert {:ok, %{record: record}} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: PlainMapRecordResponseNodeRouter},
+               "failed"
+             )
+
+    assert record.id == "original"
+    assert record.name == "Original Name"
+    assert record.content == "plain map content"
+    assert record.attributes["encoding"] == "base64"
+  end
+
+  test "preserves attributes when record responses have no encoding attributes" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+
+    payload = %{
+      record: %Record{
+        id: "r1",
+        kind: :file,
+        attributes: %{"source" => "original"},
+        materializing_event: event
+      }
+    }
+
+    assert {:ok, %{record: record}} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: RecordWithoutEncodingAttrsNodeRouter},
+               "failed"
+             )
+
+    assert record.content == "downloaded without encoding"
+    assert record.attributes == %{"source" => "original"}
+    refute Map.has_key?(record.attributes, "encoding")
+  end
+
+  test "does not read encoding from non-map attributes" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+
+    payload = %{
+      record: %Record{
+        id: "r1",
+        kind: :file,
+        attributes: %{"source" => "original"},
+        materializing_event: event
+      }
+    }
+
+    assert {:ok, %{record: record}} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: NonMapAttributesNodeRouter},
+               "failed"
+             )
+
+    assert record.content == "hello"
+    assert record.attributes == %{"source" => "original"}
+    refute Map.has_key?(record.attributes, "encoding")
+  end
+
+  test "formats materializing errors" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+    payload = %{record: %Record{id: "r1", kind: :file, materializing_event: event}}
+
+    assert {:error, "failed: :timeout"} =
+             RecordMaterializer.materialize(payload, %{node_router: ErrorNodeRouter}, "failed")
+  end
+
+  test "returns binary materializing error reasons without inspection" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+    payload = %{record: %Record{id: "r1", kind: :file, materializing_event: event}}
+
+    assert {:error, "failed: download failed"} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: BinaryErrorNodeRouter},
+               "failed"
+             )
+  end
+
+  test "formats unexpected ok payloads" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+    payload = %{record: %Record{id: "r1", kind: :file, materializing_event: event}}
+
+    assert {:error, "failed: unexpected materialize response %{bytes: \"hello\"}"} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: UnexpectedOkNodeRouter},
+               "failed"
+             )
+  end
+
+  test "formats unexpected materializing responses" do
+    event = Event.new(%{id: "bytes"}, :channels, opts: [action: :download_bytes])
+    payload = %{record: %Record{id: "r1", kind: :file, materializing_event: event}}
+
+    assert {:error, "Unexpected materialize response: :weird_response"} =
+             RecordMaterializer.materialize(
+               payload,
+               %{node_router: UnexpectedResponseNodeRouter},
+               "failed"
+             )
+  end
+end


### PR DESCRIPTION
this moves the download document action to use the new materialization event in record for lazy file loading.

This is a requirement for the new Disk data source but also to support media attachments in communication channels' incoming message