### PR TITLE
fix(data source): seal watched records to make them safe for materialization and fix mattermost reactions variants

### DIFF
--- a/docs/services/channels.md
+++ b/docs/services/channels.md
@@ -313,6 +313,7 @@ Response behavior:
 - Data source providers return accepted/rejected JSON envelopes from the channels controller.
 - For `jido_connect` data-source webhooks, verification remains synchronous in `handle_webhook/2`, then post-verification processing runs asynchronously via `Zaq.Channels.JidoConnectBridge.WebhookWorker` on the `:channels` queue.
 - Data-source collection webhooks are metadata-only. Channels normalizes the delivery, resolves the Engine watch channel, calls the provider's collection change listing action with the stored checkpoint, and dispatches the resulting signals to Engine.
+- Changed collection metadata is converted to canonical Records in Channels. Both collection changes and successful file-watch metadata reads use `DataSourceBridge.seal_response/2`, including recursive permission sealing, before Engine handoff. Sparse tombstones and synthetic metadata-read fallbacks are not issued provenance. Watch notifications do not mint new materialization handles or grant permission bypass.
 - Provider sync notifications, such as Google Drive `resource_state: "sync"`, are accepted but treated as no-ops.
 - Public webhook URLs are built with `Zaq.Channels.WebhookUrl` from `system.global.base_url`. If the global base URL is unset, external provider watch setup is unavailable until configured.
 

--- a/docs/services/channels.md
+++ b/docs/services/channels.md
@@ -518,6 +518,16 @@ Reactions are feedback, not a separate domain. The channel layer owns exactly on
 
 Nothing downstream of step 3 knows a reaction was involved. See `docs/services/engine.md` for the `:rate_message` contract.
 
+For Mattermost, `ReactionMapper` maps `+1`, `thumbsup`, and `thumbs_up` to 5,
+and `-1`, `thumbsdown`, and `thumbs_down` to 1. These shortcodes can be bare
+or wrapped in a matched pair of colons, with an optional `_light_skin_tone`,
+`_medium_light_skin_tone`, `_medium_skin_tone`, `_medium_dark_skin_tone`, or
+`_dark_skin_tone` suffix inside the colons (for example, `:+1_medium_skin_tone:`).
+Only complete shortcodes match: custom prefixes, invalid suffixes, trailing junk,
+and unpaired colons remain ignored. This rating lookup does not change adapter
+event normalization, other providers' mappings, or supported Unicode forms.
+Reaction removals and unrelated emoji still dispatch no rating.
+
 ### Outbound flow
 
 Called by channels delivery routing (`Channels.Api` -> bridge-specific `send_reply/2`):

--- a/docs/services/ingestion.md
+++ b/docs/services/ingestion.md
@@ -73,6 +73,19 @@ remains available for immediate operations such as folder expansion and material
 - `count_watched_provider_documents/2` — counts watched provider documents for a data-source config.
 - `data_source_inherited_watch/3`, `data_source_record_watch_state/2`, `data_source_record_watch_active?/1` — shared BO/processing helpers for direct and inherited folder watch state.
 
+Watch changes carrying canonical Record maps are reconstructed with `Record.from_map/1`,
+preserving verified provenance, permission projections, handles, and canonical metadata
+before job persistence. Invalid canonical projections are not scheduled. Sparse removal
+signals retain their existing deletion and watch-filtering behavior.
+
+Previously failed jobs whose stored `source_record` lacks valid provenance are not repaired
+by retrying: retry reuses the same snapshot. After deploying the watch fix, manually ingest
+the affected files again through the data-source browser to obtain fresh trusted Records,
+or let a new provider change create a fresh job. Do not add signatures to old job payloads
+or disable verification. Provider checkpoints may already have advanced, so do not assume
+the failed changes will automatically replay. Metadata-read fallback records remain unsigned;
+if those continue failing, investigate provider access and metadata-fetch errors first.
+
 **Access control**
 - `can_access_file?/2` — returns true if a user may access a file; super admins bypass all checks; Everyone grants provide public access; documents with no permission rows are private (admin-only)
 - `list_document_permissions/1` — list all permissions for a document (preloads `:person`, `:team`)

--- a/lib/zaq/channels/data_source_bridge.ex
+++ b/lib/zaq/channels/data_source_bridge.ex
@@ -616,11 +616,19 @@ defmodule Zaq.Channels.DataSourceBridge do
     end
   end
 
