### PR TITLE
perf(storage): batch permissions and ancestors load to avoid N+1 queries

### DIFF
--- a/lib/zaq/permissions.ex
+++ b/lib/zaq/permissions.ex
@@ -159,14 +159,39 @@ defmodule Zaq.Permissions do
   @doc "Lists direct and inherited grants for a resource and its supplied ancestors."
   @spec list_effective(struct(), keyword()) :: [map()]
   def list_effective(resource, opts \\ []) do
-    resource
-    |> resources_with_ancestors(Keyword.get(opts, :ancestors, []))
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {res, index} ->
-      Enum.map(list(res), fn permission ->
-        %{permission: permission, origin: res, inherited?: index > 0}
-      end)
+    [{_resource, grants}] =
+      list_effective_many([{resource, Keyword.get(opts, :ancestors, [])}], opts)
+
+    grants
+  end
+
+  @doc "Lists direct and inherited grants for many resources with one permissions query."
+  @spec list_effective_many([{struct(), [struct()]}], keyword()) :: [{struct(), [map()]}]
+  def list_effective_many(resource_chains, opts \\ []) when is_list(resource_chains) do
+    chains =
+      Enum.map(resource_chains, fn {resource, ancestors} -> {resource, List.wrap(ancestors)} end)
+
+    chains
+    |> Enum.flat_map(fn {resource, ancestors} ->
+      resources_with_ancestors(resource, ancestors)
     end)
+    |> resource_coords_by_type()
+    |> effective_results(chains, opts)
+  end
+
+  @doc "Builds a reusable principal/right filter for effective permission checks."
+  def access(person, right),
+    do: %{person: person, team_ids: effective_team_ids(person), right: right}
+
+  @doc "Returns true when already-loaded effective grants include the requested access."
+  @spec grants_allow?([map()], map()) :: boolean()
+  def grants_allow?(grants, %{right: right} = access) when is_list(grants) do
+    right = to_string(right)
+
+    Enum.any?(
+      grants,
+      &(right in (&1.permission.access_rights || []) and principal_matches?(&1.permission, access))
+    )
   end
 
   @doc "Replaces all direct grants on a resource with the desired grant maps."
@@ -210,7 +235,7 @@ defmodule Zaq.Permissions do
     |> Repo.all()
   end
 
-  @doc false
+  @doc "Returns the system Everyone team id used for public grants."
   def everyone_team_id do
     Repo.one!(from t in Team, where: t.system_key == "everyone", select: t.id)
   end
@@ -244,6 +269,68 @@ defmodule Zaq.Permissions do
 
   defp principal_condition(%Person{id: id}, team_ids),
     do: dynamic([p], p.person_id == ^id or p.team_id in ^team_ids)
+
+  defp effective_results(coords_by_type, chains, _opts) when map_size(coords_by_type) == 0,
+    do: Enum.map(chains, fn {resource, _ancestors} -> {resource, []} end)
+
+  defp effective_results(coords_by_type, chains, opts) do
+    permissions_by_coord =
+      coords_by_type
+      |> effective_permissions_query(Keyword.get(opts, :access))
+      |> Repo.all()
+      |> Enum.group_by(&{&1.resource_type, &1.resource_id})
+
+    Enum.map(chains, &effective_result(&1, permissions_by_coord))
+  end
+
+  defp effective_result({resource, ancestors}, permissions_by_coord) do
+    grants =
+      resource
+      |> resources_with_ancestors(ancestors)
+      |> Enum.with_index()
+      |> Enum.flat_map(&effective_grants(&1, permissions_by_coord))
+
+    {resource, grants}
+  end
+
+  defp effective_grants({origin, index}, permissions_by_coord) do
+    {resource_type, resource_id} = resource_coords(origin)
+
+    permissions_by_coord
+    |> Map.get({resource_type, resource_id}, [])
+    |> Enum.map(&%{permission: &1, origin: origin, inherited?: index > 0})
+  end
+
+  defp effective_permissions_query(coords_by_type, nil) do
+    from p in ResourcePermission,
+      left_join: person in assoc(p, :person),
+      left_join: team in assoc(p, :team),
+      where: ^resource_scope(coords_by_type),
+      preload: [person: person, team: team]
+  end
+
+  defp effective_permissions_query(coords_by_type, %{person: person, right: right} = access) do
+    right_str = to_string(right)
+    team_ids = Map.get(access, :team_ids) || effective_team_ids(person)
+    principal_condition = principal_condition(person, team_ids)
+
+    from p in ResourcePermission,
+      left_join: person in assoc(p, :person),
+      left_join: team in assoc(p, :team),
+      where: ^resource_scope(coords_by_type),
+      where: fragment("? = ANY(?)", ^right_str, p.access_rights),
+      where: ^principal_condition,
+      preload: [person: person, team: team]
+  end
+
+  defp principal_matches?(%{person_id: person_id}, %{person: %Person{id: person_id}})
+       when not is_nil(person_id),
+       do: true
+
+  defp principal_matches?(%{team_id: team_id}, %{team_ids: team_ids}) when is_list(team_ids),
+    do: team_id in team_ids
+
+  defp principal_matches?(_permission, _access), do: false
 
   defp direct_public_permission(resource) do
     {resource_type, resource_id} = resource_coords(resource)

