### PR TITLE
fix(Data source): get document on google drive use valid field mask

### DIFF
--- a/lib/zaq/channels/jido_connect_bridge.ex
+++ b/lib/zaq/channels/jido_connect_bridge.ex
@@ -121,7 +121,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
   @impl true
   def get_file(config, params, _context \\ %{}) when is_map(config) and is_map(params) do
-    params = maybe_embed_permissions_projection(params, config)
+    params = maybe_embed_permissions_projection(params, config, :get_item_metadata)
 
     with {:ok, payload} <- invoke_intent(config, :get_item_metadata, params),
          {:ok, record} <- map_file_from_payload(payload, config, params) do
@@ -1933,23 +1933,28 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
   defp canonical_access_rights(_value), do: []
 
-  defp maybe_embed_permissions_projection(params, %{provider: provider} = _config)
+  defp maybe_embed_permissions_projection(params, %{provider: provider} = config)
+       when is_map(params) and (is_binary(provider) or is_atom(provider)) do
+    maybe_embed_permissions_projection(params, config, :list_items)
+  end
+
+  defp maybe_embed_permissions_projection(params, _), do: params
+
+  defp maybe_embed_permissions_projection(params, %{provider: provider}, action_intent)
        when is_map(params) and (is_binary(provider) or is_atom(provider)) do
     if truthy?(Map.get(params, :include_permissions) || Map.get(params, "include_permissions")) do
-      enrich_permissions_projection(provider, params)
+      enrich_permissions_projection(provider, params, action_intent)
     else
       params
     end
   end
 
-  defp maybe_embed_permissions_projection(params, _), do: params
-
-  defp enrich_permissions_projection(provider, params) do
+  defp enrich_permissions_projection(provider, params, action_intent) do
     provider = to_string(provider)
 
-    with {:ok, action} <- resolve_action(provider, :list_items),
+    with {:ok, action} <- resolve_action(provider, action_intent),
          true <- action_supports_fields_input?(provider, action) do
-      maybe_set_provider_permission_fields(provider, params)
+      maybe_set_provider_permission_fields(provider, params, action_intent)
     else
       _ -> params
     end
@@ -1998,7 +2003,30 @@ defmodule Zaq.Channels.JidoConnectBridge do
 
   defp fields_input?(_), do: false
 
-  defp maybe_set_provider_permission_fields("google_drive", params) do
+  defp maybe_set_provider_permission_fields("google_drive", params, :get_item_metadata) do
+    permission_fields =
+      "permissions(id,type,role,emailAddress,domain,displayName,allowFileDiscovery,deleted,expirationTime)"
+
+    fields = Map.get(params, :fields) || Map.get(params, "fields")
+
+    merged_fields =
+      cond do
+        is_binary(fields) and String.contains?(fields, "permissions(") ->
+          fields
+
+        is_binary(fields) ->
+          fields <> ",#{permission_fields}"
+
+        true ->
+          default_google_drive_file_fields_with_permissions(permission_fields)
+      end
+
+    params
+    |> Map.put(:fields, merged_fields)
+    |> Map.put("fields", merged_fields)
+  end
+
+  defp maybe_set_provider_permission_fields("google_drive", params, _action_intent) do
     permission_fields =
       "permissions(id,type,role,emailAddress,domain,displayName,allowFileDiscovery,deleted,expirationTime)"
 
@@ -2031,7 +2059,14 @@ defmodule Zaq.Channels.JidoConnectBridge do
     |> Map.put("fields", merged_fields)
   end
 
-  defp maybe_set_provider_permission_fields(_provider, params), do: params
+  defp maybe_set_provider_permission_fields(_provider, params, _action_intent), do: params
+
+  defp default_google_drive_file_fields_with_permissions(permission_fields) do
+    file_fields =
+      "id,name,mimeType,description,webViewLink,webContentLink,iconLink,thumbnailLink,size,md5Checksum,createdTime,modifiedTime,parents,owners,shared,trashed,starred,driveId"
+
+    "#{file_fields},#{permission_fields}"
+  end
 
   defp default_google_drive_list_fields_with_permissions(permission_fields) do
     file_fields =

--- a/test/zaq/channels/jido_connect_bridge_test.exs
+++ b/test/zaq/channels/jido_connect_bridge_test.exs
@@ -92,6 +92,43 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
     def triggers(_integration), do: {:ok, []}
   end
 