-  defp seal_response({:ok, payload}, %ChannelConfig{} = config) do
+  @doc """
+  Seals successful canonical Records issued by a trusted data-source bridge.
+
+  Used by synchronous operations and verified provider-change processing. This
+  is not an authorization boundary: callers must not pass untrusted requests,
+  synthetic fallback Records, or tombstones as successful provider records.
+  """
+  @spec seal_response(term(), map()) :: term()
+  def seal_response({:ok, payload}, %ChannelConfig{} = config) do
     seal_value(payload, config)
   end
 
-  defp seal_response(other, _config), do: other
+  def seal_response(other, _config), do: other
 
   defp seal_value(%RecordPage{records: records} = page, %ChannelConfig{} = config)
        when is_list(records) do

--- a/lib/zaq/channels/jido_chat_bridge/reaction_mapper.ex
+++ b/lib/zaq/channels/jido_chat_bridge/reaction_mapper.ex
@@ -4,11 +4,22 @@ defmodule Zaq.Channels.JidoChatBridge.ReactionMapper do
 
   This module normalizes reactions from supported chat providers into
   provider-agnostic numeric ratings before they are dispatched to the engine.
+
+  Mattermost thumb shortcodes accept optional paired colons and one standard
+  skin-tone suffix. Only the existing thumb aliases are normalized; custom
+  names, malformed shortcodes and other providers' representations are unchanged.
   """
+
+  @mattermost_shortcode ~r/\A(:?)(\+1|-1|thumbsup|thumbs_up|thumbsdown|thumbs_down)(?:_(?:light|medium_light|medium|medium_dark|dark)_skin_tone)?\1\z/
 
   @doc """
   Returns `{:ok, rating}` for a recognised emoji, or `:ignored` for
   unmapped reactions.
+
+  Mattermost accepts `+1`, `thumbsup`, `thumbs_up` (5) and `-1`, `thumbsdown`,
+  `thumbs_down` (1), bare or colon-wrapped, optionally suffixed with
+  `_light_skin_tone`, `_medium_light_skin_tone`, `_medium_skin_tone`,
+  `_medium_dark_skin_tone` or `_dark_skin_tone`.
 
   Total by design: callers run inside the bridge state process and pass
   provider-supplied values, so a missing or malformed emoji must be ignored
@@ -52,6 +63,13 @@ defmodule Zaq.Channels.JidoChatBridge.ReactionMapper do
 
   defp emoji_to_rating(:discord, "thumbsdown"), do: {:ok, 1}
   defp emoji_to_rating(:discord, "-1"), do: {:ok, 1}
+
+  defp emoji_to_rating(:mattermost, emoji) do
+    case Regex.run(@mattermost_shortcode, emoji, capture: [2]) do
+      [base] -> emoji_to_rating(:mattermost, base)
+      nil -> nil
+    end
+  end
 
   # Fallback
   defp emoji_to_rating(_provider, _emoji), do: nil

--- a/lib/zaq/channels/jido_connect_bridge.ex
+++ b/lib/zaq/channels/jido_connect_bridge.ex
@@ -2651,11 +2651,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
         record = read_any(signal, [:record, "record"])
 
         if is_map(record) and not deleted_signal?(signal) do
-          record =
-            record
-            |> map_file_record()
-            |> apply_signal_change(signal)
-            |> then(&put_external_record_attrs(config, &1))
+          record = normalize_changed_record(config, record, signal)
 
           signal |> Map.delete("record") |> Map.put(:record, record)
         else
@@ -2818,11 +2814,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
       {:ok, payload} ->
         raw = read_any(payload, [:file, "file"]) || payload
 
-        record =
-          raw
-          |> map_file_record()
-          |> apply_signal_change(signal)
-          |> then(&put_external_record_attrs(config, &1))
+        record = normalize_changed_record(config, raw, signal)
 
         DataSourceBridge.seal_response({:ok, record}, config)
 
@@ -2831,6 +2823,13 @@ defmodule Zaq.Channels.JidoConnectBridge do
          %Record{id: file_id, kind: :file, raw: %{}, attributes: %{}}
          |> apply_signal_change(signal)}
     end
+  end
+
+  defp normalize_changed_record(config, raw, signal) do
+    raw
+    |> map_file_record()
+    |> apply_signal_change(signal)
+    |> then(&put_external_record_attrs(config, &1))
   end
 
   defp deleted_signal?(signal) when is_map(signal) do

--- a/lib/zaq/channels/jido_connect_bridge.ex
+++ b/lib/zaq/channels/jido_connect_bridge.ex
@@ -1750,7 +1750,7 @@ defmodule Zaq.Channels.JidoConnectBridge do
       parent_ids: parent_ids,
       mime_type: mime_type,
       path: read_stringish(raw, ["path", :path]),