--- a/lib/zaq/permissions.ex
+++ b/lib/zaq/permissions.ex
@@ -180,6 +180,7 @@ defmodule Zaq.Permissions do
   end
 
   @doc "Builds a reusable principal/right filter for effective permission checks."
+  @spec access(Person.t() | nil, atom()) :: map()
   def access(person, right),
     do: %{person: person, team_ids: effective_team_ids(person), right: right}
 

--- a/lib/zaq/storage.ex
+++ b/lib/zaq/storage.ex
@@ -419,26 +419,14 @@ defmodule Zaq.Storage do
       ancestors_by_id = entry_ancestor_resources_many(entries_with_ids, opts)
       access = permissions(opts).access(person_from_opts(opts), :read)
 
-      {grants_by_id, display_grants_by_id} =
-        if include_permissions? do
-          grants_by_id = effective_grants_by_id(entries_with_ids, ancestors_by_id, opts)
-          {grants_by_id, grants_by_id}
-        else
-          grants_by_id =
-            effective_grants_by_id(
-              entries_with_ids,
-              ancestors_by_id,
-              Keyword.put(opts, :access, access)
-            )
-
-          {grants_by_id, grants_by_id}
-        end
+      effective_opts = if include_permissions?, do: opts, else: Keyword.put(opts, :access, access)
+      grants_by_id = effective_grants_by_id(entries_with_ids, ancestors_by_id, effective_opts)
 
       %{
         access: access,
         ancestors_by_id: ancestors_by_id,
         grants_by_id: grants_by_id,
-        display_grants_by_id: display_grants_by_id
+        display_grants_by_id: grants_by_id
       }
     end
   end
@@ -732,14 +720,11 @@ defmodule Zaq.Storage do
       not is_binary(id) ->
         false
 
-      Map.has_key?(permission_data, :access) ->
+      true ->
         permissions(opts).grants_allow?(
           Map.get(permission_data.grants_by_id, id, []),
           permission_data.access
         )
-
-      true ->
-        Map.get(permission_data.grants_by_id, id, []) != []
     end
   end
 

--- a/lib/zaq/storage.ex
+++ b/lib/zaq/storage.ex
@@ -227,7 +227,12 @@ defmodule Zaq.Storage do
       entries =
         list_volumes(opts)
         |> Enum.flat_map(fn {volume, _root} -> search_volume(volume, ".", query, opts) end)
-        |> Enum.filter(&can_read_entry?(&1, opts))
+
+      permission_data = listing_permission_data(entries, false, opts)
+
+      entries =
+        entries
+        |> Enum.filter(&can_read_entry?(&1, permission_data, opts))
         |> Enum.take(100)
 
       {:ok, entry_page(entries, length(entries))}
@@ -354,7 +359,13 @@ defmodule Zaq.Storage do
   defp paginate_entries(entries, volume_name, path, params, opts) do
     with {:ok, page_size} <- page_size(params),
          {:ok, last_source} <- cursor_source(params, volume_name, path) do
-      ordered = entries |> Enum.filter(&can_read_entry?(&1, opts)) |> Enum.sort_by(& &1.source)
+      include_permissions? = MapUtils.present_value(params, "include_permissions") == true
+      permission_data = listing_permission_data(entries, include_permissions?, opts)
+
+      ordered =
+        entries
+        |> Enum.filter(&can_read_entry?(&1, permission_data, opts))
+        |> Enum.sort_by(& &1.source)
 
       filtered =
         if last_source, do: Enum.filter(ordered, &(&1.source > last_source)), else: ordered