+  defmodule StubJidoConnectGetFileWithFields do
+    def actions(_integration) do
+      {:ok,
+       [
+         %{
+           id: "stub.file.get",
+           resource: :file,
+           verb: :get,
+           auth_profile: :user,
+           auth_profiles: [:user],
+           input: [%{name: :fields}]
+         }
+       ]}
+    end
+
+    def invoke(_integration, "stub.file.get", params, opts) do
+      send(self(), {:invoke_get_file, params, opts})
+
+      {:ok,
+       %{
+         file: %{
+           "id" => Map.get(params, "file_id") || Map.get(params, :file_id),
+           "name" => "Doc 1",
+           "mimeType" => "application/pdf",
+           "permissions" => [
+             %{
+               "id" => "u1",
+               "type" => "user",
+               "role" => "reader",
+               "emailAddress" => "a@example.com"
+             }
+           ]
+         }
+       }}
+    end
+  end
+
   defmodule StubJidoConnectStructPermissions do
     def actions(_integration) do
       StubJidoConnect.actions(nil)
@@ -2006,6 +2043,31 @@ defmodule Zaq.Channels.JidoConnectBridgeTest do
     fields = Map.get(params, :fields) || Map.get(params, "fields")
     assert String.contains?(fields, "nextPageToken,")
     assert String.contains?(fields, "permissions(")
+  end
+
+  test "get_file with include_permissions uses a single-file Google Drive field mask" do
+    config = insert_data_source_config(:google_drive)
+    credential = create_credential!()
+    _grant = create_active_grant!(credential, config.id)
+
+    Application.put_env(
+      :zaq,
+      :jido_connect_bridge_jido_connect_module,
+      StubJidoConnectGetFileWithFields
+    )
+
+    assert {:ok, %{record: %Record{id: "f1"}}} =
+             JidoConnectBridge.get_file(config, %{
+               "file_id" => "f1",
+               "include_permissions" => true
+             })
+
+    assert_received {:invoke_get_file, params, _opts}
+    fields = Map.get(params, :fields) || Map.get(params, "fields")
+
+    assert String.contains?(fields, "permissions(")
+    refute String.contains?(fields, "nextPageToken")
+    refute String.contains?(fields, "files(")
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
This is a **Google Drive-specific field-mask bug in `JidoConnectBridge.get_file/3`**, not a generic `get_document` failure.

**Cause**

1. `get_document` dispatches `:data_source_get_file` (`lib/zaq/agent/tools/data_source/get_document.ex:36`).
2. Permission enforcement adds `include_permissions: true` for normal requests (`lib/zaq/channels/data_source_bridge.ex:710`).
3. `JidoConnectBridge.get_file/3` enriches the request with permission fields (`lib/zaq/channels/jido_connect_bridge.ex:123`).
4. That enrichment incorrectly uses the Google Drive **files.list** field mask:
   ```text
   nextPageToken,files(id,name,...,permissions(...))
   ```
5. The mask is then sent to Google’s **files.get** endpoint. `nextPageToken` and `files(...)` are list-response fields, so Google rejects it with:
   ```text
   Invalid field selection nextPageToken
   ```

The connector already distinguishes these masks:

- `files.get`: `id,name,...,permissions(...)`
- `files.list`: `nextPageToken,files(...)`

See `deps/jido_connect_google_drive/.../fields.ex:117-147`.

**Scope**

- `google_drive` + `JidoConnectBridge.get_file/3`: affected.
- Agent `get_document` against Google Drive: affected.
- Other callers of Google Drive `get_file`: likely affected when permissions are enforced.
- Google Drive `list_documents` / search: the list-shaped mask is valid there.
- Disk bridge: **not affected by this error**. It calls Storage’s `:describe_document` directly and never constructs Google field masks (`lib/zaq/channels/disk_bridge.ex:143`).
- SharePoint and other JidoConnect providers: not affected by this exact bug because the faulty mask-building clause is specific to `"google_drive"`.

The regression appears to have been introduced in commit `f05a55b5`, when permission projection was added to `get_file/3`. The missing test is a Google Drive `get_file` assertion verifying that its permission-enriched `fields` value uses a single-file mask rather than a list mask.