-      url: read_stringish(raw, ["web_view_link", :web_view_link]),
+      url: read_stringish(raw, ["web_view_link", :web_view_link, "web_url", :web_url]),
       size: read_integer(raw, ["size", :size]),
       description: read_stringish(raw, ["description", :description]),
       owners: read_owners(raw),
@@ -2632,13 +2632,38 @@ defmodule Zaq.Channels.JidoConnectBridge do
   end
 
   defp process_collection_webhook_delivery(config, payload, trigger, delivery_map, watch_channel) do
-    with {:ok, changes} <- list_collection_changes(config, watch_channel) do
+    with {:ok, changes} <- list_collection_changes(config, watch_channel),
+         {:ok, signals} <- normalize_watch_signals(config, changes) do
       dispatch_watch_changes_to_engine(config, payload, trigger, delivery_map, watch_channel, %{
-        signals: read_any(changes, [:signals, "signals"]) || [],
+        signals: signals,
         checkpoint: watch_channel_checkpoint(watch_channel),
         next_checkpoint: read_stringish(changes, [:checkpoint, "checkpoint", :cursor, "cursor"])
       })
     end
+  end
+
+  defp normalize_watch_signals(config, changes) do
+    signals =
+      changes
+      |> read_any([:signals, "signals"])
+      |> List.wrap()
+      |> Enum.map(fn signal ->
+        record = read_any(signal, [:record, "record"])
+
+        if is_map(record) and not deleted_signal?(signal) do
+          record =
+            record
+            |> map_file_record()
+            |> apply_signal_change(signal)
+            |> then(&put_external_record_attrs(config, &1))
+
+          signal |> Map.delete("record") |> Map.put(:record, record)
+        else
+          signal
+        end
+      end)
+
+    DataSourceBridge.seal_response({:ok, signals}, config)
   end
 
   defp resolve_watch_channel(config, delivery_map) do
@@ -2792,7 +2817,14 @@ defmodule Zaq.Channels.JidoConnectBridge do
     case invoke_intent(config, :get_item_metadata, %{file_id: file_id}) do
       {:ok, payload} ->
         raw = read_any(payload, [:file, "file"]) || payload
