### PR TITLE
feat(data source): enforce external data sources with provider's permissions and person's identity

### DIFF
--- a/docs/services/channels.md
+++ b/docs/services/channels.md
@@ -174,16 +174,21 @@ again before returning content.
 
 Data-source file callbacks receive `%Zaq.Events.TrustedContext{}` separately from provider
 parameters. `Zaq.Channels.Api` derives it only from the incoming event envelope; bridges must
-never derive actors or `skip_permissions` from request parameters. Bridges that dispatch to
-another role, such as `DiskBridge` dispatching to Storage, project the same trusted context
-through that role's event helper.
+never derive actors or `skip_permissions` from request parameters. New code puts permission
+bypass in top-level runtime context or `event.opts[:skip_permissions]`, not in actor maps;
+actor-carried bypass is a compatibility input only. Bridges that dispatch to another role,
+such as `DiskBridge` dispatching to Storage, project the same trusted context through that
+role's event helper.
 
 `Zaq.Channels.DataSourceBridge` enforces Record permissions by default for file reads and
 mutations. Bridges normalize provider principals into permission Records with canonical
 `principal.channel`, `principal.identifier`, and `access_rights`; the global boundary matches
-those grants against the trusted actor's People-directory identity. A bridge may opt out only
-by implementing `owns_permission_checks?/0` and returning `true`; Disk does this because
-Storage owns source ACLs and checks them with current filesystem context.
+those grants against the trusted actor's People-directory identity. Signed-Record mutations
+are authorized before the bridge callback runs, and callback params contain only provider
+business fields such as `file_id`, `config_id`, metadata, and content. Provider-based updates
+are available only to bridges that implement `owns_permission_checks?/0` and return `true`;
+Disk does this because Storage owns source ACLs and checks them with current filesystem
+context.
 
 Unmaterialized data-source file records carry a signed `materialization_handle` of type
 `data_source_document`. The handle survives agent/tool JSON serialization and is redeemed

--- a/docs/services/channels.md
+++ b/docs/services/channels.md
@@ -178,10 +178,19 @@ never derive actors or `skip_permissions` from request parameters. Bridges that 
 another role, such as `DiskBridge` dispatching to Storage, project the same trusted context
 through that role's event helper.
 
+`Zaq.Channels.DataSourceBridge` enforces Record permissions by default for file reads and
+mutations. Bridges normalize provider principals into permission Records with canonical
+`principal.channel`, `principal.identifier`, and `access_rights`; the global boundary matches
+those grants against the trusted actor's People-directory identity. A bridge may opt out only
+by implementing `owns_permission_checks?/0` and returning `true`; Disk does this because
+Storage owns source ACLs and checks them with current filesystem context.
+
 Unmaterialized data-source file records carry a signed `materialization_handle` of type
 `data_source_document`. The handle survives agent/tool JSON serialization and is redeemed
 through `Zaq.Materialization`; the Channels materializer validates the locator and dispatches
-the fixed `:data_source_download_document` action.
+the fixed `:data_source_download_document` action. The handle is a bearer capability disclosed
+only on Records the caller was authorized to read, so redemption does not repeat the provider
+permission check.
 
 Unmaterialized communication-media records carry a signed `materialization_handle`
 of type `communication_media`. The handle is redeemed through the same

--- a/docs/services/materialization.md
+++ b/docs/services/materialization.md
@@ -6,15 +6,17 @@
 available from another service role.
 
 Records carry metadata plus optional `materialization_handle`. The handle is a signed
-locator, not an authorization grant. It contains only:
+bearer locator: possession is enough to redeem content because handles are only disclosed
+on Records after the data-source boundary authorizes `read` access. It contains only:
 
 - `v` — handle version
 - `type` — allowlisted materializer key
 - `locator` — materializer-specific primitive fields
 
 Handles intentionally do not contain destination roles, actions, modules, credentials,
-actors, or permission decisions. Current authorization must come from the trusted runtime
-context that redeems the handle.
+actors, or permission decisions. Do not mint or expose a materialization handle for a
+Record until its caller is authorized to read that Record; redemption does not re-check
+provider ACLs.
 
 `Zaq.Events.TrustedContext` is the only reusable projection of that runtime context across
 role and bridge boundaries. It retains the canonical actor and literal
@@ -48,6 +50,8 @@ Locator fields:
 
 Per-redemption options:
 
+- `document_mime_type` — optional source MIME type when the caller needs to override or
+  supply representation metadata outside the signed locator.
 - `export_mime_type` — optional requested export MIME type. This is request-time
   representation state, not document identity, so it is passed separately from the
   signed locator. When present it overrides any configured default for the source

--- a/lib/zaq/agent/tools/data_source/download_document.ex
+++ b/lib/zaq/agent/tools/data_source/download_document.ex
@@ -2,9 +2,7 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
   @moduledoc """
   ReAct tool: materializes Record content.
 
-  Pass either a `materialization_handle` returned by a Record, or a `provider` +
-  `document_id` pair. The provider pair may include `config_id` to select an explicit
-  data-source configuration.
+  Pass a `materialization_handle` returned by an authorized Record.
 
   Delegates to Channels through `NodeRouter.dispatch/1`.
   """
@@ -17,12 +15,6 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
                     "Signed materialization handle returned by any supported unmaterialized Record, including data-source documents and communication-channel attachments."
                 )
                 |> Zoi.optional(),
-              provider:
-                Zoi.string(description: "Datasource provider key.")
-                |> Zoi.optional(),
-              document_id:
-                Zoi.string(description: "Provider document identifier.")
-                |> Zoi.optional(),
               document_mime_type:
                 Zoi.string(
                   description:
@@ -34,9 +26,6 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
                   description:
                     "Optional target MIME type to request provider export when supported."
                 )
-                |> Zoi.optional(),
-              config_id:
-                Zoi.string(description: "Optional scoped datasource config id.")
                 |> Zoi.optional()
             },
             unrecognized_keys: :preserve
@@ -60,17 +49,17 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
     description: """
     Materialize a record to retrieve its full content.
 
-    Pass either a materialization_handle, or a data-source provider plus document_id.
-    Handles can materialize any supported Record, including communication-channel attachments.
-    Include config_id with provider/document_id when a specific data-source config is required.
+    Handles can materialize any supported Record, including data-source documents and
+    communication-channel attachments. Data-source handles are bearer capabilities that are
+    disclosed only on Records the actor was authorized to read.
+    Optional MIME fields control source/export representation only; they are not identity or
+    authorization inputs.
 
     Returns the normalized record including its materialized content.
     """,
     schema: @schema
 
   alias Jido.Action.Tool
-  alias Zaq.Agent.Tools.DataSourceTool
-  alias Zaq.Channels.Materializers.DataSourceDocument
   alias Zaq.Helpers
   alias Zaq.Materialization
 
@@ -90,24 +79,14 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
         Map.get(params, :materialization_handle) || Map.get(params, "materialization_handle")
       )
 
-    has_provider? = not Helpers.blank?(Map.get(params, :provider) || Map.get(params, "provider"))
-
-    has_document_id? =
-      not Helpers.blank?(Map.get(params, :document_id) || Map.get(params, "document_id"))
-
-    has_provider_mode? = has_provider? and has_document_id?
-
-    validate_input_mode_flags(has_handle?, has_provider_mode?)
+    validate_input_mode_flags(has_handle?)
   end
 
   def validate_input_mode(_params, _opts),
     do: {:error, "download_document input must be an object"}
 
-  defp validate_input_mode_flags(true, false), do: :ok
-  defp validate_input_mode_flags(false, true), do: :ok
-
-  defp validate_input_mode_flags(_has_handle?, _has_provider_mode?),
-    do: {:error, "provide either materialization_handle or provider with document_id"}
+  defp validate_input_mode_flags(true), do: :ok
+  defp validate_input_mode_flags(false), do: {:error, "provide materialization_handle"}
 
   @impl Jido.Action
 
@@ -120,37 +99,22 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocument do
     )
   end
 
-  def run(%{provider: provider, document_id: document_id} = params, context) do
-    error_prefix = "Data source document download failed"
-    attrs = optional_attrs(params)
-
-    with {:ok, handle} <- DataSourceDocument.issue(provider, document_id, attrs),
-         {:ok, payload} <-
-           Materialization.materialize(
-             handle,
-             context,
-             error_prefix,
-             materialization_options(params)
-           ) do
-      {:ok, payload}
-    else
-      {:error, reason} when is_binary(reason) -> {:error, reason}
-      {:error, reason} -> {:error, "#{error_prefix}: #{inspect(reason)}"}
-    end
-  end
-
   def run(_params, _context),
-    do: {:error, "Provide either materialization_handle or provider with document_id"}
-
-  defp optional_attrs(params) do
-    %{}
-    |> DataSourceTool.merge_optional(params, [:document_mime_type, :config_id])
-    |> Map.reject(fn {_key, value} -> Helpers.blank?(value) end)
-  end
+    do: {:error, "Provide materialization_handle"}
 
   defp materialization_options(params) do
     %{}
-    |> DataSourceTool.merge_optional(params, [:export_mime_type])
+    |> put_if_present(
+      "document_mime_type",
+      Map.get(params, :document_mime_type) || Map.get(params, "document_mime_type")
+    )
+    |> put_if_present(
+      "export_mime_type",
+      Map.get(params, :export_mime_type) || Map.get(params, "export_mime_type")
+    )
     |> Map.reject(fn {_key, value} -> Helpers.blank?(value) end)
   end