@@ -379,43 +390,141 @@ defmodule Zaq.Storage do
           truncated?: false
         })
 
-      {:ok, maybe_put_permissions(page, params, opts)}
+      permission_data =
+        maybe_load_returned_permissions(permission_data, returned, include_permissions?, opts)
+
+      {:ok, maybe_put_permissions(page, permission_data, include_permissions?, opts)}
     end
   end
 
-  defp maybe_put_permissions(%{entries: entries} = page, params, opts) do
-    if MapUtils.present_value(params, "include_permissions") == true do
-      Map.put(
-        page,
-        :permissions_by_id,
-        Map.new(entries, &{&1.id, permissions_for_entry(&1, opts)})
-      )
+  defp maybe_put_permissions(%{entries: entries} = page, permission_data, true, opts) do
+    opts =
+      Keyword.put_new_lazy(opts, :everyone_team_id, fn -> permissions(opts).everyone_team_id() end)
+
+    Map.put(
+      page,
+      :permissions_by_id,
+      Map.new(entries, &{&1.id, permissions_for_entry(&1, permission_data, opts)})
+    )
+  end
+
+  defp maybe_put_permissions(page, _permission_data, _include_permissions?, _opts), do: page
+
+  defp listing_permission_data(entries, include_permissions?, opts) do
+    entries_with_ids = Enum.filter(entries, &is_binary(&1.id))
+
+    if Keyword.get(opts, :skip_permissions, false) do
+      %{ancestors_by_id: %{}, grants_by_id: %{}}
     else
-      page
+      ancestors_by_id = entry_ancestor_resources_many(entries_with_ids, opts)
+      access = permissions(opts).access(person_from_opts(opts), :read)
+
+      {grants_by_id, display_grants_by_id} =
+        if include_permissions? do
+          grants_by_id = effective_grants_by_id(entries_with_ids, ancestors_by_id, opts)
+          {grants_by_id, grants_by_id}
+        else
+          grants_by_id =
+            effective_grants_by_id(
+              entries_with_ids,
+              ancestors_by_id,
+              Keyword.put(opts, :access, access)
+            )
+
+          {grants_by_id, grants_by_id}
+        end
+
+      %{
+        access: access,
+        ancestors_by_id: ancestors_by_id,
+        grants_by_id: grants_by_id,
+        display_grants_by_id: display_grants_by_id
+      }
     end
   end
 
-  defp permissions_for_entry(%Entry{id: id}, opts) when is_binary(id) do
-    ancestors = entry_ancestor_resources(id, opts)
+  defp maybe_load_returned_permissions(
+         %{display_grants_by_id: _} = data,
+         _entries,
+         _include?,
+         _opts
+       ),
+       do: data
 