-        {:ok, map_file_record(raw) |> apply_signal_change(signal)}
+
+        record =
+          raw
+          |> map_file_record()
+          |> apply_signal_change(signal)
+          |> then(&put_external_record_attrs(config, &1))
+
+        DataSourceBridge.seal_response({:ok, record}, config)
 
       _ ->
         {:ok,
@@ -2802,7 +2834,9 @@ defmodule Zaq.Channels.JidoConnectBridge do
   end
 
   defp deleted_signal?(signal) when is_map(signal) do
-    Map.get(signal, :removed) == true or
+    Map.get(signal, :removed?) == true or
+      Map.get(signal, "removed?") == true or
+      Map.get(signal, :removed) == true or
       Map.get(signal, "removed") == true or
       Map.get(signal, :deleted) == true or
       Map.get(signal, "deleted") == true or

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -1186,6 +1186,12 @@ defmodule Zaq.Ingestion do
   defp data_source_signal_record(signal, use_fallback_id?) when is_map(signal) do
     record = read_any(signal, [:record, "record"])
 
+    # Removals carry sparse identity metadata, not signed ingestible Records.
+    record =
+      if data_source_signal_removed?(signal) and is_map(record) and not is_struct(record),
+        do: Map.drop(record, [:provenance_ref, "provenance_ref"]),
+        else: record
+
     provider_record_id =
       if use_fallback_id? do
         read_stringish(signal, [:provider_record_id, "provider_record_id", :id, "id"])
@@ -1202,6 +1208,14 @@ defmodule Zaq.Ingestion do
   defp normalize_data_source_record(record), do: normalize_data_source_record(record, nil)
 
   defp normalize_data_source_record(%Record{} = record, _fallback_id), do: record
+
+  defp normalize_data_source_record(record, _fallback_id)
+       when is_map_key(record, :provenance_ref) or is_map_key(record, "provenance_ref") do
+    case Record.from_map(record) do
+      {:ok, canonical} -> canonical
+      {:error, _reason} -> nil
+    end
+  end
 
   defp normalize_data_source_record(record, fallback_id) when is_map(record) do
     id =

--- a/lib/zaq/ingestion/ingestion.ex
+++ b/lib/zaq/ingestion/ingestion.ex
@@ -1212,8 +1212,12 @@ defmodule Zaq.Ingestion do
   defp normalize_data_source_record(record, _fallback_id)
        when is_map_key(record, :provenance_ref) or is_map_key(record, "provenance_ref") do
     case Record.from_map(record) do
-      {:ok, canonical} -> canonical
-      {:error, _reason} -> nil
+      {:ok, canonical} ->
+        canonical
+
+      {:error, reason} ->
+        log_rejected_data_source_record(record, reason)
+        nil
     end
   end
 
@@ -1242,6 +1246,19 @@ defmodule Zaq.Ingestion do
   end
 
   defp normalize_data_source_record(_record, _fallback_id), do: nil
+
+  defp log_rejected_data_source_record(record, reason) do
+    # Only bounded identity text and an error category belong in diagnostics,
+    # never the projection, permission payload, or provenance token.
+    id = read_any(record, [:id, "id"])
+    id = if is_binary(id), do: binary_part(id, 0, min(byte_size(id), 128)), else: nil
+    reason = if is_atom(reason), do: reason, else: :invalid_record
+
+    Logger.warning(fn ->
+      "[Ingestion] Rejected data-source record " <>
+        "id=#{inspect(id)} reason=#{inspect(reason)}"
+    end)
+  end
 
   defp maybe_apply_signal_change(nil, _signal), do: nil
 

--- a/test/zaq/channels/jido_chat_bridge/mattermost_reaction_ingress_test.exs
+++ b/test/zaq/channels/jido_chat_bridge/mattermost_reaction_ingress_test.exs
@@ -137,6 +137,42 @@ defmodule Zaq.Channels.JidoChatBridge.MattermostReactionIngressTest do
     assert event.request.rater_attrs.rating == 1
   end
 
+  test "toned shortcodes reach Engine with the original message and rater", %{
+    pid: pid,
+    config: config
+  } do
+    for {emoji, rating} <- [
+          {"+1_medium_skin_tone", 5},
+          {":+1_medium_skin_tone:", 5},
+          {"thumbs_down_dark_skin_tone", 1},
+          {":-1_light_skin_tone:", 1}
+        ] do
+      assert :ok = deliver(pid, config, reaction_envelope(emoji))
+
+      assert_received {:node_router_dispatch, event}
+      assert event.opts[:action] == :rate_message
+
+      assert %{
+               message_ref: {:external_id, "post-1"},
+               rater_attrs: %{channel_user_id: "user-123", rating: ^rating}
+             } = event.request
+
+      refute_received {:node_router_dispatch, _event}
+    end
+  end
+
+  test "removing a toned reaction dispatches nothing", %{pid: pid, config: config} do
+    assert :ok =
+             deliver(pid, config, reaction_envelope(":+1_medium_skin_tone:", "reaction_removed"))
+
+    refute_received {:node_router_dispatch, _event}
+  end
+
+  test "custom toned names dispatch nothing", %{pid: pid, config: config} do
+    assert :ok = deliver(pid, config, reaction_envelope("custom_+1_medium_skin_tone"))
+    refute_received {:node_router_dispatch, _event}
+  end
+
   test "removing a reaction dispatches nothing", %{pid: pid, config: config} do
     assert :ok = deliver(pid, config, reaction_envelope("thumbsup", "reaction_removed"))
 

--- a/test/zaq/channels/jido_chat_bridge/reaction_mapper_test.exs
+++ b/test/zaq/channels/jido_chat_bridge/reaction_mapper_test.exs
@@ -1,7 +1,100 @@
 defmodule Zaq.Channels.JidoChatBridge.ReactionMapperTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Zaq.Channels.JidoChatBridge.ReactionMapper
+
+  @mattermost_aliases [
+    {"+1", 5},
+    {"thumbsup", 5},
+    {"thumbs_up", 5},
+    {"-1", 1},
+    {"thumbsdown", 1},
+    {"thumbs_down", 1}
+  ]
+  @tone_suffixes [
+    "",
+    "_light_skin_tone",
+    "_medium_light_skin_tone",
+    "_medium_skin_tone",
+    "_medium_dark_skin_tone",
+    "_dark_skin_tone"
+  ]
+
+  describe "to_rating/2 Mattermost shortcodes" do
+    test "maps paired-colon aliases and all five standard skin tones" do
+      for {base, rating} <- @mattermost_aliases do
+        assert ReactionMapper.to_rating(:mattermost, ":#{base}:") == {:ok, rating}
+      end
+
+      for suffix <- @tone_suffixes do
+        assert {:ok, 5} = ReactionMapper.to_rating(:mattermost, "+1" <> suffix)
+        assert {:ok, 1} = ReactionMapper.to_rating(:mattermost, ":-1#{suffix}:")
+      end
+
+      assert {:ok, 5} = ReactionMapper.to_rating(:mattermost, ":+1_medium_skin_tone:")
+    end
+
+    property "valid tone suffixes and paired delimiters preserve the base rating" do
+      check all(
+              {base, rating} <- member_of(@mattermost_aliases),
+              suffix <- member_of(@tone_suffixes),
+              delimiter <- member_of(["", ":"]),
+              max_runs: 100
+            ) do
+        assert ReactionMapper.to_rating(:mattermost, delimiter <> base <> suffix <> delimiter) ==
+                 {:ok, rating}
+      end
+    end
+
+    test "ignores invalid suffixes, custom names, junk and malformed delimiters" do
+      for emoji <- [
+            "+1_medium_skin",
+            "-1_blue_skin_tone",
+            "thumbsup_skin_tone",
+            "thumbs_up_medium_medium_skin_tone",
+            "custom_+1_medium_skin_tone",
+            "+1_medium_skin_tone_custom",
+            "+1_medium_skin_tone_dark_skin_tone",
+            ":+1",
+            "+1:",
+            ":-1_dark_skin_tone",
+            "-1_dark_skin_tone:",
+            "::+1::",
+            ":+1:_medium_skin_tone",
+            " +1",
+            "+1\n",
+            ":+1_medium_skin_tone:\n",
+            "+1_medium_skin_tone\0",
+            <<255>>
+          ] do
+        assert ReactionMapper.to_rating(:mattermost, emoji) == :ignored
+      end
+    end
+
+    property "custom prefixes and trailing junk never become ratings" do
+      check all(
+              {base, _rating} <- member_of(@mattermost_aliases),
+              suffix <- member_of(@tone_suffixes),
+              junk <- string(:alphanumeric, min_length: 1, max_length: 16),
+              max_runs: 100
+            ) do
+        assert :ignored = ReactionMapper.to_rating(:mattermost, junk <> "_" <> base <> suffix)
+        assert :ignored = ReactionMapper.to_rating(:mattermost, base <> suffix <> "_" <> junk)
+      end
+    end
+
+    test "does not extend other providers' shortcode mappings or Unicode forms" do
+      for provider <- [:slack, :discord, :unknown], {base, _rating} <- @mattermost_aliases do
+        assert :ignored = ReactionMapper.to_rating(provider, ":#{base}:")
+        assert :ignored = ReactionMapper.to_rating(provider, base <> "_medium_skin_tone")
+        assert :ignored = ReactionMapper.to_rating(provider, ":#{base}_medium_skin_tone:")
+      end
+
+      assert :ignored = ReactionMapper.to_rating(:mattermost, "\u{1F44D}\u{1F3FD}")
+      assert :ignored = ReactionMapper.to_rating(:mattermost, "\u{1F44E}\u{1F3FD}")
+    end
+  end
 
   describe "to_rating/2 unicode emoji" do
     test "maps positive unicode emoji to the top rating for any provider" do

--- a/test/zaq/channels/jido_connect_bridge_coverage_gaps_test.exs
+++ b/test/zaq/channels/jido_connect_bridge_coverage_gaps_test.exs
@@ -26,8 +26,11 @@ defmodule Zaq.Channels.JidoConnectBridgeCoverageGapsTest do
   alias StubIntegration, as: BridgeStubIntegration
   alias Zaq.Channels.ChannelConfig
   alias Zaq.Channels.JidoConnectBridge
+  alias Zaq.Contracts.Record.Provenance
   alias Zaq.Engine.Connect
   alias Zaq.Ingestion.Document
+  alias Zaq.Ingestion.IngestJob
+  alias Zaq.Ingestion.RecordSource
   alias Zaq.Repo
 
   defmodule StubIntegration do
@@ -299,7 +302,22 @@ defmodule Zaq.Channels.JidoConnectBridgeCoverageGapsTest do
     end
 
     def invoke(_integration, "stub.files.get", %{file_id: "file-1"}, _opts) do
-      {:ok, %{file: %{"id" => "file-1", "name" => "File 1", "mimeType" => "application/pdf"}}}
+      {:ok,
+       %{
+         file: %{
+           "id" => "file-1",
+           "name" => "File 1",
+           "mimeType" => "application/pdf",
+           "permissions" => [
+             %{
+               "id" => "reader-1",
+               "type" => "user",
+               "emailAddress" => "reader@example.test",
+               "role" => "reader"
+             }
+           ]
+         }
+       }}
     end
 
     def triggers(_integration),
@@ -780,6 +798,11 @@ defmodule Zaq.Channels.JidoConnectBridgeCoverageGapsTest do
 
     config = insert_data_source_config(:google_drive)
 
+    credential = create_credential!()
+    grant = create_active_grant!(credential, to_string(config.id))
+    Process.put(:stub_runtime_grant, grant)
+    Process.put(:stub_runtime_credential, credential)
+
     assert {:ok, %{accepted: true, job_id: _job_id}} =
              JidoConnectBridge.handle_webhook(config, %{"headers" => %{}, "raw_body" => "{}"})
 
@@ -791,6 +814,24 @@ defmodule Zaq.Channels.JidoConnectBridgeCoverageGapsTest do
     assert record.attributes["provider"] == "google_drive"
     assert record.attributes["config_id"] == to_string(config.id)
     assert %DateTime{} = record.deleted_at
+
+    {:ok, _} =
+      Document.insert_new(%{
+        source: "data_source/google_drive/#{config.id}/file-1",
+        watch_status: "watched"
+      })
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert {:ok, %{jobs: [job]}} = Zaq.Ingestion.process_data_source_changes(request)
+      stored = Repo.get!(IngestJob, job.id).source_record
+      assert {:ok, restored} = RecordSource.from_storage_map(stored)
+      assert restored.provenance_ref == record.provenance_ref
+      assert [permission] = restored.permissions
+      assert permission.id == "reader-1"
+      assert permission.attributes["access_rights"] == ["read"]
+      assert {:ok, claims} = Provenance.verify(permission)
+      assert claims["config_id"] == config.id
+    end)
   end
 
   test "watch_item ensures config-level collection watch and unwatch can stop provider channel" do