+
+  defp put_if_present(map, _key, nil), do: map
+  defp put_if_present(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/zaq/channels/data_source_bridge.ex
+++ b/lib/zaq/channels/data_source_bridge.ex
@@ -37,7 +37,15 @@ defmodule Zaq.Channels.DataSourceBridge do
 
   File operations receive a normalized `Zaq.Events.TrustedContext` as their third callback
   argument. Identity and explicit permission bypass therefore remain separate from provider
-  parameters and cannot be supplied by model-controlled request fields.
+  parameters and cannot be supplied by model-controlled request fields. Bridge callback params
+  contain only provider business fields such as `file_id`, `config_id`, metadata, and content;
+  they never carry the full `%Zaq.Contracts.Record{}`.
+
+  Mutations through a signed Record are authorized here before the bridge callback runs.
+  Provider-based `update_file/3` is available only to bridges that implement
+  `owns_permission_checks?/0`, because those bridges re-check permissions in their source
+  system. Other bridges must mutate via signed Records so this boundary can enforce the
+  Record permissions.
   """
 
   alias Zaq.Channels.Bridge
@@ -690,6 +698,9 @@ defmodule Zaq.Channels.DataSourceBridge do
     end
   end
 
+  defp authorize_response({:ok, _payload}, _bridge, _right, _context),
+    do: {:error, {:invalid_bridge_response, :authorization_required}}
+
   defp authorize_response(other, _bridge, _right, _context), do: other
 
   defp permission_projection_params(params, %TrustedContext{skip_permissions: true}) do
@@ -768,9 +779,8 @@ defmodule Zaq.Channels.DataSourceBridge do
 
   defp fetch_unscoped_data_source_config(provider), do: Bridge.fetch_channel_config(provider)
 
-  defp delete_file_params(record, claims) do
+  defp delete_file_params(_record, claims) do
     %{"file_id" => Map.fetch!(claims, "provider_record_id")}
-    |> Map.put("record", record)
     |> maybe_put("config_id", Map.get(claims, "config_id"))
   end
 
@@ -782,7 +792,6 @@ defmodule Zaq.Channels.DataSourceBridge do
     |> Map.new()
     |> drop_copied_record_path(record)
     |> Map.put("file_id", Map.fetch!(claims, "provider_record_id"))
-    |> Map.put("record", record)
     |> maybe_put("config_id", Map.get(claims, "config_id"))
   end
 

--- a/lib/zaq/channels/data_source_bridge.ex
+++ b/lib/zaq/channels/data_source_bridge.ex
@@ -672,15 +672,12 @@ defmodule Zaq.Channels.DataSourceBridge do
 
   defp authorize_response({:ok, %RecordPage{records: records} = page}, bridge, right, context)
        when is_list(records) do
-    if bridge_owns_permission_checks?(bridge) or
-         TrustedContext.normalize(context).skip_permissions do
+    context = TrustedContext.normalize(context)
+
+    if bridge_owns_permission_checks?(bridge) or context.skip_permissions do
       {:ok, page}
     else
-      records =
-        Enum.filter(
-          records,
-          &(Authorization.can?(TrustedContext.normalize(context).actor, &1, right) == true)
-        )
+      records = Authorization.filter(context.actor, records, right)
 
       {:ok,
        %{page | records: records, stats: Map.put(page.stats || %{}, :returned, length(records))}}
@@ -714,6 +711,8 @@ defmodule Zaq.Channels.DataSourceBridge do
   end
 
   defp authorize_record(bridge, %Record{} = record, rights, context) when is_list(rights) do
+    context = TrustedContext.normalize(context)
+
     cond do
       rights == [] ->
         {:error, {:invalid_request, :changes_required}}
@@ -721,10 +720,10 @@ defmodule Zaq.Channels.DataSourceBridge do
       bridge_owns_permission_checks?(bridge) ->
         :ok
 
-      TrustedContext.normalize(context).skip_permissions ->
+      context.skip_permissions ->
         :ok
 
-      Enum.all?(rights, &Authorization.can?(TrustedContext.normalize(context).actor, record, &1)) ->
+      Enum.all?(rights, &Authorization.can?(context.actor, record, &1)) ->
         :ok
 
       true ->

--- a/lib/zaq/channels/data_source_bridge.ex
+++ b/lib/zaq/channels/data_source_bridge.ex
@@ -43,6 +43,7 @@ defmodule Zaq.Channels.DataSourceBridge do
   alias Zaq.Channels.Bridge
   alias Zaq.Channels.ChannelConfig
   alias Zaq.Contracts.Record
+  alias Zaq.Contracts.Record.Authorization
   alias Zaq.Contracts.Record.Provenance
   alias Zaq.Contracts.RecordPage
   alias Zaq.Events.TrustedContext
@@ -86,6 +87,7 @@ defmodule Zaq.Channels.DataSourceBridge do
   @callback sheet_append_values(map(), map()) :: {:ok, map()} | {:error, term()}
   @callback sheet_clear_values(map(), map()) :: {:ok, map()} | {:error, term()}
   @callback sheet_delete_tab(map(), map()) :: {:ok, map()} | {:error, term()}
+  @callback owns_permission_checks?() :: boolean()
 
   # Every callback above is optional. This module already dispatches through
   # `supports_callback?/3` and answers `{:error, :unsupported}` for anything a bridge does
@@ -127,7 +129,8 @@ defmodule Zaq.Channels.DataSourceBridge do
                       sheet_update_values: 2,
                       sheet_append_values: 2,
                       sheet_clear_values: 2,
-                      sheet_delete_tab: 2
+                      sheet_delete_tab: 2,
+                      owns_permission_checks?: 0
 
   @required_capabilities [
     :list_items,
@@ -340,10 +343,17 @@ defmodule Zaq.Channels.DataSourceBridge do
           {:ok, RecordPage.t()} | {:error, term()}
   def list_files(provider, params \\ %{}, context \\ %{})
       when is_map(params) and is_map(context) do
+    trusted_context = TrustedContext.normalize(context)
+
     with {:ok, bridge} <- Bridge.resolve_bridge(provider),
          {:ok, config} <- resolve_data_source_config(provider, params),
          true <- supports_callback?(bridge, :list_files, 3) || {:error, :unsupported} do
-      bridge.list_files(config, params, TrustedContext.normalize(context))
+      bridge.list_files(
+        config,
+        permission_projection_params(params, trusted_context),
+        trusted_context
+      )
+      |> authorize_response(bridge, :read, trusted_context)
       |> seal_response(config)
     end
   end
@@ -365,10 +375,17 @@ defmodule Zaq.Channels.DataSourceBridge do
   @spec get_file(atom() | String.t(), map(), map() | TrustedContext.t()) ::
           {:ok, map()} | {:error, term()}
   def get_file(provider, params \\ %{}, context \\ %{}) when is_map(params) and is_map(context) do
+    trusted_context = TrustedContext.normalize(context)
+
     with {:ok, bridge} <- Bridge.resolve_bridge(provider),
          {:ok, config} <- resolve_data_source_config(provider, params),
          true <- supports_callback?(bridge, :get_file, 3) || {:error, :unsupported} do
-      bridge.get_file(config, params, TrustedContext.normalize(context))
+      bridge.get_file(
+        config,
+        permission_projection_params(params, trusted_context),
+        trusted_context
+      )
+      |> authorize_response(bridge, :read, trusted_context)
       |> seal_response(config)
     end
   end
@@ -385,7 +402,8 @@ defmodule Zaq.Channels.DataSourceBridge do
          params <- update_file_params(record, claims, params),
          {:ok, bridge} <- Bridge.resolve_bridge(provider),
          {:ok, config} <- resolve_data_source_config(provider, params),
-         true <- supports_callback?(bridge, :update_file, 3) || {:error, :unsupported} do
+         true <- supports_callback?(bridge, :update_file, 3) || {:error, :unsupported},
+         :ok <- authorize_record(bridge, record, update_rights(params), context) do
       bridge.update_file(config, params, TrustedContext.normalize(context))
       |> seal_response(config)
     end
@@ -397,6 +415,9 @@ defmodule Zaq.Channels.DataSourceBridge do
       when is_map(params) and is_map(context) do
     with {:ok, bridge} <- Bridge.resolve_bridge(provider),
          {:ok, config} <- resolve_data_source_config(provider, params),
+         true <-
+           bridge_owns_permission_checks?(bridge) ||
+             {:error, {:invalid_request, :record_required}},
          true <- supports_callback?(bridge, :update_file, 3) || {:error, :unsupported} do
       bridge.update_file(config, params, TrustedContext.normalize(context))
       |> seal_response(config)
@@ -408,10 +429,11 @@ defmodule Zaq.Channels.DataSourceBridge do
   def delete_file(%Record{} = record, context \\ %{}) when is_map(context) do
     with {:ok, claims} <- Provenance.verify(record),
          {:ok, provider} <- claim_provider(claims),
-         params <- delete_file_params(claims),
+         params <- delete_file_params(record, claims),
          {:ok, bridge} <- Bridge.resolve_bridge(provider),
          {:ok, config} <- resolve_data_source_config(provider, params),
-         true <- supports_callback?(bridge, :delete_file, 3) || {:error, :unsupported} do
+         true <- supports_callback?(bridge, :delete_file, 3) || {:error, :unsupported},
+         :ok <- authorize_record(bridge, record, [:delete], context) do
       bridge.delete_file(config, params, TrustedContext.normalize(context))
     end
   end
@@ -421,10 +443,17 @@ defmodule Zaq.Channels.DataSourceBridge do
           {:ok, RecordPage.t()} | {:error, term()}
   def search_files(provider, params \\ %{}, context \\ %{})
       when is_map(params) and is_map(context) do
+    trusted_context = TrustedContext.normalize(context)
+
     with {:ok, bridge} <- Bridge.resolve_bridge(provider),
          {:ok, config} <- resolve_data_source_config(provider, params),
          true <- supports_callback?(bridge, :search_files, 3) || {:error, :unsupported} do
-      bridge.search_files(config, params, TrustedContext.normalize(context))
+      bridge.search_files(
+        config,
+        permission_projection_params(params, trusted_context),
+        trusted_context
+      )
+      |> authorize_response(bridge, :read, trusted_context)
       |> seal_response(config)
     end
   end
@@ -641,6 +670,96 @@ defmodule Zaq.Channels.DataSourceBridge do
     %{"provider" => provider, "config_id" => id}
   end
 
+  defp authorize_response({:ok, %RecordPage{records: records} = page}, bridge, right, context)
+       when is_list(records) do
+    if bridge_owns_permission_checks?(bridge) or
+         TrustedContext.normalize(context).skip_permissions do
+      {:ok, page}
+    else
+      records =
+        Enum.filter(
+          records,
+          &(Authorization.can?(TrustedContext.normalize(context).actor, &1, right) == true)
+        )
+
+      {:ok,
+       %{page | records: records, stats: Map.put(page.stats || %{}, :returned, length(records))}}
+    end
+  end
+
+  defp authorize_response({:ok, %{record: %Record{} = record} = payload}, bridge, right, context) do
+    with :ok <- authorize_record(bridge, record, [right], context) do
+      {:ok, payload}
+    end
+  end
+
+  defp authorize_response(other, _bridge, _right, _context), do: other
+
+  defp permission_projection_params(params, %TrustedContext{skip_permissions: true}) do
+    put_include_permissions(params, explicitly_requested_permissions?(params))
+  end
+
+  defp permission_projection_params(params, %TrustedContext{}),
+    do: put_include_permissions(params, true)
+
+  defp explicitly_requested_permissions?(params) do
+    Map.get(params, "include_permissions") == true or
+      Map.get(params, :include_permissions) == true
+  end
+
+  defp put_include_permissions(params, value) do
+    params
+    |> Map.delete(:include_permissions)
+    |> Map.put("include_permissions", value)
+  end
+
+  defp authorize_record(bridge, %Record{} = record, rights, context) when is_list(rights) do
+    cond do
+      rights == [] ->
+        {:error, {:invalid_request, :changes_required}}
+
+      bridge_owns_permission_checks?(bridge) ->
+        :ok
+
+      TrustedContext.normalize(context).skip_permissions ->
+        :ok
+
+      Enum.all?(rights, &Authorization.can?(TrustedContext.normalize(context).actor, record, &1)) ->
+        :ok
+
+      true ->
+        {:error, :unauthorized}
+    end
+  end
+
+  defp bridge_owns_permission_checks?(bridge) do
+    function_exported?(bridge, :owns_permission_checks?, 0) and
+      bridge.owns_permission_checks?() == true
+  end
+
+  defp update_rights(params) do
+    rights = []
+
+    rights =
+      if present_update_value?(params, [
+           "name",
+           :name,
+           "content",
+           :content,
+           "mime_type",
+           :mime_type
+         ]), do: [:edit | rights], else: rights
+
+    rights =
+      if present_update_value?(params, ["path", :path, "parent_id", :parent_id]),
+        do: [:move | rights],
+        else: rights
+
+    Enum.uniq(rights)
+  end
+
+  defp present_update_value?(params, keys), do: Enum.any?(keys, &Map.has_key?(params, &1))
+
   defp resolve_data_source_config(provider, params) do
     case normalize_config_id(params) do
       {:ok, id} -> fetch_scoped_data_source_config(provider, id)
@@ -650,8 +769,9 @@ defmodule Zaq.Channels.DataSourceBridge do
 
   defp fetch_unscoped_data_source_config(provider), do: Bridge.fetch_channel_config(provider)
 
-  defp delete_file_params(claims) do
+  defp delete_file_params(record, claims) do
     %{"file_id" => Map.fetch!(claims, "provider_record_id")}
+    |> Map.put("record", record)
     |> maybe_put("config_id", Map.get(claims, "config_id"))
   end
 
@@ -663,6 +783,7 @@ defmodule Zaq.Channels.DataSourceBridge do
     |> Map.new()
     |> drop_copied_record_path(record)
     |> Map.put("file_id", Map.fetch!(claims, "provider_record_id"))
+    |> Map.put("record", record)
     |> maybe_put("config_id", Map.get(claims, "config_id"))
   end
 

--- a/lib/zaq/channels/disk_bridge.ex
+++ b/lib/zaq/channels/disk_bridge.ex
@@ -57,6 +57,9 @@ defmodule Zaq.Channels.DiskBridge do
   @impl Zaq.Channels.Bridge
   def to_internal(_payload, _config), do: {:error, :unsupported}
 
+  @impl Zaq.Channels.DataSourceBridge
+  def owns_permission_checks?, do: true
+
   @impl Zaq.Channels.Bridge
   def capability_snapshot(_config) do
     resolved =

--- a/lib/zaq/channels/jido_connect_bridge.ex
+++ b/lib/zaq/channels/jido_connect_bridge.ex
@@ -79,6 +79,16 @@ defmodule Zaq.Channels.JidoConnectBridge do
   alias Zaq.Utils.Scopes
   require Logger
 
+  @provider_read_permissions MapSet.new(["read", "reader", "commenter"])
+  @provider_edit_permissions MapSet.new([
+                               "edit",
+                               "write",
+                               "writer",
+                               "owner",
+                               "organizer",
+                               "fileorganizer"
+                             ])
+
   @impl true
   def auth_handshake(config, params) when is_map(config) and is_map(params),
     do: {:error, :unsupported}
@@ -111,6 +121,8 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
   @impl true
   def get_file(config, params, _context \\ %{}) when is_map(config) and is_map(params) do
+    params = maybe_embed_permissions_projection(params, config)
+
     with {:ok, payload} <- invoke_intent(config, :get_item_metadata, params),
          {:ok, record} <- map_file_from_payload(payload, config, params) do
       {:ok, %{record: record}}
@@ -119,7 +131,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
   @impl true
   def update_file(config, params, _context \\ %{}) when is_map(config) and is_map(params) do
-    with {:ok, payload} <- invoke_intent(config, :update_item, params),
+    with {:ok, payload} <- invoke_intent(config, :update_item, provider_params(params)),
          {:ok, record} <- map_file_from_payload(payload) do
       {:ok, %{status: "updated", record: record}}
     end
@@ -127,13 +139,15 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
   @impl true
   def delete_file(config, params, _context \\ %{}) when is_map(config) and is_map(params) do
-    with {:ok, payload} <- invoke_intent(config, :delete_item, params) do
+    with {:ok, payload} <- invoke_intent(config, :delete_item, provider_params(params)) do
       {:ok, %{status: "deleted", result: payload}}
     end
   end
 
   @impl true
   def search_files(config, params, _context \\ %{}) when is_map(config) and is_map(params) do
+    params = maybe_embed_permissions_projection(params, config)
+
     with {:ok, payload} <- invoke_intent(config, :search_items, params) do
       map_file_page(payload, config, params)
     end
@@ -1815,6 +1829,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
     %{
       "permission_id" => read_stringish(raw, ["id", :id, "permission_id", :permission_id]),
       "principal_type" => read_stringish(raw, ["type", :type]),
+      "principal" => permission_principal(raw),
       "principal_key" =>
         read_stringish(raw, [
           "emailAddress",
@@ -1829,6 +1844,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
           :permission_id
         ]),
       "role" => read_stringish(raw, ["role", :role]),
+      "access_rights" => permission_access_rights(raw),
       "inherited" => read_any(raw, ["inherited", :inherited, "inherited?", :inherited?]),
       "origin_resource_id" =>
         read_stringish(raw, [
@@ -1853,6 +1869,69 @@ defmodule Zaq.Channels.JidoConnectBridge do
         nil
     end
   end
+
+  defp permission_principal(raw) do
+    channel = permission_principal_channel(raw)
+    identifier = permission_principal_identifier(raw)
+
+    if is_binary(channel) and is_binary(identifier) do
+      %{"channel" => channel, "identifier" => identifier}
+    end
+  end
+
+  defp permission_principal_channel(raw) do
+    cond do
+      read_stringish(raw, ["emailAddress", :emailAddress, "email_address", :email_address]) ->
+        "email"
+
+      read_stringish(raw, ["email", :email]) ->
+        "email"
+
+      true ->
+        read_stringish(raw, ["channel", :channel, "principal_channel", :principal_channel])
+    end
+  end
+
+  defp permission_principal_identifier(raw) do
+    read_stringish(raw, [
+      "emailAddress",
+      :emailAddress,
+      "email_address",
+      :email_address,
+      "email",
+      :email,
+      "channel_identifier",
+      :channel_identifier,
+      "principal_key",
+      :principal_key
+    ])
+  end
+
+  defp permission_access_rights(raw) do
+    raw
+    |> read_any(["access_rights", :access_rights])
+    |> List.wrap()
+    |> case do
+      [] -> [read_stringish(raw, ["role", :role])]
+      rights -> rights
+    end
+    |> Enum.flat_map(&canonical_access_rights/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp canonical_access_rights(value) when is_binary(value) do
+    value = value |> String.trim() |> String.downcase()
+
+    cond do
+      MapSet.member?(@provider_read_permissions, value) -> ["read"]
+      MapSet.member?(@provider_edit_permissions, value) -> ["read", "edit", "move", "delete"]
+      value in ["move", "delete"] -> [value]
+      true -> []
+    end
+  end
+
+  defp canonical_access_rights(_value), do: []
 
   defp maybe_embed_permissions_projection(params, %{provider: provider} = _config)
        when is_map(params) and (is_binary(provider) or is_atom(provider)) do
@@ -3389,6 +3468,9 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
   defp webhook_worker_module,
     do: Application.get_env(:zaq, :jido_connect_bridge_webhook_worker_module, WebhookWorker)
+
+  defp provider_params(params) when is_map(params),
+    do: Map.drop(params, ["record", :record])
 
   defp oban_module,
     do: Application.get_env(:zaq, :jido_connect_bridge_oban_module, Oban)

--- a/lib/zaq/channels/materializers/data_source_document.ex
+++ b/lib/zaq/channels/materializers/data_source_document.ex
@@ -11,7 +11,7 @@ defmodule Zaq.Channels.Materializers.DataSourceDocument do
 
   @type_key "data_source_document"
   @locator_fields ~w(config_id document_mime_type)
-  @option_fields ~w(export_mime_type)
+  @option_fields ~w(document_mime_type export_mime_type)
 
   @spec issue(atom() | String.t(), String.t(), map(), keyword()) ::
           {:ok, String.t()} | {:error, term()}

--- a/lib/zaq/contracts/record/authorization.ex
+++ b/lib/zaq/contracts/record/authorization.ex
@@ -1,0 +1,91 @@
+defmodule Zaq.Contracts.Record.Authorization do
+  @moduledoc """
+  Generic actor authorization for Records that carry normalized permission Records.
+  """
+
+  alias Zaq.Accounts.People
+  alias Zaq.Contracts.Record
+  alias Zaq.Identity.ActorNormalizer
+
+  @spec can?(map() | nil, Record.t(), atom()) :: boolean()
+  def can?(actor, %Record{permissions: permissions}, right) when is_list(permissions) do
+    with person_id when not is_nil(person_id) <- ActorNormalizer.person_id(actor),
+         person when not is_nil(person) <- People.get_person_with_channels(person_id) do
+      Enum.any?(permissions, &permission_matches?(&1, person, right))
+    else
+      _ -> false
+    end
+  end
+
+  def can?(_actor, _record, _right), do: false
+
+  defp permission_matches?(%Record{attributes: attrs}, person, right) when is_map(attrs) do
+    principal_matches?(attrs, person) and right in access_rights(attrs)
+  end
+
+  defp permission_matches?(_permission, _person, _right), do: false
+
+  defp principal_matches?(attrs, person) do
+    case principal(attrs) do
+      {"email", identifier} ->
+        normalized(identifier) == normalized(person.email) or
+          Enum.any?(person.channels || [], &channel_matches?(&1, "email", identifier))
+
+      {channel, identifier} ->
+        Enum.any?(person.channels || [], &channel_matches?(&1, channel, identifier))
+
+      _ ->
+        false
+    end
+  end
+
+  defp channel_matches?(channel, platform, identifier) do
+    channel.platform == platform and
+      normalized(channel.channel_identifier) == normalized(identifier)
+  end
+
+  defp principal(attrs) do
+    case get(attrs, "principal") do
+      %{} = principal ->
+        channel = get(principal, "channel") || get(principal, "type")
+        identifier = get(principal, "identifier") || get(principal, "key")
+        normalized_principal(channel, identifier)
+
+      _ ->
+        channel = get(attrs, "principal_channel") || get(attrs, "principal_type")
+        normalized_principal(channel, get(attrs, "principal_key"))
+    end
+  end
+
+  defp normalized_principal(channel, identifier)
+       when is_binary(channel) and is_binary(identifier) and channel != "" and identifier != "" do
+    {String.downcase(String.trim(channel)), String.trim(identifier)}
+  end
+
+  defp normalized_principal(_channel, _identifier), do: nil
+
+  defp access_rights(attrs) do
+    attrs
+    |> get("access_rights")
+    |> List.wrap()
+    |> Enum.map(&to_string/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.flat_map(&canonical_right/1)
+  end
+
+  defp canonical_right("read"), do: [:read]
+  defp canonical_right("edit"), do: [:edit]
+  defp canonical_right("move"), do: [:move]
+  defp canonical_right("delete"), do: [:delete]
+  defp canonical_right(_right), do: []
+
+  defp normalized(value) when is_binary(value), do: value |> String.trim() |> String.downcase()
+  defp normalized(_value), do: nil
+
+  defp get(map, key) do
+    Map.get(map, key) || Map.get(map, String.to_existing_atom(key))
+  rescue
+    ArgumentError -> Map.get(map, key)
+  end
+end

--- a/lib/zaq/contracts/record/authorization.ex
+++ b/lib/zaq/contracts/record/authorization.ex
@@ -4,20 +4,42 @@ defmodule Zaq.Contracts.Record.Authorization do
   """
 
   alias Zaq.Accounts.People
+  alias Zaq.Accounts.Person
   alias Zaq.Contracts.Record
   alias Zaq.Identity.ActorNormalizer
 
-  @spec can?(map() | nil, Record.t(), atom()) :: boolean()
-  def can?(actor, %Record{permissions: permissions}, right) when is_list(permissions) do
+  @spec can?(Person.t() | map() | nil, Record.t(), atom()) :: boolean()
+  def can?(%Person{} = person, %Record{permissions: permissions}, right)
+      when is_list(permissions) do
+    Enum.any?(permissions, &permission_matches?(&1, person, right))
+  end
+
+  def can?(actor, %Record{} = record, right) do
     with person_id when not is_nil(person_id) <- ActorNormalizer.person_id(actor),
          person when not is_nil(person) <- People.get_person_with_channels(person_id) do
-      Enum.any?(permissions, &permission_matches?(&1, person, right))
+      can?(person, record, right)
     else
       _ -> false
     end
   end
 
   def can?(_actor, _record, _right), do: false
+
+  @spec filter(Person.t() | map() | nil, [Record.t()], atom()) :: [Record.t()]
+  def filter(%Person{} = person, records, right) when is_list(records) do
+    Enum.filter(records, &(can?(person, &1, right) == true))
+  end
+
+  def filter(actor, records, right) when is_list(records) do
+    with person_id when not is_nil(person_id) <- ActorNormalizer.person_id(actor),
+         person when not is_nil(person) <- People.get_person_with_channels(person_id) do
+      filter(person, records, right)
+    else
+      _ -> []
+    end
+  end
+
+  def filter(_actor, _records, _right), do: []
 
   defp permission_matches?(%Record{attributes: attrs}, person, right) when is_map(attrs) do
     principal_matches?(attrs, person) and right in access_rights(attrs)
@@ -29,10 +51,10 @@ defmodule Zaq.Contracts.Record.Authorization do
     case principal(attrs) do
       {"email", identifier} ->
         normalized(identifier) == normalized(person.email) or
-          Enum.any?(person.channels || [], &channel_matches?(&1, "email", identifier))
+          Enum.any?(person_channels(person), &channel_matches?(&1, "email", identifier))
 
       {channel, identifier} ->
-        Enum.any?(person.channels || [], &channel_matches?(&1, channel, identifier))
+        Enum.any?(person_channels(person), &channel_matches?(&1, channel, identifier))
 
       _ ->
         false
@@ -43,6 +65,9 @@ defmodule Zaq.Contracts.Record.Authorization do
     channel.platform == platform and
       normalized(channel.channel_identifier) == normalized(identifier)
   end
+
+  defp person_channels(%Person{channels: channels}) when is_list(channels), do: channels
+  defp person_channels(_person), do: []
 
   defp principal(attrs) do
     case get(attrs, "principal") do

--- a/lib/zaq/events/trusted_context.ex
+++ b/lib/zaq/events/trusted_context.ex
@@ -5,6 +5,13 @@ defmodule Zaq.Events.TrustedContext do
   Callers may provide a larger runtime context, but only canonical identity and an explicit
   permission bypass are retained. Runtime dependencies such as the node router and config are
   consumed locally when producing event-builder options and are never stored in this struct.
+
+  Put new permission-bypass decisions in one of two places: top-level
+  `context.skip_permissions` before a local call, or `event.opts[:skip_permissions]` before an
+  event crosses a role boundary. Actors carry identity; new code should not put authorization
+  decisions in actor maps. `from_event/1` still recognizes `actor.skip_permissions` as a
+  compatibility input for older BO call paths. Request parameters are never trusted for
+  permission bypass.
   """
 
   alias Zaq.Event

--- a/lib/zaq/events/trusted_context.ex
+++ b/lib/zaq/events/trusted_context.ex
@@ -40,9 +40,14 @@ defmodule Zaq.Events.TrustedContext do
   def from_event(%Event{} = event) do
     %__MODULE__{
       actor: event.actor,
-      skip_permissions: Keyword.get(event.opts, :skip_permissions) == true
+      skip_permissions:
+        Keyword.get(event.opts, :skip_permissions) == true or actor_skip_permissions?(event.actor)
     }
   end
+
+  defp actor_skip_permissions?(%{skip_permissions: true}), do: true
+  defp actor_skip_permissions?(%{"skip_permissions" => true}), do: true
+  defp actor_skip_permissions?(_actor), do: false
 
   @doc "Projects context into options accepted by role event builders."
   @spec event_builder_opts(t() | map(), keyword()) :: keyword()

--- a/lib/zaq_web/live/bo/ai/ingestion_live.ex
+++ b/lib/zaq_web/live/bo/ai/ingestion_live.ex
@@ -26,6 +26,7 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   alias Zaq.System
   alias ZaqWeb.Components.Drawer
   alias ZaqWeb.Live.BO.AI.BOActor
+  alias ZaqWeb.Live.BO.DataSourceEvents
   alias ZaqWeb.Live.BO.PreviewHelpers
 
   import Ecto.Query
@@ -1303,26 +1304,22 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   end
 
   defp dispatch_list_files(provider, params, socket) do
-    opts = [action: :data_source_list_files]
-    opts = Keyword.put(opts, :data_source_bridge_module, data_source_bridge_module())
-
-    Event.new(%{provider: provider, params: params}, :channels,
-      opts: opts,
-      actor: BOActor.build(socket.assigns.current_user)
+    DataSourceEvents.build_and_dispatch(
+      :data_source_list_files,
+      %{provider: provider, params: params},
+      socket.assigns.current_user,
+      event_opts: [data_source_bridge_module: data_source_bridge_module()]
     )
-    |> NodeRouter.dispatch()
     |> Map.get(:response)
   end
 
   defp dispatch_data_source_action(action, provider, params, socket) do
-    opts = [action: action]
-    opts = Keyword.put(opts, :data_source_bridge_module, data_source_bridge_module())
-
-    Event.new(%{provider: provider, params: params}, :channels,
-      opts: opts,
-      actor: BOActor.build(socket.assigns.current_user)
+    DataSourceEvents.build_and_dispatch(
+      action,
+      %{provider: provider, params: params},
+      socket.assigns.current_user,
+      event_opts: [data_source_bridge_module: data_source_bridge_module()]
     )
-    |> NodeRouter.dispatch()
     |> Map.get(:response)
   end
 
@@ -1389,14 +1386,12 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   end
 
   defp dispatch_data_source_update(record, params, socket) do
-    opts = [action: :data_source_update_file]
-    opts = Keyword.put(opts, :data_source_bridge_module, data_source_bridge_module())
-
-    Event.new(%{record: record, params: params}, :channels,
-      opts: opts,
-      actor: BOActor.build(socket.assigns.current_user)
+    DataSourceEvents.build_and_dispatch(
+      :data_source_update_file,
+      %{record: record, params: params},
+      socket.assigns.current_user,
+      event_opts: [data_source_bridge_module: data_source_bridge_module()]
     )
-    |> NodeRouter.dispatch()
     |> Map.get(:response)
   end
 
@@ -1416,14 +1411,12 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLive do
   end
 
   defp dispatch_data_source_delete(record, socket) do
-    opts = [action: :data_source_delete_file]
-    opts = Keyword.put(opts, :data_source_bridge_module, data_source_bridge_module())
-
-    Event.new(%{record: record}, :channels,
-      opts: opts,
-      actor: BOActor.build(socket.assigns.current_user)
+    DataSourceEvents.build_and_dispatch(
+      :data_source_delete_file,
+      %{record: record},
+      socket.assigns.current_user,
+      event_opts: [data_source_bridge_module: data_source_bridge_module()]
     )
-    |> NodeRouter.dispatch()
     |> Map.get(:response)
   end
 

--- a/lib/zaq_web/live/bo/data_source_events.ex
+++ b/lib/zaq_web/live/bo/data_source_events.ex
@@ -4,7 +4,8 @@ defmodule ZaqWeb.Live.BO.DataSourceEvents do
 
   BO actor identity is trusted by the LiveView boundary. Super-admin permission bypass is
   projected into allowlisted event options so downstream services do not need to inspect the
-  actor map for authorization flags.
+  actor map for authorization flags. New BO data-source events should treat
+  `event.opts[:skip_permissions]` as the transport location for bypass decisions.
   """
 
   alias Zaq.Event

--- a/lib/zaq_web/live/bo/data_source_events.ex
+++ b/lib/zaq_web/live/bo/data_source_events.ex
@@ -1,0 +1,41 @@
+defmodule ZaqWeb.Live.BO.DataSourceEvents do
+  @moduledoc """
+  Builds trusted BO data-source events for Channels dispatch.
+
+  BO actor identity is trusted by the LiveView boundary. Super-admin permission bypass is
+  projected into allowlisted event options so downstream services do not need to inspect the
+  actor map for authorization flags.
+  """
+
+  alias Zaq.Event
+  alias Zaq.NodeRouter
+  alias ZaqWeb.Live.BO.AI.BOActor
+
+  @spec build(atom(), map(), map() | nil, keyword()) :: Event.t()
+  def build(action, request, current_user, opts \\ []) when is_atom(action) and is_map(request) do
+    actor = BOActor.build(current_user)
+
+    event_opts =
+      opts
+      |> Keyword.get(:event_opts, [])
+      |> Keyword.put(:action, action)
+      |> maybe_put_skip_permissions(actor)
+
+    Event.new(request, :channels,
+      opts: event_opts,
+      actor: actor
+    )
+  end
+
+  @spec build_and_dispatch(atom(), map(), map() | nil, keyword()) :: Event.t()
+  def build_and_dispatch(action, request, current_user, opts \\ []) do
+    action
+    |> build(request, current_user, opts)
+    |> NodeRouter.dispatch()
+  end
+
+  defp maybe_put_skip_permissions(opts, %{skip_permissions: true}),
+    do: Keyword.put(opts, :skip_permissions, true)
+
+  defp maybe_put_skip_permissions(opts, _actor), do: opts
+end

--- a/lib/zaq_web/live/bo/data_sources/provider_live.ex
+++ b/lib/zaq_web/live/bo/data_sources/provider_live.ex
@@ -17,6 +17,7 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLive do
   alias ZaqWeb.Live.BO.Communication.ChannelConfigPersistence
   alias ZaqWeb.Live.BO.Communication.OAuthClaimState
   alias ZaqWeb.Live.BO.Communication.OAuthPopupUI
+  alias ZaqWeb.Live.BO.DataSourceEvents
   alias ZaqWeb.Live.BO.EngineDispatch
   require Logger
 
@@ -371,7 +372,8 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLive do
 
     {folders, error, meta} =
       root_folders_for_provider(socket.assigns.provider, config.id, root_selector,
-        max_pages: max_pages
+        max_pages: max_pages,
+        current_user: socket.assigns.current_user
       )
 
     {:noreply,
@@ -407,7 +409,8 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLive do
         {new_folders, error, new_meta} =
           root_folders_for_provider(socket.assigns.provider, config.id, root_selector,
             max_pages: max_pages,
-            page_token: token
+            page_token: token,
+            current_user: socket.assigns.current_user
           )
 
         merged_folders =
@@ -685,10 +688,19 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLive do
   defp root_folders_for_provider(provider, config_id, root_selector, opts) do
     max_pages = Keyword.get(opts, :max_pages, @max_pages_default)
     start_page_token = Keyword.get(opts, :page_token)
+    current_user = Keyword.get(opts, :current_user)
 
     filters = datasource_list_filters(root_selector)
 
-    do_list_root_folders(provider, config_id, filters, root_selector, max_pages, start_page_token)
+    do_list_root_folders(
+      provider,
+      config_id,
+      filters,
+      root_selector,
+      max_pages,
+      start_page_token,
+      current_user
+    )
   end
 
   defp do_list_root_folders(
@@ -697,7 +709,8 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLive do
          filters,
          root_selector,
          max_pages,
-         start_page_token
+         start_page_token,
+         current_user
        ) do
     base_params = %{
       "config_id" => config_id,
@@ -712,7 +725,7 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLive do
       params = with_page_token(base_params, token)
 
       handle_root_folder_page_response(
-        dispatch_list_files(provider, params),
+        dispatch_list_files(provider, params, current_user),
         provider,
         config_id,
         root_selector,
@@ -875,15 +888,17 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLive do
     end
   end
 
-  defp dispatch_list_files(provider, params) do
-    event =
-      Event.new(
-        %{provider: provider, params: params},
-        :channels,
-        opts: [action: :data_source_list_files]
-      )
+  defp dispatch_list_files(provider, params, current_user) do
+    DataSourceEvents.build_and_dispatch(
+      :data_source_list_files,
+      %{provider: provider, params: params},
+      current_user,
+      event_opts: [data_source_bridge_module: data_source_bridge_module()]
+    ).response
+  end
 
-    NodeRouter.dispatch(event).response
+  defp data_source_bridge_module do
+    Zaq.Config.get(:zaq, :provider_live_data_source_bridge_module, DataSourceBridge, [])
   end
 
   defp dispatch_export_options(provider, params) do

--- a/test/support/provider_live_data_source_bridge_stubs.ex
+++ b/test/support/provider_live_data_source_bridge_stubs.ex
@@ -96,6 +96,17 @@ defmodule Zaq.Test.ProviderLiveDataSourceBridgeStubs.StillMore do
   end
 end
 
+defmodule Zaq.Test.ProviderLiveDataSourceBridgeStubs.CaptureContext do
+  @moduledoc false
+
+  alias Zaq.Test.ProviderLiveDataSourceBridgeStubs, as: Stubs
+
+  def list_files(_config, params, context) do
+    send(self(), {:provider_live_list_files, params, context})
+    {:ok, Stubs.page([Stubs.record("folder-captured", "Captured")], nil)}
+  end
+end
+
 defmodule Zaq.Test.ProviderLiveDataSourceBridgeStubs.DisplayMessageError do
   @moduledoc false
 

--- a/test/zaq/agent/tools/data_source/download_document_test.exs
+++ b/test/zaq/agent/tools/data_source/download_document_test.exs
@@ -3,12 +3,10 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
 
   alias Jido.Action.Schema
   alias Zaq.Agent.Tools.DataSource.DownloadDocument
-  alias Zaq.Channels.Materializers.DataSourceDocument
   alias Zaq.Contracts.Record
   alias Zaq.Contracts.Record.Provenance
   alias Zaq.Event
   alias Zaq.Materialization
-  alias Zaq.Materialization.Handle
   alias Zaq.Storage.Materializers.DiskDocument
 
   defmodule StubNodeRouter do
@@ -61,16 +59,8 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
       assert :ok = DownloadDocument.validate_input_mode(%{materialization_handle: "handle"})
     end
 
-    test "accepts provider and document_id input" do
-      assert :ok =
-               DownloadDocument.validate_input_mode(%{
-                 provider: "google_drive",
-                 document_id: "f1"
-               })
-    end
-
-    test "rejects missing, partial, and ambiguous input modes" do
-      message = "provide either materialization_handle or provider with document_id"
+    test "rejects missing and provider/document_id input modes" do
+      message = "provide materialization_handle"
 
       assert {:error, ^message} = DownloadDocument.validate_input_mode(%{})
 
@@ -81,7 +71,6 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
 
       assert {:error, ^message} =
                DownloadDocument.validate_input_mode(%{
-                 materialization_handle: "handle",
                  provider: "google_drive",
                  document_id: "f1"
                })
@@ -90,15 +79,15 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
     test "pre-validation converts map params using the action schema" do
       assert {:ok, converted} =
                DownloadDocument.on_before_validate_params(%{
-                 "provider" => "google_drive",
-                 "document_id" => "f1",
-                 "config_id" => "12",
+                 "materialization_handle" => "handle",
+                 "document_mime_type" => "text/markdown",
+                 "export_mime_type" => "text/plain",
                  "ignored" => "kept"
                })
 
-      assert converted.provider == "google_drive"
-      assert converted.document_id == "f1"
-      assert converted.config_id == "12"
+      assert converted.materialization_handle == "handle"
+      assert converted.document_mime_type == "text/markdown"
+      assert converted.export_mime_type == "text/plain"
       assert converted["ignored"] == "kept"
     end
 
@@ -132,7 +121,7 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
     assert_received {:dispatch, :channels, :data_source_download_document, %{"file_id" => "f1"}}
   end
 
-  test "materializes a signed handle with an explicit export MIME override" do
+  test "materializes a signed handle with MIME representation options" do
     assert {:ok, handle} =
              Materialization.issue("data_source_document", %{
                "provider" => "google_drive",
@@ -141,81 +130,48 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
 
     assert {:ok, %{record: %Record{} = record}} =
              DownloadDocument.run(
-               %{materialization_handle: handle, export_mime_type: "text/plain"},
-               %{node_router: StubNodeRouter}
-             )
-
-    assert record.id == "f1"
-    assert record.content == "abc"
-
-    assert_received {:dispatch, :channels, :data_source_download_document,
-                     %{"file_id" => "f1", "export_mime_type" => "text/plain"}}
-  end
-
-  test "provider and document_id mode issues then redeems a data-source handle" do
-    assert {:ok, %{record: %Record{} = record}} =
-             DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
-               node_router: StubNodeRouter
-             })
-
-    assert record.id == "f1"
-    assert record.content == "abc"
-    assert_received {:dispatch, :channels, :data_source_download_document, %{"file_id" => "f1"}}
-  end
-
-  test "provider mode preserves config and MIME options in the download request" do
-    assert {:ok, _} =
-             DownloadDocument.run(
                %{
-                 provider: "google_drive",
-                 document_id: "f1",
-                 config_id: "12",
+                 materialization_handle: handle,
                  document_mime_type: "application/vnd.google-apps.document",
                  export_mime_type: "text/plain"
                },
                %{node_router: StubNodeRouter}
              )
 
+    assert record.id == "f1"
+    assert record.content == "abc"
+
     assert_received {:dispatch, :channels, :data_source_download_document,
                      %{
                        "file_id" => "f1",
-                       "config_id" => "12",
                        "document_mime_type" => "application/vnd.google-apps.document",
                        "export_mime_type" => "text/plain"
                      }}
   end
 
-  test "provider mode keeps export MIME out of the signed locator" do
+  test "returns formatted errors" do
     assert {:ok, handle} =
-             DataSourceDocument.issue("google_drive", "f1", %{
-               "config_id" => "12",
-               "document_mime_type" => "application/vnd.google-apps.document",
-               "export_mime_type" => "text/plain"
+             Materialization.issue("data_source_document", %{
+               "provider" => "google_drive",
+               "file_id" => "f1"
              })
 
-    assert {:ok, %{locator: locator}} = Handle.verify(handle)
-
-    refute Map.has_key?(locator, "export_mime_type")
-  end
-
-  test "returns formatted errors" do
-    assert {:error, "Data source document download failed: :timeout"} =
-             DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
+    assert {:error, "Record materialization failed: :timeout"} =
+             DownloadDocument.run(%{materialization_handle: handle}, %{
                node_router: ErrorNodeRouter
              })
 
     assert {:error,
-            "Data source document download failed: unexpected materialize response :weird_response"} =
-             DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
+            "Record materialization failed: unexpected materialize response :weird_response"} =
+             DownloadDocument.run(%{materialization_handle: handle}, %{
                node_router: UnexpectedNodeRouter
              })
   end
 
   test "run returns an error when params do not contain a valid mode" do
-    assert {:error, "Provide either materialization_handle or provider with document_id"} =
-             DownloadDocument.run(%{}, %{})
+    assert {:error, "Provide materialization_handle"} = DownloadDocument.run(%{}, %{})
 
-    assert {:error, "Provide either materialization_handle or provider with document_id"} =
+    assert {:error, "Provide materialization_handle"} =
              DownloadDocument.run(%{provider: "google_drive"}, %{})
   end
 
@@ -288,23 +244,24 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
     end
 
     test "takes the second hop and returns text content for a text file" do
+      {:ok, handle} = DiskDocument.issue("guide.md")
+
       assert {:ok, %{record: %Record{} = record}} =
-               DownloadDocument.run(%{provider: "disk", document_id: "guide.md"}, %{
+               DownloadDocument.run(%{materialization_handle: handle}, %{
                  node_router: DiskNodeRouter
                })
 
       assert record.content == "# guide"
       refute Map.has_key?(record.attributes, "encoding")
 
-      assert_received {:first_hop, :channels, :data_source_download_document,
-                       %{"file_id" => "guide.md"}}
-
       assert_received {:second_hop, :storage, :materialize_document, "guide.md"}
     end
 
     test "returns base64 content for a binary file, flagged in attributes" do
+      {:ok, handle} = DiskDocument.issue("deck.pdf")
+
       assert {:ok, %{record: %Record{} = record}} =
-               DownloadDocument.run(%{provider: "disk", document_id: "deck.pdf"}, %{
+               DownloadDocument.run(%{materialization_handle: handle}, %{
                  node_router: DiskNodeRouter
                })
 
@@ -313,8 +270,14 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
     end
 
     test "a provider answering with content directly takes exactly one hop" do
+      assert {:ok, handle} =
+               Materialization.issue("data_source_document", %{
+                 "provider" => "google_drive",
+                 "file_id" => "f1"
+               })
+
       assert {:ok, %{record: %Record{id: "f1", content: "abc"}}} =
-               DownloadDocument.run(%{provider: "google_drive", document_id: "f1"}, %{
+               DownloadDocument.run(%{materialization_handle: handle}, %{
                  node_router: StubNodeRouter
                })
 
@@ -324,36 +287,19 @@ defmodule Zaq.Agent.Tools.DataSource.DownloadDocumentTest do
     end
 
     test "an error on the first hop is prefixed and no second hop is attempted" do
-      assert {:error, "Data source document download failed: :not_found"} =
-               DownloadDocument.run(%{provider: "disk", document_id: "guide.md"}, %{
+      {:ok, handle} =
+        Materialization.issue("data_source_document", %{
+          "provider" => "disk",
+          "file_id" => "guide.md"
+        })
+
+      assert {:error, "Record materialization failed: :not_found"} =
+               DownloadDocument.run(%{materialization_handle: handle}, %{
                  node_router: DiskFirstHopErrorRouter
                })
 
       assert_received :first_hop
       refute_received :second_hop
-    end
-
-    test "still merges the optional mime type and config keys into the first request" do
-      assert {:ok, _} =
-               DownloadDocument.run(
-                 %{
-                   provider: "disk",
-                   document_id: "guide.md",
-                   document_mime_type: "text/markdown",
-                   export_mime_type: "text/plain",
-                   config_id: "12"
-                 },
-                 %{node_router: DiskNodeRouter}
-               )
-
-      assert_received {:first_hop, :channels, :data_source_download_document, params}
-
-      assert params == %{
-               "file_id" => "guide.md",
-               "document_mime_type" => "text/markdown",
-               "export_mime_type" => "text/plain",
-               "config_id" => "12"
-             }
     end
   end
 end

--- a/test/zaq/channels/api_test.exs
+++ b/test/zaq/channels/api_test.exs
@@ -970,6 +970,25 @@ defmodule Zaq.Channels.ApiTest do
     assert context == %TrustedContext{actor: nil, skip_permissions: true}
   end
 
+  test "carries trusted bypass projected from BO actor" do
+    actor = %{person_id: 7, provider: "bo", skip_permissions: true}
+
+    event =
+      Event.new(%{provider: :disk, params: %{"query" => "invoice"}}, :channels,
+        actor: actor,
+        opts: [
+          action: :data_source_search_files,
+          data_source_bridge_module: StubDataSourceBridge
+        ]
+      )
+
+    result = Api.handle_event(event, :data_source_search_files, nil)
+    assert {:ok, %{records: [%{"id" => "f1"}]}} = result.response
+
+    assert_received {:ds_search_files, :disk, %{"query" => "invoice"}, context}
+    assert context == %TrustedContext{actor: actor, skip_permissions: true}
+  end
+
   test "does not trust bypass or actor markers from request params" do
     actor = %{person_id: 7, provider: "bo"}
 

--- a/test/zaq/channels/data_source_bridge_test.exs
+++ b/test/zaq/channels/data_source_bridge_test.exs
@@ -2,6 +2,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
   use Zaq.DataCase, async: false
   use ExUnitProperties
 
+  alias Zaq.Accounts.{People, PersonChannel}
   alias Zaq.Channels.{Bridge, ChannelConfig, DataSourceBridge, DiskBridge}
   alias Zaq.Contracts.Record
   alias Zaq.Contracts.Record.Provenance
@@ -239,7 +240,10 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
       permission = %Record{
         id: "perm-1",
         kind: :permission,
-        attributes: %{"target_id" => "user@example.com", "role" => "reader"}
+        attributes: %{
+          "principal" => %{"channel" => "email", "identifier" => "user@example.com"},
+          "access_rights" => ["read"]
+        }
       }
 
       record = %Record{
@@ -304,6 +308,54 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
   defp disk_settings(:disk), do: %{"volumes" => [%{"name" => "docs", "path" => "docs"}]}
   defp disk_settings("disk"), do: %{"volumes" => [%{"name" => "docs", "path" => "docs"}]}
   defp disk_settings(_provider), do: %{}
+
+  defp person_fixture(email \\ nil) do
+    unique = System.unique_integer([:positive])
+    email = email || "actor-#{unique}@example.com"
+
+    {:ok, person} =
+      People.create_person(%{
+        "full_name" => "Actor #{unique}",
+        "email" => email,
+        "phone" => "+1555#{unique}"
+      })
+
+    person
+  end
+
+  defp permission_fixture(email, rights) do
+    %Record{
+      id: "perm-#{System.unique_integer([:positive])}",
+      kind: :permission,
+      attributes: %{
+        "principal" => %{"channel" => "email", "identifier" => email},
+        "access_rights" => rights
+      }
+    }
+  end
+
+  defp actor_context(person), do: %{actor: %{person: %{id: person.id}}}
+
+  defp use_record_returning_bridge do
+    Application.put_env(:zaq, :channels, %{
+      google_drive: %{
+        bridge: StubRecordReturningDataSourceBridge,
+        adapter: __MODULE__.StubAdapter
+      }
+    })
+  end
+
+  defp person_channel_fixture(person, attrs) do
+    params =
+      %{
+        platform: "mattermost",
+        channel_identifier: "channel-#{System.unique_integer([:positive])}",
+        person_id: person.id
+      }
+      |> Map.merge(attrs)
+
+    Repo.insert!(%PersonChannel{} |> PersonChannel.changeset(params))
+  end
 
   test "delegates datasource operations to provider bridge" do
     insert_data_source_config(:google_drive)
@@ -405,9 +457,14 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     end)
 
     config = insert_data_source_config(:google_drive)
+    person = person_fixture("USER@example.com")
 
     assert {:ok, %RecordPage{records: [%Record{} = record]}} =
-             DataSourceBridge.list_files(:google_drive, %{config_id: config.id})
+             DataSourceBridge.list_files(
+               :google_drive,
+               %{config_id: config.id},
+               actor_context(person)
+             )
 
     assert is_binary(record.provenance_ref)
     assert {:ok, claims} = Provenance.verify(record)
@@ -419,13 +476,55 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert {:ok, _permission_claims} = Provenance.verify(permission)
 
     assert {:ok, %{record: %Record{} = empty_permissions_record}} =
-             DataSourceBridge.get_file(:google_drive, %{
-               "file_id" => "file-2",
-               config_id: config.id
-             })
+             DataSourceBridge.get_file(
+               :google_drive,
+               %{
+                 "file_id" => "file-2",
+                 config_id: config.id
+               },
+               %{skip_permissions: true}
+             )
 
     assert {:ok, empty_claims} = Provenance.verify(empty_permissions_record)
     assert empty_claims["permissions"] == %{"state" => "loaded", "entries" => []}
+  end
+
+  test "globally filters and denies provider records by normalized permissions" do
+    original_channels = Application.get_env(:zaq, :channels)
+
+    Application.put_env(:zaq, :channels, %{
+      google_drive: %{
+        bridge: StubRecordReturningDataSourceBridge,
+        adapter: __MODULE__.StubAdapter
+      }
+    })
+
+    on_exit(fn -> Application.put_env(:zaq, :channels, original_channels) end)
+
+    config = insert_data_source_config(:google_drive)
+    actor = person_fixture("user@example.com")
+    other = person_fixture("other@example.com")
+
+    assert {:ok, %RecordPage{records: [%Record{id: "file-1"}]}} =
+             DataSourceBridge.list_files(
+               :google_drive,
+               %{config_id: config.id},
+               actor_context(actor)
+             )
+
+    assert {:ok, %RecordPage{records: []}} =
+             DataSourceBridge.list_files(
+               :google_drive,
+               %{config_id: config.id},
+               actor_context(other)
+             )
+
+    assert {:error, :unauthorized} =
+             DataSourceBridge.get_file(
+               :google_drive,
+               %{"file_id" => "file-2", config_id: config.id},
+               actor_context(actor)
+             )
   end
 
   test "replace_permissions delegates scoped config and trusted context" do
@@ -579,14 +678,23 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
       Provenance.seal(update_record, %{"provider" => "google_drive", "config_id" => config_id})
 
     assert {:ok, %{status: "updated", record: %{"id" => "f1"}}} =
-             DataSourceBridge.update_file(update_record, %{
-               "file_id" => "attacker-file",
-               "name" => "Renamed",
-               config_id: "999"
-             })
+             DataSourceBridge.update_file(
+               update_record,
+               %{
+                 "file_id" => "attacker-file",
+                 "name" => "Renamed",
+                 config_id: "999"
+               },
+               %{skip_permissions: true}
+             )
 
     assert_received {:update_file, ^config_id,
-                     %{"file_id" => "f1", "name" => "Renamed", "config_id" => ^config_id}}
+                     %{
+                       "file_id" => "f1",
+                       "name" => "Renamed",
+                       "config_id" => ^config_id,
+                       "record" => ^update_record
+                     }}
 
     delete_record = %Record{
       id: "record-f1",
@@ -601,9 +709,15 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     {:ok, delete_record} =
       Provenance.seal(delete_record, %{"provider" => "google_drive", "config_id" => config_id})
 
-    assert {:ok, %{status: "deleted", result: %{}}} = DataSourceBridge.delete_file(delete_record)
+    assert {:ok, %{status: "deleted", result: %{}}} =
+             DataSourceBridge.delete_file(delete_record, %{skip_permissions: true})
 
-    assert_received {:delete_file, ^config_id, %{"file_id" => "f1", "config_id" => ^config_id}}
+    assert_received {:delete_file, ^config_id,
+                     %{
+                       "file_id" => "f1",
+                       "config_id" => ^config_id,
+                       "record" => ^delete_record
+                     }}
 
     fallback_record = %Record{
       id: "fallback-f1",
@@ -615,10 +729,14 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
       Provenance.seal(fallback_record, %{"provider" => "google_drive", "config_id" => config_id})
 
     assert {:ok, %{status: "deleted", result: %{}}} =
-             DataSourceBridge.delete_file(fallback_record)
+             DataSourceBridge.delete_file(fallback_record, %{skip_permissions: true})
 
     assert_received {:delete_file, ^config_id,
-                     %{"file_id" => "fallback-f1", "config_id" => ^config_id}}
+                     %{
+                       "file_id" => "fallback-f1",
+                       "config_id" => ^config_id,
+                       "record" => ^fallback_record
+                     }}
 
     invalid_record = %Record{id: "f1", kind: :file, attributes: %{}}
 
@@ -657,7 +775,124 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert_received {:channel_stats, ^config_id, %{config_id: ^config_id}}
   end
 
-  test "update_file delegates provider-based updates through scoped config" do
+  test "read wrappers force permission projection unless permissions are bypassed" do
+    config = insert_data_source_config(:google_drive)
+    config_id = config.id
+
+    assert {:ok, %{records: []}} =
+             DataSourceBridge.list_files(:google_drive, %{
+               config_id: config_id,
+               include_permissions: false
+             })
+
+    assert_received {:list_files, ^config_id, list_params}
+    assert list_params["include_permissions"] == true
+    assert list_params[:include_permissions] == nil
+
+    assert {:ok, %{records: [%{"id" => "f1"}]}} =
+             DataSourceBridge.search_files(:google_drive, %{
+               "query" => "invoice",
+               "include_permissions" => false,
+               config_id: config_id
+             })
+
+    assert_received {:search_files, ^config_id, search_params}
+    assert search_params["include_permissions"] == true
+    assert search_params[:include_permissions] == nil
+
+    assert {:ok, %{record: %{"id" => "f1"}}} =
+             DataSourceBridge.get_file(:google_drive, %{
+               "file_id" => "f1",
+               config_id: config_id
+             })
+
+    assert_received {:get_file, ^config_id, get_params}
+    assert get_params["include_permissions"] == true
+    assert get_params[:include_permissions] == nil
+  end
+
+  test "trusted bypass omits permission projection unless explicitly requested" do
+    config = insert_data_source_config(:google_drive)
+    config_id = config.id
+
+    assert {:ok, %{records: []}} =
+             DataSourceBridge.list_files(
+               :google_drive,
+               %{config_id: config_id},
+               %{skip_permissions: true}
+             )
+
+    assert_received {:list_files, ^config_id, list_params}
+    assert list_params["include_permissions"] == false
+    assert list_params[:include_permissions] == nil
+
+    assert {:ok, %{records: [%{"id" => "f1"}]}} =
+             DataSourceBridge.search_files(
+               :google_drive,
+               %{"query" => "invoice", config_id: config_id, include_permissions: true},
+               %{skip_permissions: true}
+             )
+
+    assert_received {:search_files, ^config_id, search_params}
+    assert search_params["include_permissions"] == true
+    assert search_params[:include_permissions] == nil
+
+    assert {:ok, %{record: %{"id" => "f1"}}} =
+             DataSourceBridge.get_file(
+               :google_drive,
+               %{"file_id" => "f1", "include_permissions" => false, config_id: config_id},
+               %{skip_permissions: true}
+             )
+
+    assert_received {:get_file, ^config_id, get_params}
+    assert get_params["include_permissions"] == false
+    assert get_params[:include_permissions] == nil
+  end
+
+  test "list_files authorizes email principals through email person channels" do
+    use_record_returning_bridge()
+
+    config = insert_data_source_config(:google_drive)
+    person = person_fixture("mattermost-user-#{System.unique_integer([:positive])}@example.com")
+
+    person_channel_fixture(person, %{
+      platform: "mattermost",
+      channel_identifier: "MM_USER_1"
+    })
+
+    person_channel_fixture(person, %{
+      platform: "email",
+      channel_identifier: "User@Example.COM"
+    })
+
+    assert {:ok, %{records: [%Record{id: "file-1"}], stats: %{returned: 1}}} =
+             DataSourceBridge.list_files(
+               :google_drive,
+               %{config_id: config.id},
+               actor_context(person)
+             )
+  end
+
+  test "list_files rejects email principals not associated to the actor person" do
+    use_record_returning_bridge()
+
+    config = insert_data_source_config(:google_drive)
+    person = person_fixture("different-#{System.unique_integer([:positive])}@example.com")
+
+    person_channel_fixture(person, %{
+      platform: "mattermost",
+      channel_identifier: "MM_USER_2"
+    })
+
+    assert {:ok, %{records: [], stats: %{returned: 0}}} =
+             DataSourceBridge.list_files(
+               :google_drive,
+               %{config_id: config.id},
+               actor_context(person)
+             )
+  end
+
+  test "update_file rejects provider-based updates for globally authorized bridges" do
     config = insert_data_source_config(:google_drive)
     config_id = config.id
 
@@ -667,15 +902,16 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
       "name" => "Renamed"
     }
 
-    assert {:ok, %{status: "updated", record: %{"id" => "f1"}}} =
+    assert {:error, {:invalid_request, :record_required}} =
              DataSourceBridge.update_file(:google_drive, params)
 
-    assert_received {:update_file, ^config_id, ^params}
+    refute_received {:update_file, ^config_id, ^params}
   end
 
   property "update_file uses signed record identity instead of caller-supplied routing params" do
     config = insert_data_source_config(:google_drive)
     config_id = config.id
+    person = person_fixture()
 
     check all(
             provider_file_id <- StreamData.string(:alphanumeric, min_length: 1, max_length: 24),
@@ -690,24 +926,30 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
           "provider" => "google_drive",
           "config_id" => config_id,
           "provider_record_id" => provider_file_id
-        }
+        },
+        permissions: [permission_fixture(person.email, ["edit"])]
       }
 
       {:ok, record} =
         Provenance.seal(record, %{"provider" => "google_drive", "config_id" => config_id})
 
       assert {:ok, %{status: "updated"}} =
-               DataSourceBridge.update_file(record, %{
-                 "file_id" => attempted_file_id,
-                 :config_id => attempted_config_id,
-                 "name" => "Renamed"
-               })
+               DataSourceBridge.update_file(
+                 record,
+                 %{
+                   "file_id" => attempted_file_id,
+                   :config_id => attempted_config_id,
+                   "name" => "Renamed"
+                 },
+                 actor_context(person)
+               )
 
       assert_received {:update_file, ^config_id,
                        %{
                          "file_id" => ^provider_file_id,
                          "config_id" => ^config_id,
-                         "name" => "Renamed"
+                         "name" => "Renamed",
+                         "record" => ^record
                        }}
     end
   end
@@ -715,6 +957,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
   test "update_file drops path when the caller copied current record metadata" do
     config = insert_data_source_config(:google_drive)
     config_id = config.id
+    person = person_fixture()
 
     record = %Record{
       id: "f1",
@@ -727,17 +970,21 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
         "relative_path" => "Tesla model 3.png",
         "source" => "archives/Tesla model 3.png",
         "volume" => "archives"
-      }
+      },
+      permissions: [permission_fixture(person.email, ["edit"])]
     }
 
     {:ok, record} =
       Provenance.seal(record, %{"provider" => "google_drive", "config_id" => config_id})
 
-    assert {:ok, %{status: "updated"}} =
-             DataSourceBridge.update_file(record, %{"path" => "Tesla model 3.png"})
+    assert {:error, {:invalid_request, :changes_required}} =
+             DataSourceBridge.update_file(
+               record,
+               %{"path" => "Tesla model 3.png"},
+               actor_context(person)
+             )
 
-    assert_received {:update_file, ^config_id,
-                     %{"file_id" => "provider-f1", "config_id" => ^config_id}}
+    refute_received {:update_file, ^config_id, _params}
   end
 
   test "update_file rejects missing and tampered provenance" do
@@ -771,16 +1018,23 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
   test "delete_file omits config_id when provenance has only provider" do
     config = insert_data_source_config(:google_drive)
     config_id = config.id
+    person = person_fixture()
 
     record = %Record{
       id: "stable-file-id",
       kind: :file,
-      attributes: %{"provider" => "google_drive"}
+      attributes: %{"provider" => "google_drive"},
+      permissions: [permission_fixture(person.email, ["delete"])]
     }
 
     assert {:ok, sealed_record} = Provenance.seal(record, %{"provider" => "google_drive"})
-    assert {:ok, %{status: "deleted", result: %{}}} = DataSourceBridge.delete_file(sealed_record)
-    assert_received {:delete_file, ^config_id, %{"file_id" => "stable-file-id"}}
+
+    assert {:ok, %{status: "deleted", result: %{}}} =
+             DataSourceBridge.delete_file(sealed_record, actor_context(person))
+
+    assert_received {:delete_file, ^config_id,
+                     %{"file_id" => "stable-file-id", "record" => ^sealed_record}}
+
     refute_received {:delete_file, ^config_id, %{"file_id" => _, "config_id" => _}}
   end
 

--- a/test/zaq/channels/data_source_bridge_test.exs
+++ b/test/zaq/channels/data_source_bridge_test.exs
@@ -58,7 +58,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
 
     def list_files(config, params, _context) do
       send(self(), {:list_files, config.id, params})
-      {:ok, %{records: []}}
+      {:ok, %RecordPage{resource_type: :file, records: []}}
     end
 
     def create_file(config, params, _context) do
@@ -68,7 +68,16 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
 
     def get_file(config, params, _context) do
       send(self(), {:get_file, config.id, params})
-      {:ok, %{record: %{"id" => "f1"}}}
+
+      {:ok,
+       %{
+         record: %Record{
+           id: "f1",
+           kind: :file,
+           permissions: [permission("user@example.com", ["read"])],
+           attributes: %{"provider" => config.provider, "config_id" => config.id}
+         }
+       }}
     end
 
     def update_file(config, params, _context) do
@@ -83,7 +92,19 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
 
     def search_files(config, params, _context) do
       send(self(), {:search_files, config.id, params})
-      {:ok, %{records: [%{"id" => "f1"}]}}
+
+      {:ok,
+       %RecordPage{
+         resource_type: :file,
+         records: [
+           %Record{
+             id: "f1",
+             kind: :file,
+             permissions: [permission("user@example.com", ["read"])],
+             attributes: %{"provider" => config.provider, "config_id" => config.id}
+           }
+         ]
+       }}
     end
 
     def download_document(config, params, _context) do
@@ -192,6 +213,21 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
       send(self(), {:oauth_default_scopes, config.id})
       {:ok, ["read", "write"]}
     end
+
+    defp permission(email, rights) do
+      %Record{
+        id: "perm-#{System.unique_integer([:positive])}",
+        kind: :permission,
+        attributes: %{
+          "principal" => %{"channel" => "email", "identifier" => email},
+          "access_rights" => rights
+        }
+      }
+    end
+  end
+
+  defmodule StubMalformedDataSourceBridge do
+    def list_files(_config, _params, _context), do: {:ok, %{records: [%{"id" => "f1"}]}}
   end
 
   defmodule StubNoDataSourceCallbacks do
@@ -235,6 +271,27 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     end
 
     def replace_permissions(_config, _params, _context), do: {:ok, %{status: "updated"}}
+
+    def list_files(config, %{"with_handle" => true}, _context) do
+      permission = %Record{
+        id: "perm-handle",
+        kind: :permission,
+        attributes: %{
+          "principal" => %{"channel" => "email", "identifier" => "user@example.com"},
+          "access_rights" => ["read"]
+        }
+      }
+
+      record = %Record{
+        id: "file-with-handle",
+        kind: :file,
+        materialization_handle: "signed-handle",
+        permissions: [permission],
+        attributes: %{"provider" => config.provider, "config_id" => config.id}
+      }
+
+      {:ok, %RecordPage{resource_type: :file, records: [record]}}
+    end
 
     def list_files(config, _params, _context) do
       permission = %Record{
@@ -659,8 +716,12 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
 
     assert_received {:create_file, ^config_id, %{"name" => "Doc", config_id: ^config_id}}
 
-    assert {:ok, %{record: %{"id" => "f1"}}} =
-             DataSourceBridge.get_file(:google_drive, %{"file_id" => "f1", config_id: config_id})
+    assert {:ok, %{record: %Record{id: "f1"}}} =
+             DataSourceBridge.get_file(
+               :google_drive,
+               %{"file_id" => "f1", config_id: config_id},
+               %{skip_permissions: true}
+             )
 
     assert_received {:get_file, ^config_id, %{"file_id" => "f1", config_id: ^config_id}}
 
@@ -689,12 +750,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
              )
 
     assert_received {:update_file, ^config_id,
-                     %{
-                       "file_id" => "f1",
-                       "name" => "Renamed",
-                       "config_id" => ^config_id,
-                       "record" => ^update_record
-                     }}
+                     %{"file_id" => "f1", "name" => "Renamed", "config_id" => ^config_id}}
 
     delete_record = %Record{
       id: "record-f1",
@@ -712,12 +768,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert {:ok, %{status: "deleted", result: %{}}} =
              DataSourceBridge.delete_file(delete_record, %{skip_permissions: true})
 
-    assert_received {:delete_file, ^config_id,
-                     %{
-                       "file_id" => "f1",
-                       "config_id" => ^config_id,
-                       "record" => ^delete_record
-                     }}
+    assert_received {:delete_file, ^config_id, %{"file_id" => "f1", "config_id" => ^config_id}}
 
     fallback_record = %Record{
       id: "fallback-f1",
@@ -732,11 +783,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
              DataSourceBridge.delete_file(fallback_record, %{skip_permissions: true})
 
     assert_received {:delete_file, ^config_id,
-                     %{
-                       "file_id" => "fallback-f1",
-                       "config_id" => ^config_id,
-                       "record" => ^fallback_record
-                     }}
+                     %{"file_id" => "fallback-f1", "config_id" => ^config_id}}
 
     invalid_record = %Record{id: "f1", kind: :file, attributes: %{}}
 
@@ -748,11 +795,15 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert {:error, {:invalid_record, :provider_required}} =
              DataSourceBridge.update_file(invalid_record, %{"name" => "Renamed"})
 
-    assert {:ok, %{records: [%{"id" => "f1"}]}} =
-             DataSourceBridge.search_files(:google_drive, %{
-               "query" => "invoice",
-               config_id: config_id
-             })
+    assert {:ok, %{records: [%Record{id: "f1"}]}} =
+             DataSourceBridge.search_files(
+               :google_drive,
+               %{
+                 "query" => "invoice",
+                 config_id: config_id
+               },
+               %{skip_permissions: true}
+             )
 
     assert_received {:search_files, ^config_id, %{"query" => "invoice", config_id: ^config_id}}
 
@@ -789,22 +840,32 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert list_params["include_permissions"] == true
     assert list_params[:include_permissions] == nil
 
-    assert {:ok, %{records: [%{"id" => "f1"}]}} =
-             DataSourceBridge.search_files(:google_drive, %{
-               "query" => "invoice",
-               "include_permissions" => false,
-               config_id: config_id
-             })
+    person = person_fixture("user@example.com")
+
+    assert {:ok, %{records: [%Record{id: "f1"}]}} =
+             DataSourceBridge.search_files(
+               :google_drive,
+               %{
+                 "query" => "invoice",
+                 "include_permissions" => false,
+                 config_id: config_id
+               },
+               actor_context(person)
+             )
 
     assert_received {:search_files, ^config_id, search_params}
     assert search_params["include_permissions"] == true
     assert search_params[:include_permissions] == nil
 
-    assert {:ok, %{record: %{"id" => "f1"}}} =
-             DataSourceBridge.get_file(:google_drive, %{
-               "file_id" => "f1",
-               config_id: config_id
-             })
+    assert {:ok, %{record: %Record{id: "f1"}}} =
+             DataSourceBridge.get_file(
+               :google_drive,
+               %{
+                 "file_id" => "f1",
+                 config_id: config_id
+               },
+               actor_context(person)
+             )
 
     assert_received {:get_file, ^config_id, get_params}
     assert get_params["include_permissions"] == true
@@ -826,7 +887,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert list_params["include_permissions"] == false
     assert list_params[:include_permissions] == nil
 
-    assert {:ok, %{records: [%{"id" => "f1"}]}} =
+    assert {:ok, %{records: [%Record{id: "f1"}]}} =
              DataSourceBridge.search_files(
                :google_drive,
                %{"query" => "invoice", config_id: config_id, include_permissions: true},
@@ -837,7 +898,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert search_params["include_permissions"] == true
     assert search_params[:include_permissions] == nil
 
-    assert {:ok, %{record: %{"id" => "f1"}}} =
+    assert {:ok, %{record: %Record{id: "f1"}}} =
              DataSourceBridge.get_file(
                :google_drive,
                %{"file_id" => "f1", "include_permissions" => false, config_id: config_id},
@@ -890,6 +951,34 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
                %{config_id: config.id},
                actor_context(person)
              )
+  end
+
+  test "list_files does not disclose handles on unauthorized records" do
+    use_record_returning_bridge()
+
+    config = insert_data_source_config(:google_drive)
+    other = person_fixture("other-#{System.unique_integer([:positive])}@example.com")
+
+    assert {:ok, %{records: [], stats: %{returned: 0}}} =
+             DataSourceBridge.list_files(
+               :google_drive,
+               %{"with_handle" => true, config_id: config.id},
+               actor_context(other)
+             )
+  end
+
+  test "authorized read wrappers reject malformed successful record lists" do
+    Application.put_env(:zaq, :channels, %{
+      google_drive: %{
+        bridge: StubMalformedDataSourceBridge,
+        adapter: __MODULE__.StubAdapter
+      }
+    })
+
+    config = insert_data_source_config(:google_drive)
+
+    assert {:error, {:invalid_bridge_response, :authorization_required}} =
+             DataSourceBridge.list_files(:google_drive, %{config_id: config.id})
   end
 
   test "update_file rejects provider-based updates for globally authorized bridges" do
@@ -948,8 +1037,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
                        %{
                          "file_id" => ^provider_file_id,
                          "config_id" => ^config_id,
-                         "name" => "Renamed",
-                         "record" => ^record
+                         "name" => "Renamed"
                        }}
     end
   end
@@ -1032,8 +1120,7 @@ defmodule Zaq.Channels.DataSourceBridgeTest do
     assert {:ok, %{status: "deleted", result: %{}}} =
              DataSourceBridge.delete_file(sealed_record, actor_context(person))
 
-    assert_received {:delete_file, ^config_id,
-                     %{"file_id" => "stable-file-id", "record" => ^sealed_record}}
+    assert_received {:delete_file, ^config_id, %{"file_id" => "stable-file-id"}}
 
     refute_received {:delete_file, ^config_id, %{"file_id" => _, "config_id" => _}}
   end

--- a/test/zaq/channels/jido_connect_bridge_test.exs
+++ b/test/zaq/channels/jido_connect_bridge_test.exs
@@ -55,7 +55,12 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
              "mimeType" => "application/pdf",
              "parents" => ["root"],
              "permissions" => [
-               %{"id" => "ep1", "type" => "user", "emailAddress" => "owner@example.com"}
+               %{
+                 "id" => "ep1",
+                 "type" => "user",
+                 "role" => "writer",
+                 "emailAddress" => "owner@example.com"
+               }
              ]
            }
          ]
@@ -68,8 +73,18 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
       {:ok,
        %{
          permissions: [
-           %{"id" => "u1", "type" => "user", "emailAddress" => "a@example.com"},
-           %{"id" => "u2", "type" => "group", "emailAddress" => "team@example.com"}
+           %{
+             "id" => "u1",
+             "type" => "user",
+             "role" => "reader",
+             "emailAddress" => "a@example.com"
+           },
+           %{
+             "id" => "u2",
+             "type" => "group",
+             "role" => "reader",
+             "emailAddress" => "team@example.com"
+           }
          ]
        }}
     end
@@ -1367,7 +1382,14 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
 
     item = Enum.find(records, &(&1.id == "f2"))
     assert is_list(item.permissions)
-    assert [%Zaq.Contracts.Record{id: "ep1", kind: :permission}] = item.permissions
+    assert [%Zaq.Contracts.Record{id: "ep1", kind: :permission} = permission] = item.permissions
+
+    assert permission.attributes["principal"] == %{
+             "channel" => "email",
+             "identifier" => "owner@example.com"
+           }
+
+    assert permission.attributes["access_rights"] == ["delete", "edit", "move", "read"]
   end
 
   test "list_files adds google drive permission fields when include_permissions is true" do

--- a/test/zaq/contracts/record/authorization_test.exs
+++ b/test/zaq/contracts/record/authorization_test.exs
@@ -36,6 +36,66 @@ defmodule Zaq.Contracts.Record.AuthorizationTest do
       assert Authorization.can?(actor(person), record(permissions: permissions), :read)
     end
 
+    test "accepts a person that already has channels loaded" do
+      person = create_person()
+      add_channel(person.id, "mattermost", " User-42 ")
+      person = People.get_person_with_channels(person.id)
+
+      permissions = [
+        permission(%{
+          "principal" => %{"channel" => "mattermost", "identifier" => "user-42"},
+          "access_rights" => ["read"]
+        })
+      ]
+
+      assert Authorization.can?(person, record(permissions: permissions), :read)
+    end
+
+    test "filters authorized records while preserving order" do
+      person = create_person()
+
+      records = [
+        record(id: "file-1", permissions: [permission_for(person.email, ["read"])]),
+        record(id: "file-2", permissions: [permission_for("other@example.com", ["read"])]),
+        record(id: "file-3", permissions: [permission_for(person.email, ["edit"])]),
+        record(id: "file-4", permissions: [permission_for(person.email, ["read"])]),
+        record(id: "file-5", permissions: nil)
+      ]
+
+      assert Enum.map(Authorization.filter(actor(person), records, :read), & &1.id) == [
+               "file-1",
+               "file-4"
+             ]
+    end
+
+    test "returns an empty list when filtering cannot resolve a person" do
+      records = [record(permissions: [permission_for("user@example.com", ["read"])])]
+
+      assert Authorization.filter(nil, records, :read) == []
+      assert Authorization.filter(%{person: %{id: "missing"}}, records, :read) == []
+    end
+
+    test "loads a person once when filtering multiple records" do
+      person = create_person()
+
+      records =
+        for index <- 1..5 do
+          record(id: "file-#{index}", permissions: [permission_for(person.email, ["read"])])
+        end
+
+      {authorized_records, queries} =
+        capture_person_lookup_queries(fn ->
+          Authorization.filter(actor(person), records, :read)
+        end)
+
+      assert length(authorized_records) == 5
+
+      assert Enum.frequencies_by(queries, & &1.source) == %{
+               "channels" => 1,
+               "people" => 1
+             }
+    end
+
     test "supports the legacy flat principal representation" do
       person = create_person()
       add_channel(person.id, "slack", "slack-user-42")
@@ -113,8 +173,55 @@ defmodule Zaq.Contracts.Record.AuthorizationTest do
 
   defp permission(attrs), do: %Record{id: unique_id(), kind: :permission, attributes: attrs}
 
+  defp permission_for(email, rights) do
+    permission(%{
+      "principal" => %{"channel" => "email", "identifier" => email},
+      "access_rights" => rights
+    })
+  end
+
   defp record(opts) do
-    %Record{id: unique_id(), kind: :file, permissions: Keyword.get(opts, :permissions)}
+    %Record{
+      id: Keyword.get(opts, :id, unique_id()),
+      kind: :file,
+      permissions: Keyword.get(opts, :permissions)
+    }
+  end
+
+  defp capture_person_lookup_queries(fun) do
+    handler_id = {__MODULE__, :person_lookup_queries, make_ref()}
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:zaq, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if self() == test_pid and metadata[:source] in ["people", "channels"] do
+            send(
+              test_pid,
+              {:person_lookup_query, %{source: metadata[:source], query: metadata[:query]}}
+            )
+          end
+        end,
+        nil
+      )
+
+    try do
+      result = fun.()
+      {result, collect_person_lookup_queries([])}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  defp collect_person_lookup_queries(queries) do
+    receive do
+      {:person_lookup_query, query} ->
+        collect_person_lookup_queries([query | queries])
+    after
+      0 -> Enum.reverse(queries)
+    end
   end
 
   defp unique_id, do: "authorization-#{System.unique_integer([:positive])}"

--- a/test/zaq/contracts/record/authorization_test.exs
+++ b/test/zaq/contracts/record/authorization_test.exs
@@ -1,0 +1,121 @@
+defmodule Zaq.Contracts.Record.AuthorizationTest do
+  use Zaq.DataCase, async: true
+
+  alias Zaq.Accounts.People
+  alias Zaq.Contracts.Record
+  alias Zaq.Contracts.Record.Authorization
+
+  describe "can?/3" do
+    test "returns false when permissions are not a list" do
+      person = create_person()
+
+      refute Authorization.can?(actor(person), record(permissions: nil), :read)
+    end
+
+    test "ignores malformed entries in a permissions list" do
+      person = create_person()
+
+      refute Authorization.can?(
+               actor(person),
+               record(permissions: [nil, %{unexpected: "value"}]),
+               :read
+             )
+    end
+
+    test "matches a non-email principal against a person channel" do
+      person = create_person()
+      add_channel(person.id, "mattermost", " User-42 ")
+
+      permissions = [
+        permission(%{
+          "principal" => %{"channel" => " MATTERMOST ", "identifier" => " user-42 "},
+          "access_rights" => ["read"]
+        })
+      ]
+
+      assert Authorization.can?(actor(person), record(permissions: permissions), :read)
+    end
+
+    test "supports the legacy flat principal representation" do
+      person = create_person()
+      add_channel(person.id, "slack", "slack-user-42")
+
+      permissions = [
+        permission(%{
+          "principal_type" => "slack",
+          "principal_key" => "slack-user-42",
+          "access_rights" => ["read"]
+        })
+      ]
+
+      assert Authorization.can?(actor(person), record(permissions: permissions), :read)
+    end
+
+    test "rejects a permission with no usable principal" do
+      person = create_person()
+      permissions = [permission(%{"access_rights" => ["read"]})]
+
+      refute Authorization.can?(actor(person), record(permissions: permissions), :read)
+    end
+
+    test "recognizes move and discards unknown access rights" do
+      person = create_person()
+
+      permissions = [
+        permission(%{
+          "principal" => %{"channel" => "email", "identifier" => person.email},
+          "access_rights" => ["move", "share"]
+        })
+      ]
+
+      assert Authorization.can?(actor(person), record(permissions: permissions), :move)
+      refute Authorization.can?(actor(person), record(permissions: permissions), :delete)
+    end
+
+    test "falls back to an email channel when the canonical email is nil" do
+      person = create_person(%{email: nil})
+      add_channel(person.id, "email", "fallback@example.com")
+
+      permissions = [
+        permission(%{
+          "principal" => %{"channel" => "email", "identifier" => "fallback@example.com"},
+          "access_rights" => ["read"]
+        })
+      ]
+
+      assert Authorization.can?(actor(person), record(permissions: permissions), :read)
+    end
+  end
+
+  defp create_person(overrides \\ %{}) do
+    id = unique_id()
+
+    {:ok, person} =
+      People.create_person(
+        Map.merge(%{full_name: "Authorization Test #{id}", email: "#{id}@example.com"}, overrides)
+      )
+
+    person
+  end
+
+  defp add_channel(person_id, platform, identifier) do
+    {:ok, channel} =
+      People.add_channel(%{
+        "person_id" => person_id,
+        "platform" => platform,
+        "channel_identifier" => identifier
+      })
+
+    channel
+  end
+
+  defp actor(person), do: %{person: %{id: person.id}}
+
+  defp permission(attrs), do: %Record{id: unique_id(), kind: :permission, attributes: attrs}
+
+  defp record(opts) do
+    %Record{id: unique_id(), kind: :file, permissions: Keyword.get(opts, :permissions)}
+  end
+
+  defp unique_id, do: "authorization-#{System.unique_integer([:positive])}"
+end

--- a/test/zaq/events/trusted_context_test.exs
+++ b/test/zaq/events/trusted_context_test.exs
@@ -36,6 +36,14 @@ defmodule Zaq.Events.TrustedContextTest do
              %TrustedContext{actor: actor, skip_permissions: true}
   end
 
+  test "from_event trusts a string-keyed actor permission bypass" do
+    actor = %{"person_id" => 7, "skip_permissions" => true}
+    event = Event.new(%{}, :channels, actor: actor)
+
+    assert TrustedContext.from_event(event) ==
+             %TrustedContext{actor: actor, skip_permissions: true}
+  end
+
   property "only literal trusted true enables permission bypass" do
     check all(value <- StreamData.term() |> StreamData.filter(&(&1 != true))) do
       refute TrustedContext.normalize(%{skip_permissions: value}).skip_permissions
@@ -60,5 +68,20 @@ defmodule Zaq.Events.TrustedContextTest do
     assert opts[:event_opts][:materialization_verified] == true
     assert opts[:event_opts][:data_source_bridge_module] == __MODULE__
     refute Keyword.has_key?(opts[:event_opts], :action)
+  end
+
+  property "non-list context event options are ignored" do
+    check all(context_event_opts <- StreamData.term() |> StreamData.filter(&(not is_list(&1)))) do
+      opts =
+        TrustedContext.event_builder_opts(
+          %{event_opts: context_event_opts},
+          event_opts: [materialization_verified: true]
+        )
+
+      assert opts[:event_opts] == [materialization_verified: true]
+      refute Keyword.has_key?(opts, :actor)
+      refute Keyword.has_key?(opts, :node_router)
+      refute Keyword.has_key?(opts, :config)
+    end
   end
 end

--- a/test/zaq_web/live/bo/ai/ingestion_live_test.exs
+++ b/test/zaq_web/live/bo/ai/ingestion_live_test.exs
@@ -25,9 +25,10 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
   alias Zaq.SystemConfigFixtures
 
   defmodule ProviderBrowserBridgeStub do
-    def list_files(provider, params, _context) do
+    def list_files(provider, params, context) do
       if pid = Application.get_env(:zaq, :ingestion_provider_browser_test_pid) do
         send(pid, {:list_files, provider, params})
+        send(pid, {:list_files, provider, params, context})
       end
 
       response = Application.get_env(:zaq, :provider_browser_list_response, :default)
@@ -531,8 +532,12 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
     test "lists provider records from the route provider and navigates folders", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/bo/ingestion/google_drive")
 
-      assert_received {:list_files, "google_drive", %{"config_id" => config_id, "filters" => %{}}}
+      assert_received {:list_files, "google_drive", %{"config_id" => config_id, "filters" => %{}},
+                       context}
+
       assert is_integer(config_id)
+      assert context.actor.provider == "bo"
+      assert context.skip_permissions == true
       assert has_element?(view, "button", "Project Docs")
       assert has_element?(view, "span", "Budget.pdf")
       assert has_element?(view, ~s(img[src="https://drive.example/icons/folder.png"]), "")
@@ -548,7 +553,11 @@ defmodule ZaqWeb.Live.BO.AI.IngestionLiveTest do
       render_hook(view, "navigate", %{"path" => "folder-1"})
 
       assert_received {:list_files, "google_drive",
-                       %{"filters" => %{"parent" => "folder-1", "include_shared" => false}}}
+                       %{"filters" => %{"parent" => "folder-1", "include_shared" => false}},
+                       context}
+
+      assert context.actor.provider == "bo"
+      assert context.skip_permissions == true
 
       assert has_element?(view, "button", "Nested Folder")
       assert has_element?(view, "span", "No Preview.txt")

--- a/test/zaq_web/live/bo/data_source_events_test.exs
+++ b/test/zaq_web/live/bo/data_source_events_test.exs
@@ -1,0 +1,39 @@
+defmodule ZaqWeb.Live.BO.DataSourceEventsTest do
+  use ExUnit.Case, async: true
+
+  alias ZaqWeb.Live.BO.DataSourceEvents
+
+  test "builds data-source channel event with a regular BO actor" do
+    user = %{id: 1, person_id: 2, username: "regular"}
+
+    event =
+      DataSourceEvents.build(
+        :data_source_list_files,
+        %{provider: :google_drive, params: %{}},
+        user,
+        event_opts: [data_source_bridge_module: StubBridge]
+      )
+
+    assert event.next_hop.destination == :channels
+    assert event.opts[:action] == :data_source_list_files
+    assert event.opts[:data_source_bridge_module] == StubBridge
+    refute Keyword.has_key?(event.opts, :skip_permissions)
+    assert event.actor.person_id == 2
+    assert event.actor.provider == "bo"
+    assert event.actor.skip_permissions == false
+  end
+
+  test "projects super-admin bypass into trusted event options" do
+    user = %{id: 1, person_id: 2, username: "root", role: %{name: "super_admin"}}
+
+    event =
+      DataSourceEvents.build(
+        :data_source_list_files,
+        %{provider: :google_drive, params: %{}},
+        user
+      )
+
+    assert event.opts[:skip_permissions] == true
+    assert event.actor.skip_permissions == true
+  end
+end

--- a/test/zaq_web/live/bo/data_sources/provider_live_test.exs
+++ b/test/zaq_web/live/bo/data_sources/provider_live_test.exs
@@ -16,6 +16,7 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
 
     :ok = ZaqSystem.set_global_base_url("https://zaq.example")
     Application.put_env(:zaq, Zaq.Storage, base_path: "priv/documents")
+    Application.delete_env(:zaq, :provider_live_data_source_bridge_module)
 
     on_exit(fn ->
       :ok = ZaqSystem.set_global_base_url(original_base_url)
@@ -29,6 +30,8 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
         nil -> Application.delete_env(:zaq, Zaq.Storage)
         storage -> Application.put_env(:zaq, Zaq.Storage, storage)
       end
+
+      Application.delete_env(:zaq, :provider_live_data_source_bridge_module)
     end)
 
     :ok
@@ -39,12 +42,52 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
       assigns
       |> Map.put(:__changed__, %{})
       |> Map.put_new(:flash, %{})
+      |> Map.put_new(:current_user, %{id: 10, person_id: 20, username: "bo-user"})
 
     %Phoenix.LiveView.Socket{assigns: assigns}
   end
 
   defp use_data_source_bridge(provider, bridge_module) do
     BridgeStubs.put_bridge(provider, bridge_module)
+    Application.put_env(:zaq, :provider_live_data_source_bridge_module, bridge_module)
+  end
+
+  defp credential_id(provider \\ "google_drive") do
+    {:ok, credential} =
+      Connect.create_credential(%{
+        name: "cred-#{System.unique_integer([:positive])}",
+        provider: provider,
+        auth_kind: "api_key",
+        request_format: "bearer",
+        user_level: false,
+        metadata: %{},
+        scopes: ["read", "write", "files.read", "files.metadata.read", "drive.readonly"],
+        api_key: "token"
+      })
+
+    credential.id
+  end
+
+  defp connect_settings(attrs \\ %{}) do
+    Map.put_new(attrs, "credential_id", credential_id())
+  end
+
+  defp issue_active_grant!(config) do
+    credential_id = get_in(config.settings, ["connect", "credential_id"])
+
+    {:ok, _grant} =
+      Connect.issue_grant(%{
+        credential_id: credential_id,
+        provider: config.provider,
+        resource_type: "data_source",
+        resource_id: to_string(config.id),
+        owner_type: "org",
+        status: "active",
+        scopes: ["read", "write", "files.read", "files.metadata.read", "drive.readonly"],
+        api_key: "token"
+      })
+
+    config
   end
 
   defp config_changeset(provider) do
@@ -83,6 +126,85 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
 
     refute closed.assigns.credential_modal
     assert closed.assigns.credential_changeset == nil
+  end
+
+  test "open_test passes BO actor context to root folder listing" do
+    use_data_source_bridge("google_drive", BridgeStubs.CaptureContext)
+
+    config =
+      %ChannelConfig{}
+      |> ChannelConfig.changeset(%{
+        "name" => "cfg-context-#{System.unique_integer([:positive])}",
+        "provider" => "google_drive",
+        "kind" => "data_source",
+        "enabled" => true,
+        "settings" => %{"connect" => connect_settings()}
+      })
+      |> Repo.insert!()
+      |> issue_active_grant!()
+
+    current_user = %{id: 11, person_id: 21, username: "admin", role: %{name: "super_admin"}}
+
+    socket =
+      socket_with(%{
+        provider: "google_drive",
+        current_user: current_user,
+        root_folders_by_config: %{},
+        root_folder_meta_by_config: %{},
+        stats_errors_by_config: %{}
+      })
+
+    assert {:noreply, _updated} =
+             ProviderLive.handle_event(
+               "open_test",
+               %{"id" => Integer.to_string(config.id)},
+               socket
+             )
+
+    assert_received {:provider_live_list_files, params, context}
+    assert params["config_id"] == config.id
+    assert context.actor.person_id == 21
+    assert context.actor.provider == "bo"
+    assert context.skip_permissions == true
+  end
+
+  test "fetch_more passes BO actor context to paginated root folder listing" do
+    use_data_source_bridge("google_drive", BridgeStubs.CaptureContext)
+
+    config =
+      %ChannelConfig{}
+      |> ChannelConfig.changeset(%{
+        "name" => "cfg-context-page-#{System.unique_integer([:positive])}",
+        "provider" => "google_drive",
+        "kind" => "data_source",
+        "enabled" => true,
+        "settings" => %{"connect" => connect_settings()}
+      })
+      |> Repo.insert!()
+      |> issue_active_grant!()
+
+    current_user = %{id: 12, person_id: 22, username: "regular"}
+
+    socket =
+      socket_with(%{
+        provider: "google_drive",
+        current_user: current_user,
+        root_folders_by_config: %{config.id => []},
+        root_folder_meta_by_config: %{config.id => %{next_page_token: "page-2"}},
+        stats_errors_by_config: %{}
+      })
+
+    assert {:noreply, _updated} =
+             ProviderLive.handle_event(
+               "fetch_more",
+               %{"id" => Integer.to_string(config.id)},
+               socket
+             )
+
+    assert_received {:provider_live_list_files, params, context}
+    assert params["page_token"] == "page-2"
+    assert context.actor.person_id == 22
+    assert context.skip_permissions == false
   end
 
   test "disk new config starts with an editable default volume" do
@@ -659,9 +781,12 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
         "provider" => "google_drive",
         "kind" => "data_source",
         "enabled" => true,
-        "settings" => %{"connect" => %{"root_selector" => "root", "max_pages" => 1}}
+        "settings" => %{
+          "connect" => connect_settings(%{"root_selector" => "root", "max_pages" => 1})
+        }
       })
       |> Repo.insert!()
+      |> issue_active_grant!()
 
     use_data_source_bridge(:google_drive, BridgeStubs.UnexpectedResponse)
 
@@ -1713,9 +1838,12 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
         "provider" => "google_drive",
         "kind" => "data_source",
         "enabled" => true,
-        "settings" => %{"connect" => %{"root_selector" => "root", "max_pages" => 1}}
+        "settings" => %{
+          "connect" => connect_settings(%{"root_selector" => "root", "max_pages" => 1})
+        }
       })
       |> Repo.insert!()