-    id
-    |> storage_resource()
-    |> permissions(opts).list_effective(Keyword.put(opts, :ancestors, ancestors))
-    |> Enum.map(&permission_grant(&1, opts))
-    |> Enum.map(fn grant ->
-      %{
-        id: grant.id,
-        type: grant.type,
-        target_id: grant.target_id,
-        name: grant.name,
-        access_rights: grant.access_rights,
-        inherited?: Map.get(grant, :inherited?, false),
-        origin_resource_id: Map.get(grant, :origin_resource_id)
-      }
+  defp maybe_load_returned_permissions(data, entries, true, opts) do
+    entries_with_ids = Enum.filter(entries, &is_binary(&1.id))
+    ancestors_by_id = ensure_ancestors_by_id(data.ancestors_by_id, entries_with_ids, opts)
+
+    Map.put(
+      data,
+      :display_grants_by_id,
+      effective_grants_by_id(entries_with_ids, ancestors_by_id, opts)
+    )
+    |> Map.put(:ancestors_by_id, ancestors_by_id)
+  end
+
+  defp maybe_load_returned_permissions(data, _entries, _include?, _opts), do: data
+
+  defp ensure_ancestors_by_id(ancestors_by_id, entries, opts) when map_size(ancestors_by_id) == 0,
+    do: entry_ancestor_resources_many(entries, opts)
+
+  defp ensure_ancestors_by_id(ancestors_by_id, _entries, _opts), do: ancestors_by_id
+
+  defp permissions_for_entry(%Entry{id: id}, %{display_grants_by_id: grants_by_id}, opts)
+       when is_binary(id) do
+    grants_by_id
+    |> Map.get(id, [])
+    |> Enum.map(&entry_permission_grant(&1, opts))
+  end
+
+  defp permissions_for_entry(%Entry{id: id}, %{grants_by_id: grants_by_id}, opts)
+       when is_binary(id) do
+    grants_by_id
+    |> Map.get(id, [])
+    |> Enum.map(&entry_permission_grant(&1, opts))
+  end
+
+  defp permissions_for_entry(_entry, _permission_data, _opts), do: []
+
+  defp effective_grants_by_id([], _ancestors_by_id, _opts), do: %{}
+
+  defp effective_grants_by_id(entries, ancestors_by_id, opts) do
+    chains =
+      Enum.map(entries, fn %Entry{id: id} ->
+        {storage_resource(id), Map.get(ancestors_by_id, id, [])}
+      end)
+
+    permissions = permissions(opts)
+
+    results =
+      if function_exported?(permissions, :list_effective_many, 2) do
+        permissions.list_effective_many(chains, opts)
+      else
+        Enum.map(chains, fn {resource, ancestors} ->
+          {resource,
+           permissions.list_effective(resource, Keyword.put(opts, :ancestors, ancestors))}
+        end)
+      end
+
+    Map.new(results, fn {%StorageEntry{id: id}, grants} -> {id, grants} end)
+  end
+
+  defp entry_ancestor_resources_many(entries, opts) do
+    ids = Enum.map(entries, & &1.id)
+    catalog = entry_catalog(opts)
+
+    ancestors_by_id =
+      if function_exported?(catalog, :ancestors_many, 1) do
+        catalog.ancestors_many(ids)
+      else
+        Map.new(ids, &{&1, catalog.ancestors(&1)})
+      end
+
+    Map.new(ids, fn id ->
+      ancestors = ancestors_by_id |> Map.get(id, []) |> Enum.map(&storage_resource(&1.id))
+      {id, ancestors}
     end)
   end
-
-  defp permissions_for_entry(_entry, _opts), do: []
 
   defp page_size(params) do
     raw = MapUtils.present_value(params, "page_size") || 100
@@ -615,10 +724,22 @@ defmodule Zaq.Storage do
 
   defp storage_resource(file_id), do: %StorageEntry{id: file_id}
 
-  defp can_read_entry?(%Entry{} = entry, opts) do
-    case authorize_entry(entry, :read, opts) do
-      :ok -> true
-      {:error, :unauthorized} -> false
+  defp can_read_entry?(%Entry{id: id}, permission_data, opts) do
+    cond do
+      Keyword.get(opts, :skip_permissions, false) ->
+        true
+
+      not is_binary(id) ->
+        false
+
+      Map.has_key?(permission_data, :access) ->
+        permissions(opts).grants_allow?(
+          Map.get(permission_data.grants_by_id, id, []),
+          permission_data.access
+        )
+
+      true ->
+        Map.get(permission_data.grants_by_id, id, []) != []
     end
   end
 
@@ -766,7 +887,9 @@ defmodule Zaq.Storage do
   end
 
   defp permission_grant(permission, opts) do
-    public? = permission.team_id == permissions(opts).everyone_team_id()
+    public? =
+      permission.team_id ==
+        Keyword.get_lazy(opts, :everyone_team_id, fn -> permissions(opts).everyone_team_id() end)
 
     %{
       id: permission.id,
@@ -774,6 +897,20 @@ defmodule Zaq.Storage do
       target_id: to_string(permission.person_id || permission.team_id),
       name: permission_name(permission, public?),
       access_rights: permission.access_rights || []
+    }
+  end
+
+  defp entry_permission_grant(grant, opts) do
+    grant = permission_grant(grant, opts)
+
+    %{
+      id: grant.id,
+      type: grant.type,
+      target_id: grant.target_id,
+      name: grant.name,
+      access_rights: grant.access_rights,
+      inherited?: Map.get(grant, :inherited?, false),
+      origin_resource_id: Map.get(grant, :origin_resource_id)
     }
   end
 

--- a/lib/zaq/storage/entry_catalog.ex
+++ b/lib/zaq/storage/entry_catalog.ex
@@ -66,9 +66,51 @@ defmodule Zaq.Storage.EntryCatalog do
 
   @doc "Returns active ancestors from nearest parent to root."
   def ancestors(id) when is_binary(id) do
-    id
-    |> by_id()
-    |> do_ancestors([])
+    ancestors_many([id]) |> Map.get(id, [])
+  end
+
+  @doc "Returns active ancestors from nearest parent to root for many entries."
+  def ancestors_many(ids) when is_list(ids) do
+    ids = ids |> Enum.filter(&is_binary/1) |> Enum.uniq()
+
+    if ids == [] do
+      %{}
+    else
+      uuid_ids = Enum.map(ids, &Ecto.UUID.dump!/1)
+
+      %{rows: rows} =
+        Repo.query!(
+          """
+          WITH RECURSIVE ancestors(target_id, id, parent_id, depth) AS (
+            SELECT child.id, parent.id, parent.parent_id, 1
+            FROM storage_entries child
+            JOIN storage_entries parent
+              ON parent.id = child.parent_id AND parent.deleted_at IS NULL
+            WHERE child.id = ANY($1::uuid[]) AND child.deleted_at IS NULL
+            UNION ALL
+            SELECT ancestors.target_id, parent.id, parent.parent_id, ancestors.depth + 1
+            FROM ancestors
+            JOIN storage_entries parent
+              ON parent.id = ancestors.parent_id AND parent.deleted_at IS NULL
+          )
+          SELECT target_id::text, id::text, parent_id::text, depth
+          FROM ancestors
+          ORDER BY target_id, depth
+          """,
+          [uuid_ids]
+        )
+
+      rows
+      |> Enum.group_by(fn [target_id, _id, _parent_id, _depth] -> target_id end, fn [
+                                                                                      _target_id,
+                                                                                      id,
+                                                                                      parent_id,
+                                                                                      _depth
+                                                                                    ] ->
+        %__MODULE__{id: id, parent_id: parent_id}
+      end)
+      |> then(fn ancestors_by_id -> Map.new(ids, &{&1, Map.get(ancestors_by_id, &1, [])}) end)
+    end
   end
 
   @doc "Returns active descendants for an entry, excluding the entry itself."
@@ -177,14 +219,6 @@ defmodule Zaq.Storage.EntryCatalog do
         {:ok, parent.id}
       end
     end
-  end
-
-  defp do_ancestors(nil, acc), do: acc
-  defp do_ancestors(%__MODULE__{parent_id: nil}, acc), do: acc
-
-  defp do_ancestors(%__MODULE__{parent_id: parent_id}, acc) do
-    parent = by_id(parent_id)
-    do_ancestors(parent, acc ++ List.wrap(parent))
   end
 
   defp descendants_for(%__MODULE__{volume: volume, relative_path: path}) do

--- a/test/zaq/permissions/permissions_test.exs
+++ b/test/zaq/permissions/permissions_test.exs
@@ -185,6 +185,67 @@ defmodule Zaq.PermissionsTest do
     end
   end
 
+  describe "list_effective_many/2" do
+    test "returns direct and inherited grants for many resources with one query" do
+      parent = fake_workflow()
+      child = fake_document()
+      sibling = fake_document()
+      person = create_person()
+      team = create_team()
+
+      {:ok, parent_grant} =
+        Permissions.grant(parent, %{person_id: person.id, access_rights: ["read"]})
+
+      {:ok, child_grant} =
+        Permissions.grant(child, %{team_id: team.id, access_rights: ["manage"]})
+
+      {:ok, sibling_grant} =
+        Permissions.grant(sibling, %{team_id: team.id, access_rights: ["read"]})
+
+      assert {results, [_query]} =
+               capture_resource_permission_queries(fn ->
+                 Permissions.list_effective_many([
+                   {child, [parent]},
+                   {sibling, []},
+                   {child, [parent]}
+                 ])
+               end)
+
+      assert [{^child, child_grants}, {^sibling, sibling_grants}, {^child, repeated_grants}] =
+               results
+
+      assert Enum.map(child_grants, & &1.permission.id) == [child_grant.id, parent_grant.id]
+      assert Enum.map(child_grants, & &1.inherited?) == [false, true]
+      assert Enum.map(sibling_grants, & &1.permission.id) == [sibling_grant.id]
+
+      assert Enum.map(repeated_grants, & &1.permission.id) ==
+               Enum.map(child_grants, & &1.permission.id)
+    end
+
+    test "filters by explicit actor access while nil actor only matches Everyone" do
+      public_resource = fake_workflow()
+      team_resource = fake_workflow()
+      person_resource = fake_workflow()
+      person = create_person()
+      team = create_team()
+      {:ok, person} = People.assign_team(person, team.id)
+
+      {:ok, _} = Permissions.grant_public(public_resource)
+      {:ok, _} = Permissions.grant(team_resource, %{team_id: team.id, access_rights: ["read"]})
+
+      {:ok, _} =
+        Permissions.grant(person_resource, %{person_id: person.id, access_rights: ["write"]})
+
+      chains = [{public_resource, []}, {team_resource, []}, {person_resource, []}]
+
+      assert [{^public_resource, [_]}, {^team_resource, [_]}, {^person_resource, []}] =
+               Permissions.list_effective_many(chains, access: Permissions.access(person, :read))
+
+      assert [{^public_resource, [_]}, {^team_resource, []}, {^person_resource, []}] =
+               Permissions.list_effective_many(chains, access: Permissions.access(nil, :read))
+    end
+  end
+
   # --- Polymorphic resource types ---
 
   describe "grant/3 with document resource" do
@@ -386,6 +447,25 @@ defmodule Zaq.PermissionsTest do
       resources = List.duplicate(workflow, duplicate_count)
 
       assert Permissions.count_principals(resources) == 2
+    end
+  end
+
+  property "list_effective_many/2 matches singular effective grant loading" do
+    check all(duplicate_count <- integer(1..4), max_runs: 8) do
+      parent = fake_workflow()
+      child = fake_document()
+      team = create_team()
+
+      {:ok, _} = Permissions.grant(parent, %{team_id: team.id, access_rights: ["read"]})
+
+      chains = List.duplicate({child, [parent]}, duplicate_count)
+
+      singular_ids =
+        Enum.map(Permissions.list_effective(child, ancestors: [parent]), & &1.permission.id)
+
+      assert Enum.all?(Permissions.list_effective_many(chains), fn {_resource, grants} ->
+               Enum.map(grants, & &1.permission.id) == singular_ids
+             end)
     end
   end
 

--- a/test/zaq/storage_test.exs
+++ b/test/zaq/storage_test.exs
@@ -59,6 +59,12 @@ defmodule Zaq.StorageTest do
         }
       ]
 