@@ -1037,6 +1078,22 @@ defmodule Zaq.Channels.JidoConnectBridgeCoverageGapsTest do
 
     assert [%{provider_record_id: "changed-file-1"}, %{provider_record_id: "removed-file-1"}] =
              request.signals
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert {:ok, %{jobs: [job], removed: 0}} =
+               Zaq.Ingestion.process_data_source_changes(request)
+
+      stored = Repo.get!(IngestJob, job.id).source_record
+      assert {:ok, record} = RecordSource.from_storage_map(stored)
+      assert record.id == "changed-file-1"
+      assert record.parent_id == "folder-1"
+      assert record.parent_ids == ["folder-1"]
+      assert record.url == "https://drive.example/changed-file-1"
+      assert record.permissions == nil
+      assert {:ok, claims} = Provenance.verify(record)
+      assert claims["provider"] == "google_drive"
+      assert claims["config_id"] == config.id
+    end)
   end
 
   test "global changes webhook omits nil collection_id when listing changes" do
@@ -1248,6 +1305,7 @@ defmodule Zaq.Channels.JidoConnectBridgeCoverageGapsTest do
       assert record.change_type == :deleted
       assert record.lifecycle_state == :deleted
       assert is_nil(record.deleted_at)
+      assert is_nil(record.provenance_ref)
     end
 
     test "process_verified_webhook_job handles deleted webhook deliveries with atom keys" do