+      |> issue_active_grant!()
 
     use_data_source_bridge(:google_drive, BridgeStubs.DisplayMessageError)
 
@@ -1759,9 +1887,12 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
         "provider" => "google_drive",
         "kind" => "data_source",
         "enabled" => true,
-        "settings" => %{"connect" => %{"root_selector" => "root", "max_pages" => 1}}
+        "settings" => %{
+          "connect" => connect_settings(%{"root_selector" => "root", "max_pages" => 1})
+        }
       })
       |> Repo.insert!()
+      |> issue_active_grant!()
 
     use_data_source_bridge(:google_drive, BridgeStubs.NilError)
 
@@ -1947,9 +2078,12 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
           "provider" => "google_drive",
           "kind" => "data_source",
           "enabled" => true,
-          "settings" => %{"connect" => %{"root_selector" => "root", "max_pages" => 2}}
+          "settings" => %{
+            "connect" => connect_settings(%{"root_selector" => "root", "max_pages" => 2})
+          }
         })
         |> Repo.insert!()
+        |> issue_active_grant!()
 
       use_data_source_bridge(:google_drive, BridgeStubs.ContinuationThenHalt)
 
@@ -1990,9 +2124,12 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
           "provider" => "google_drive",
           "kind" => "data_source",
           "enabled" => true,