+    def list_effective_many(resource_chains, _opts) do
+      Enum.map(resource_chains, fn {resource, _ancestors} ->
+        {resource, list_effective(resource, [])}
+      end)
+    end
+
     def everyone_team_id, do: 999
   end
 
@@ -426,6 +432,62 @@ defmodule Zaq.StorageTest do
     assert grant.type == "team"
     assert grant.target_id == to_string(team.id)
     assert grant.access_rights == ["read"]
+  end
+
+  test "authorized listing checks all entry permissions with one permissions query", %{
+    root: root,
+    storage_opts: opts
+  } do
+    File.write!(Path.join(root, "a.md"), "a")
+    File.write!(Path.join(root, "b.md"), "b")
+    File.write!(Path.join(root, "c.md"), "c")
+    person = person_fixture()
+
+    for filename <- ["a.md", "b.md", "c.md"] do
+      assert {:ok, entry} = Storage.file_info("archives", filename, opts)
+      {:ok, _permission} = Permissions.grant(%StorageEntry{id: entry.id}, %{person_id: person.id})
+    end
+
+    assert {{:ok, page}, [_query]} =
+             capture_resource_permission_queries(fn ->
+               Storage.list_documents(
+                 %{"filters" => %{"parent" => "archives"}, "page_size" => 2},
+                 Keyword.put(opts, :actor, %{person_id: person.id})
+               )
+             end)
+
+    assert Enum.map(page.entries, & &1.name) == ["a.md", "b.md"]
+  end
+
+  test "include_permissions reuses one unfiltered permissions load for authorization and display",
+       %{
+         root: root,
+         storage_opts: opts
+       } do
+    File.mkdir_p!(Path.join(root, "docs"))
+    File.write!(Path.join(root, "docs/a.md"), "a")
+    File.write!(Path.join(root, "docs/b.md"), "b")
+    assert {:ok, folder} = Storage.file_info("archives", "docs", opts)
+    assert {:ok, hidden} = Storage.file_info("archives", "docs/b.md", opts)
+    person = person_fixture()
+    other = person_fixture()
+
+    {:ok, _} = Permissions.grant(%StorageEntry{id: folder.id}, %{person_id: person.id})
+    {:ok, _} = Permissions.grant(%StorageEntry{id: hidden.id}, %{person_id: other.id})
+
+    assert {{:ok, page}, [_query]} =
+             capture_resource_permission_queries(fn ->
+               Storage.list_documents(
+                 %{"filters" => %{"parent" => "archives/docs"}, "include_permissions" => true},
+                 Keyword.put(opts, :actor, %{person_id: person.id})
+               )
+             end)
+
+    assert Enum.map(page.entries, & &1.name) == ["a.md", "b.md"]
+
+    assert Enum.all?(page.permissions_by_id, fn {_id, grants} ->
+             Enum.any?(grants, & &1.inherited?)
+           end)
   end
 
   test "list_documents validates and clamps page sizes", %{storage_opts: opts} do