--- a/test/zaq/ingestion/ingest_worker_test.exs
+++ b/test/zaq/ingestion/ingest_worker_test.exs
@@ -123,6 +123,83 @@ defmodule Zaq.Ingestion.IngestWorkerTest do
   end
 
   describe "perform/1" do
+    test "unsigned persisted source records still fail closed on the final attempt" do
+      record = %Record{
+        id: "unsigned-watch",
+        kind: :file,
+        attributes: %{"provider" => "google_drive", "config_id" => "cfg-watch"}
+      }
+
+      job = create_job(%{source_record: RecordSource.to_storage_map(record)})
+
+      assert {:cancel, :invalid_source_record} =
+               IngestWorker.perform(%Oban.Job{
+                 args: %{"job_id" => job.id},
+                 attempt: 3,
+                 max_attempts: 3
+               })
+
+      assert Repo.get!(IngestJob, job.id).status == "failed"
+    end
+
+    test "materializes a persisted signed JSON watch change" do
+      previous = Application.get_env(:zaq, :ingestion_data_source_bridge_module)
+
+      Application.put_env(
+        :zaq,
+        :ingestion_data_source_bridge_module,
+        __MODULE__.ExternalDataSourceBridgeStub
+      )
+
+      on_exit(fn ->
+        if is_nil(previous),
+          do: Application.delete_env(:zaq, :ingestion_data_source_bridge_module),
+          else: Application.put_env(:zaq, :ingestion_data_source_bridge_module, previous)
+      end)
+
+      source = "data_source/google_drive/cfg-watch/watch-1"
+      document = create_document(%{source: source, watch_status: "watched"})
+
+      record =
+        signed_record(%Record{
+          id: "watch-1",
+          kind: :file,
+          name: "Watch.pdf",
+          mime_type: "application/pdf",
+          permissions: [],
+          attributes: %{"provider" => "google_drive", "config_id" => "cfg-watch"}
+        })
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, %{jobs: [job]}} =
+                 Zaq.Ingestion.process_data_source_changes(%{
+                   provider: "google_drive",
+                   config_id: "cfg-watch",
+                   signals: [
+                     %{record: Jason.decode!(Jason.encode!(record)), change_type: "updated"}
+                   ]
+                 })
+
+        expect(Zaq.DocumentProcessorMock, :process_single_file, fn path, opts ->
+          assert File.read!(path) == "PDF bytes"
+          assert opts[:source_override] == source
+          {:ok, document}
+        end)
+
+        assert :ok =
+                 IngestWorker.perform(%Oban.Job{
+                   args: %{"job_id" => job.id},
+                   attempt: 1,
+                   max_attempts: 3
+                 })
+
+        assert_received {:download_document, "google_drive", %{"file_id" => "watch-1"}}
+        assert_received {:download_context, context}
+        refute context.skip_permissions
+        assert Repo.get!(IngestJob, job.id).status == "completed"
+      end)
+    end
+
     test "materializes a reloaded ingestion job without its runtime router" do
       previous = Application.get_env(:zaq, :ingestion_data_source_bridge_module)
 