-          "settings" => %{"connect" => %{"root_selector" => "root", "max_pages" => 1}}
+          "settings" => %{
+            "connect" => connect_settings(%{"root_selector" => "root", "max_pages" => 1})
+          }
         })
         |> Repo.insert!()
+        |> issue_active_grant!()
 
       use_data_source_bridge(:google_drive, BridgeStubs.StillMore)
 
@@ -2133,9 +2270,12 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
           "provider" => "google_drive",
           "kind" => "data_source",
           "enabled" => true,
-          "settings" => %{"connect" => %{"root_selector" => "root", "max_pages" => 1}}
+          "settings" => %{
+            "connect" => connect_settings(%{"root_selector" => "root", "max_pages" => 1})
+          }
         })
         |> Repo.insert!()
+        |> issue_active_grant!()
 
       use_data_source_bridge(:google_drive, BridgeStubs.NilIdDuplicate)
 
@@ -2232,7 +2372,9 @@ defmodule ZaqWeb.Live.BO.DataSources.ProviderLiveTest do
               "provider" => "google_drive",
               "kind" => "data_source",
               "enabled" => true,
-              "settings" => %{"connect" => %{"root_selector" => "root", "max_pages" => 5}}
+              "settings" => %{
+                "connect" => connect_settings(%{"root_selector" => "root", "max_pages" => 5})
+              }
             }),
           modal: :new,
           form: nil,


### PR DESCRIPTION
This PR fixes permissions checks on Data Source bridges by matching the Record's permissions (returned by the external provider) with the actor from the person's directory. 

Providing a generic permission layer for all data source while allowing an escape hatch (currently used by the Disk bridge for fine grained storage permissions)