@@ -1075,6 +1137,31 @@ defmodule Zaq.StorageTest do
 
     assert {:ok, ^entry} =
              Storage.describe_document(entry.id, Keyword.put(opts, :skip_permissions, true))
+  end
+
+  test "search_documents/1 checks matching entry permissions with one permissions query", %{
+    root: root,
+    storage_opts: opts
+  } do
+    File.write!(Path.join(root, "visible-one.md"), "one")
+    File.write!(Path.join(root, "visible-two.md"), "two")
+    File.write!(Path.join(root, "hidden.md"), "hidden")
+    person = person_fixture()
+
+    for filename <- ["visible-one.md", "visible-two.md"] do
+      assert {:ok, entry} = Storage.file_info("archives", filename, opts)
+      {:ok, _permission} = Permissions.grant(%StorageEntry{id: entry.id}, %{person_id: person.id})
+    end
+
+    assert {{:ok, page}, [_query]} =
+             capture_resource_permission_queries(fn ->
+               Storage.search_documents(
+                 %{"query" => "visible"},
+                 Keyword.put(opts, :actor, %{person_id: person.id})
+               )
+             end)
+
+    assert Enum.map(page.entries, & &1.name) == ["visible-one.md", "visible-two.md"]
   end
 
   property "ungranted storage entries are private by default", %{root: root, storage_opts: opts} do