--- a/test/zaq/ingestion/ingestion_record_test.exs
+++ b/test/zaq/ingestion/ingestion_record_test.exs
@@ -5,8 +5,11 @@ defmodule Zaq.Ingestion.RecordIngestionTest do
   import Mox
 
   alias Zaq.Contracts.{Record, RecordPage}
+  alias Zaq.Contracts.Record.Provenance
   alias Zaq.Ingestion
+  alias Zaq.Ingestion.Document
   alias Zaq.Ingestion.IngestJob
+  alias Zaq.Ingestion.RecordSource
   alias Zaq.Repo
 
   setup do
@@ -132,6 +135,134 @@ defmodule Zaq.Ingestion.RecordIngestionTest do
                  }
         end
       end)
+    end
+  end
+
+  property "watch ingestion preserves signed canonical projections across persistence" do
+    check all(
+            id <- string(:alphanumeric, min_length: 1, max_length: 30),
+            projection <- member_of([:json, :atom]),
+            permission_state <- member_of([:not_loaded, :empty, :loaded]),
+            max_runs: 20
+          ) do
+      {:ok, permission} =
+        Provenance.seal(%Record{
+          id: "reader",
+          kind: :permission,
+          attributes: %{
+            "principal" => %{"channel" => "email", "identifier" => "reader@example.test"},
+            "access_rights" => ["read"]
+          }
+        })
+
+      permissions =
+        case permission_state do
+          :not_loaded -> nil
+          :empty -> []
+          :loaded -> [permission]
+        end
+
+      {:ok, record} =
+        Provenance.seal(%Record{
+          id: id,
+          kind: :file,
+          name: "Changed.md",
+          parent_id: "watched-folder",
+          parent_ids: ["watched-folder"],
+          permissions: permissions,
+          materialization_handle: "preserve-opaque-handle",
+          attributes: %{"provider" => "google_drive", "config_id" => "watch-config"}
+        })
+
+      {:ok, _} =
+        Document.upsert(%{
+          source: "data_source/google_drive/watch-config/#{id}",
+          watch_status: "watched"
+        })
+
+      map =
+        if projection == :json,
+          do: Jason.decode!(Jason.encode!(record)),
+          else: Map.from_struct(record)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, %{jobs: [job], removed: 0}} =
+                 Ingestion.process_data_source_changes(%{
+                   provider: "google_drive",
+                   config_id: "watch-config",
+                   signals: [%{record: map, change_type: :updated}]
+                 })
+
+        stored = Repo.get!(IngestJob, job.id).source_record
+        assert {:ok, restored} = RecordSource.from_storage_map(stored)
+        assert restored.provenance_ref == record.provenance_ref
+        assert restored.materialization_handle == record.materialization_handle
+        assert restored.permissions == permissions
+        assert restored.parent_id == record.parent_id
+        assert restored.parent_ids == record.parent_ids
+      end)
+    end
+  end
+
+  property "watch maps with invalid provenance never become ingestion jobs" do
+    check all(
+            id <- string(:alphanumeric, min_length: 1, max_length: 20),
+            mutation <- member_of([:identity, :permissions, :signature, :missing]),
+            max_runs: 20
+          ) do
+      {:ok, record} =
+        Provenance.seal(%Record{id: id, kind: :file, permissions: nil})
+
+      map = Jason.decode!(Jason.encode!(record))
+
+      map =
+        case mutation do
+          :identity -> Map.put(map, "id", id <> "-tampered")
+          :permissions -> Map.put(map, "permissions", [])
+          :signature -> Map.put(map, "provenance_ref", "invalid")
+          :missing -> Map.put(map, "provenance_ref", nil)
+        end
+
+      {:ok, _} =
+        Document.upsert(%{
+          source: "data_source/google_drive/watch-config/#{map["id"]}",
+          watch_status: "watched"
+        })
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, %{jobs: [], removed: 0}} =
+                 Ingestion.process_data_source_changes(%{
+                   provider: "google_drive",
+                   config_id: "watch-config",
+                   records: [map]
+                 })
+
+        assert Repo.aggregate(IngestJob, :count) == 0
+      end)
+    end
+  end
+
+  test "unsigned JSON tombstones still delete only watched documents" do
+    for status <- ["watched", "unwatched"] do
+      id = "removed-#{status}"
+
+      {:ok, document} =
+        Document.insert_new(%{
+          source: "data_source/google_drive/watch-config/#{id}",
+          watch_status: status
+        })
+
+      tombstone = %Record{id: id, kind: :file, change_type: :deleted, lifecycle_state: :deleted}
+      removed = if status == "watched", do: 1, else: 0
+
+      assert {:ok, %{jobs: [], removed: ^removed}} =
+               Ingestion.process_data_source_changes(%{
+                 provider: "google_drive",
+                 config_id: "watch-config",
+                 signals: [%{removed?: true, record: Jason.decode!(Jason.encode!(tombstone))}]
+               })
+
+      assert is_nil(Repo.get(Document, document.id)) == (status == "watched")
     end
   end
 end

--- a/test/zaq/ingestion/ingestion_record_test.exs
+++ b/test/zaq/ingestion/ingestion_record_test.exs
@@ -3,6 +3,7 @@ defmodule Zaq.Ingestion.RecordIngestionTest do
   use ExUnitProperties
 
   import Mox
+  import ExUnit.CaptureLog
 
   alias Zaq.Contracts.{Record, RecordPage}
   alias Zaq.Contracts.Record.Provenance
@@ -239,6 +240,45 @@ defmodule Zaq.Ingestion.RecordIngestionTest do
 
         assert Repo.aggregate(IngestJob, :count) == 0
       end)
+    end
+  end
+
+  test "rejected canonical maps log identity and reason without sensitive projections" do
+    for map <- [
+          %{id: "rejected-watch", kind: :file, provenance_ref: "private-token"},
+          %{"id" => "rejected-watch", "kind" => "file", "provenance_ref" => "private-token"}
+        ] do
+      log =
+        capture_log(fn ->
+          assert {:ok, %{jobs: [], removed: 0}} =
+                   Ingestion.process_data_source_changes(%{
+                     records: [Map.put(map, "raw", %{"secret" => "private-payload"})]
+                   })
+        end)
+
+      assert log =~ "[warning]"
+      assert log =~ "Rejected data-source record id=\"rejected-watch\""
+      assert log =~ "reason=:invalid_record_provenance"
+      refute log =~ "private-token"
+      refute log =~ "private-payload"
+      assert Repo.aggregate(IngestJob, :count) == 0
+    end
+  end
+
+  property "rejection diagnostics bound and escape untrusted identifiers" do
+    check all(id <- binary(min_length: 129, max_length: 512), max_runs: 20) do
+      log =
+        capture_log(fn ->
+          assert {:ok, %{jobs: [], removed: 0}} =
+                   Ingestion.process_data_source_changes(%{
+                     records: [%{id: id, kind: :file, provenance_ref: nil}]
+                   })
+        end)
+
+      assert log =~ "Rejected data-source record"
+      assert log =~ "reason=:missing_record_provenance"
+      assert byte_size(log) < 2_000
+      assert length(String.split(String.trim(log), "\n")) == 1
     end
   end
 


### PR DESCRIPTION
fixes the gap in watched files that were not properly sealed
fixes #655 