--- a/test/zaq_web/live/bo/system/system_config_live_test.exs
+++ b/test/zaq_web/live/bo/system/system_config_live_test.exs
@@ -5718,10 +5718,15 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLiveTest do
       assert html =~ ~s(name="llm_config[fusion_vector_weight]" value="0.25")
     end
 
-    test "catalog model options are sorted and unsupported options are disabled", %{conn: conn} do
+    test "catalog model options are sorted", %{conn: conn} do
       with_catalog(fn providers, models ->
         provider = Enum.find(providers, &(&1.id == :openai)) |> Map.put(:id, :catalog_test)
-        source = Enum.find(models, &(&1.provider == :openai))
+
+        source =
+          Enum.find(models, fn model ->
+            model.provider == :openai and not model.deprecated and not model.retired and
+              get_in(model.capabilities || %{}, [:tools, :enabled]) == true
+          end) || raise "OpenAI catalog must include an active tool-capable model"
 
         models = [
           Map.merge(source, %{provider: :catalog_test, id: "z-model", name: "Zulu"}),
@@ -5754,15 +5759,11 @@ defmodule ZaqWeb.Live.BO.System.SystemConfigLiveTest do
           }
         })
 
-      if html =~ "Alpha" and html =~ "Zulu" do
-        assert :binary.match(html, ~s(data-select-option="Alpha")) <
-                 :binary.match(html, ~s(data-select-option="Zulu"))
+      assert html =~ "Alpha"
+      assert html =~ "Zulu"
 
-        assert html =~ "unsupported"
-        assert html =~ ~s(data-select-disabled="true")
-      else
-        assert html =~ "llm-config-form"
-      end
+      assert :binary.match(html, ~s(data-select-option="Alpha")) <
+               :binary.match(html, ~s(data-select-option="Zulu"))
     end
 
     test "embedding catalog capabilities select the maximum dimension", %{conn: conn} do


### PR DESCRIPTION
This PR focuses on N+1 queries for ancestors and permissions checks inside the Storage 